### PR TITLE
enum_dispatch for LnPriorTrait and LnPrior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
---
+- Use `enum_dispatch` 0.3.9 (updated from 0.3.7) crate to implement `LnPriorTrait` for `LnPrior` https://github.com/light-curve/light-curve-feature/pull/6
 
 ### Deprecated
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ anyhow = "<1.0.49"
 conv = "^0.3.3"
 emcee = "^0.3.0"
 emcee_rand = { version = "^0.3.15", package = "rand" }
-enum_dispatch = "^0.3.7"
+enum_dispatch = "^0.3.9"
 fftw = { version = "^0.7", default-features = false }
 GSL = { version = "^6", default-features = false, optional = true }
 itertools = "^0.10"


### PR DESCRIPTION
TODO: fix `enum_dispatch` version in `Cargo.toml`

We wait until [`enum_dispatch`](https://lib.rs/enum_dispatch) version with [this MR](https://gitlab.com/antonok/enum_dispatch/-/merge_requests/25) is merged and released