### PR TITLE
FeatureEvaluator::eval_no_ts_check

### DIFF
--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -46,6 +46,7 @@ where
             m_required: features.iter().any(|x| x.is_m_required()),
             w_required: features.iter().any(|x| x.is_w_required()),
             sorting_required: features.iter().any(|x| x.is_sorting_required()),
+            variability_required: features.iter().any(|x| x.is_variability_required()),
         }
         .into();
         Self {
@@ -118,10 +119,10 @@ where
     T: Float,
     F: FeatureEvaluator<T>,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let mut vec = Vec::with_capacity(self.size_hint());
         for x in &self.features {
-            vec.extend(x.eval(ts)?);
+            vec.extend(x.eval_no_ts_check(ts)?);
         }
         Ok(vec)
     }

--- a/src/features/amplitude.rs
+++ b/src/features/amplitude.rs
@@ -47,6 +47,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: false,
+    variability_required: false,
 );
 
 impl FeatureNamesDescriptionsTrait for Amplitude {
@@ -63,8 +64,7 @@ impl<T> FeatureEvaluator<T> for Amplitude
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         Ok(vec![T::half() * (ts.m.get_max() - ts.m.get_min())])
     }
 }

--- a/src/features/anderson_darling_normal.rs
+++ b/src/features/anderson_darling_normal.rs
@@ -46,6 +46,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: false,
+    variability_required: true,
 );
 
 impl FeatureNamesDescriptionsTrait for AndersonDarlingNormal {
@@ -62,10 +63,10 @@ impl<T> FeatureEvaluator<T> for AndersonDarlingNormal
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        let size = self.check_ts_length(ts)?;
-        let m_std = get_nonzero_m_std(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
+        let size = ts.lenu();
         let m_mean = ts.m.get_mean();
+        let m_std = ts.m.get_std();
         let sum: f64 =
             ts.m.get_sorted()
                 .as_ref()

--- a/src/features/bazin_fit.rs
+++ b/src/features/bazin_fit.rs
@@ -108,6 +108,7 @@ lazy_info!(
     m_required: true,
     w_required: true,
     sorting_required: true, // improve reproducibility
+    variability_required: false,
 );
 
 struct Params<'a, T> {

--- a/src/features/beyond_n_std.rs
+++ b/src/features/beyond_n_std.rs
@@ -94,6 +94,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: false,
+    variability_required: false,
 );
 
 impl<T> Default for BeyondNStd<T>
@@ -122,8 +123,7 @@ impl<T> FeatureEvaluator<T> for BeyondNStd<T>
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let m_mean = ts.m.get_mean();
         let threshold = ts.m.get_std() * self.nstd;
         let count_beyond = ts.m.sample.fold(0, |count, &m| {

--- a/src/features/cusum.rs
+++ b/src/features/cusum.rs
@@ -46,6 +46,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: true,
+    variability_required: true,
 );
 
 impl FeatureNamesDescriptionsTrait for Cusum {
@@ -62,10 +63,9 @@ impl<T> FeatureEvaluator<T> for Cusum
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
-        let m_std = get_nonzero_m_std(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let m_mean = ts.m.get_mean();
+        let m_std = ts.m.get_std();
         let (_last_cusum, min_cusum, max_cusum) = ts.m.as_slice().iter().fold(
             (T::zero(), T::infinity(), -T::infinity()),
             |(mut cusum, min_cusum, max_cusum), &m| {

--- a/src/features/duration.rs
+++ b/src/features/duration.rs
@@ -39,6 +39,7 @@ lazy_info!(
     m_required: false,
     w_required: false,
     sorting_required: true,
+    variability_required: false,
 );
 
 impl FeatureNamesDescriptionsTrait for Duration {
@@ -55,8 +56,7 @@ impl<T> FeatureEvaluator<T> for Duration
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         Ok(vec![ts.t.sample[ts.lenu() - 1] - ts.t.sample[0]])
     }
 }

--- a/src/features/eta.rs
+++ b/src/features/eta.rs
@@ -42,6 +42,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: true,
+    variability_required: true,
 );
 
 impl FeatureNamesDescriptionsTrait for Eta {
@@ -58,9 +59,8 @@ impl<T> FeatureEvaluator<T> for Eta
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
-        let m_std2 = get_nonzero_m_std2(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
+        let m_std2 = ts.m.get_std2();
         let value =
             ts.m.as_slice()
                 .iter()

--- a/src/features/eta_e.rs
+++ b/src/features/eta_e.rs
@@ -47,6 +47,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: true,
+    variability_required: true,
 );
 
 impl FeatureNamesDescriptionsTrait for EtaE {
@@ -63,9 +64,8 @@ impl<T> FeatureEvaluator<T> for EtaE
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
-        let m_std2 = get_nonzero_m_std2(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
+        let m_std2 = ts.m.get_std2();
         let sq_slope_sum =
             ts.t.as_slice()
                 .iter()

--- a/src/features/excess_variance.rs
+++ b/src/features/excess_variance.rs
@@ -32,6 +32,7 @@ lazy_info!(
     m_required: true,
     w_required: true,
     sorting_required: false,
+    variability_required: false,
 );
 
 impl ExcessVariance {
@@ -58,8 +59,7 @@ impl<T> FeatureEvaluator<T> for ExcessVariance
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let mean_error2 = ts.w.sample.fold(T::zero(), |sum, w| sum + w.recip()) / ts.lenf();
         Ok(vec![
             (ts.m.get_std2() - mean_error2) / ts.m.get_mean().powi(2),

--- a/src/features/inter_percentile_range.rs
+++ b/src/features/inter_percentile_range.rs
@@ -42,6 +42,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: false,
+    variability_required: false,
 );
 
 impl InterPercentileRange {
@@ -91,8 +92,7 @@ impl<T> FeatureEvaluator<T> for InterPercentileRange
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let ppf_low = ts.m.get_sorted().ppf(self.quantile);
         let ppf_high = ts.m.get_sorted().ppf(1.0 - self.quantile);
         let value = ppf_high - ppf_low;

--- a/src/features/kurtosis.rs
+++ b/src/features/kurtosis.rs
@@ -43,6 +43,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: false,
+    variability_required: true,
 );
 
 impl FeatureNamesDescriptionsTrait for Kurtosis {
@@ -59,10 +60,9 @@ impl<T> FeatureEvaluator<T> for Kurtosis
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
-        let m_std2 = get_nonzero_m_std2(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let m_mean = ts.m.get_mean();
+        let m_std2 = ts.m.get_std2();
         let n = ts.lenf();
         let n1 = n + T::one();
         let n_1 = n - T::one();

--- a/src/features/linear_fit.rs
+++ b/src/features/linear_fit.rs
@@ -45,6 +45,7 @@ lazy_info!(
     m_required: true,
     w_required: true,
     sorting_required: true,
+    variability_required: false,
 );
 
 impl FeatureNamesDescriptionsTrait for LinearFit {
@@ -69,8 +70,7 @@ impl<T> FeatureEvaluator<T> for LinearFit
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let result = fit_straight_line(ts, true);
         Ok(vec![
             result.slope,

--- a/src/features/linear_trend.rs
+++ b/src/features/linear_trend.rs
@@ -43,6 +43,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: true,
+    variability_required: false,
 );
 
 impl FeatureNamesDescriptionsTrait for LinearTrend {
@@ -63,8 +64,7 @@ impl<T> FeatureEvaluator<T> for LinearTrend
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let result = fit_straight_line(ts, false);
         Ok(vec![
             result.slope,

--- a/src/features/magnitude_percentage_ratio.rs
+++ b/src/features/magnitude_percentage_ratio.rs
@@ -41,6 +41,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: false,
+    variability_required: true,
 );
 
 impl MagnitudePercentageRatio {
@@ -112,18 +113,13 @@ impl<T> FeatureEvaluator<T> for MagnitudePercentageRatio
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let m_sorted = ts.m.get_sorted();
         let numerator =
             m_sorted.ppf(1.0 - self.quantile_numerator) - m_sorted.ppf(self.quantile_numerator);
         let denumerator =
             m_sorted.ppf(1.0 - self.quantile_denominator) - m_sorted.ppf(self.quantile_denominator);
-        if numerator.is_zero() & denumerator.is_zero() {
-            Err(EvaluatorError::FlatTimeSeries)
-        } else {
-            Ok(vec![numerator / denumerator])
-        }
+        Ok(vec![numerator / denumerator])
     }
 }
 

--- a/src/features/maximum_slope.rs
+++ b/src/features/maximum_slope.rs
@@ -33,6 +33,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: true,
+    variability_required: false,
 );
 
 impl MaximumSlope {
@@ -57,8 +58,7 @@ impl<T> FeatureEvaluator<T> for MaximumSlope
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let result =
             ts.t.as_slice()
                 .iter()

--- a/src/features/maximum_time_interval.rs
+++ b/src/features/maximum_time_interval.rs
@@ -40,6 +40,7 @@ lazy_info!(
     m_required: false,
     w_required: false,
     sorting_required: true,
+    variability_required: false,
 );
 
 impl FeatureNamesDescriptionsTrait for MaximumTimeInterval {
@@ -56,8 +57,7 @@ impl<T> FeatureEvaluator<T> for MaximumTimeInterval
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let dt =
             ts.t.as_slice()
                 .iter()

--- a/src/features/mean.rs
+++ b/src/features/mean.rs
@@ -28,6 +28,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: false,
+    variability_required: false,
 );
 
 impl Mean {
@@ -54,7 +55,7 @@ impl<T> FeatureEvaluator<T> for Mean
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         self.check_ts_length(ts)?;
         Ok(vec![ts.m.get_mean()])
     }

--- a/src/features/mean_variance.rs
+++ b/src/features/mean_variance.rs
@@ -27,6 +27,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: false,
+    variability_required: false,
 );
 
 impl MeanVariance {
@@ -53,8 +54,7 @@ impl<T> FeatureEvaluator<T> for MeanVariance
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         Ok(vec![ts.m.get_std() / ts.m.get_mean()])
     }
 }

--- a/src/features/median.rs
+++ b/src/features/median.rs
@@ -27,6 +27,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: false,
+    variability_required: false,
 );
 
 impl Median {
@@ -53,8 +54,7 @@ impl<T> FeatureEvaluator<T> for Median
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         Ok(vec![ts.m.get_median()])
     }
 }

--- a/src/features/median_absolute_deviation.rs
+++ b/src/features/median_absolute_deviation.rs
@@ -30,6 +30,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: false,
+    variability_required: false,
 );
 
 impl MedianAbsoluteDeviation {
@@ -56,8 +57,7 @@ impl<T> FeatureEvaluator<T> for MedianAbsoluteDeviation
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let m_median = ts.m.get_median();
         let sorted_deviation: SortedArray<_> =
             ts.m.sample

--- a/src/features/median_buffer_range_percentage.rs
+++ b/src/features/median_buffer_range_percentage.rs
@@ -38,6 +38,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: false,
+    variability_required: false,
 );
 
 impl<T> MedianBufferRangePercentage<T>
@@ -102,8 +103,7 @@ impl<T> FeatureEvaluator<T> for MedianBufferRangePercentage<T>
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let m_median = ts.m.get_median();
         let amplitude = T::half() * (ts.m.get_max() - ts.m.get_min());
         let threshold = self.quantile * amplitude;

--- a/src/features/minimum_time_interval.rs
+++ b/src/features/minimum_time_interval.rs
@@ -40,6 +40,7 @@ lazy_info!(
     m_required: false,
     w_required: false,
     sorting_required: true,
+    variability_required: false,
 );
 
 impl FeatureNamesDescriptionsTrait for MinimumTimeInterval {
@@ -56,8 +57,7 @@ impl<T> FeatureEvaluator<T> for MinimumTimeInterval
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let dt =
             ts.t.as_slice()
                 .iter()

--- a/src/features/observation_count.rs
+++ b/src/features/observation_count.rs
@@ -39,6 +39,7 @@ lazy_info!(
     m_required: false,
     w_required: false,
     sorting_required: false,
+    variability_required: false,
 );
 
 impl FeatureNamesDescriptionsTrait for ObservationCount {
@@ -55,8 +56,7 @@ impl<T> FeatureEvaluator<T> for ObservationCount
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         Ok(vec![ts.lenf()])
     }
 }

--- a/src/features/percent_amplitude.rs
+++ b/src/features/percent_amplitude.rs
@@ -30,6 +30,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: false,
+    variability_required: false,
 );
 
 impl PercentAmplitude {
@@ -56,8 +57,7 @@ impl<T> FeatureEvaluator<T> for PercentAmplitude
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let m_min = ts.m.get_min();
         let m_max = ts.m.get_max();
         let m_median = ts.m.get_median();

--- a/src/features/percent_difference_magnitude_percentile.rs
+++ b/src/features/percent_difference_magnitude_percentile.rs
@@ -38,6 +38,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: false,
+    variability_required: false,
 );
 
 impl PercentDifferenceMagnitudePercentile {
@@ -94,8 +95,7 @@ impl<T> FeatureEvaluator<T> for PercentDifferenceMagnitudePercentile
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let nominator =
             ts.m.get_sorted().ppf(1.0 - self.quantile) - ts.m.get_sorted().ppf(self.quantile);
         let denominator = ts.m.get_median();

--- a/src/features/periodogram.rs
+++ b/src/features/periodogram.rs
@@ -49,6 +49,7 @@ impl PeriodogramPeaks {
             m_required: true,
             w_required: false,
             sorting_required: true,
+            variability_required: false,
         };
         let names = (0..peaks)
             .flat_map(|i| vec![format!("period_{}", i), format!("period_s_to_n_{}", i)])
@@ -120,8 +121,7 @@ impl<T> FeatureEvaluator<T> for PeriodogramPeaks
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let peak_indices = peak_indices_reverse_sorted(&ts.m.sample);
         Ok(peak_indices
             .iter()
@@ -310,6 +310,7 @@ where
             m_required: true,
             w_required: false,
             sorting_required: true,
+            variability_required: false,
         };
         Self {
             properties: EvaluatorProperties {

--- a/src/features/reduced_chi2.rs
+++ b/src/features/reduced_chi2.rs
@@ -33,6 +33,7 @@ lazy_info!(
     m_required: true,
     w_required: true,
     sorting_required: false,
+    variability_required: false,
 );
 
 impl ReducedChi2 {
@@ -59,8 +60,7 @@ impl<T> FeatureEvaluator<T> for ReducedChi2
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         Ok(vec![ts.get_m_reduced_chi2()])
     }
 }

--- a/src/features/skew.rs
+++ b/src/features/skew.rs
@@ -32,6 +32,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: false,
+    variability_required: true,
 );
 
 impl Skew {
@@ -58,10 +59,9 @@ impl<T> FeatureEvaluator<T> for Skew
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
-        let m_std = get_nonzero_m_std(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         let m_mean = ts.m.get_mean();
+        let m_std = ts.m.get_std();
         let n = ts.lenf();
         let n_1 = n - T::one();
         let n_2 = n_1 - T::one();

--- a/src/features/standard_deviation.rs
+++ b/src/features/standard_deviation.rs
@@ -32,6 +32,7 @@ lazy_info!(
     m_required: true,
     w_required: false,
     sorting_required: false,
+    variability_required: false,
 );
 
 impl StandardDeviation {
@@ -58,8 +59,7 @@ impl<T> FeatureEvaluator<T> for StandardDeviation
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         Ok(vec![ts.m.get_std()])
     }
 }

--- a/src/features/stetson_k.rs
+++ b/src/features/stetson_k.rs
@@ -34,6 +34,7 @@ lazy_info!(
     m_required: true,
     w_required: true,
     sorting_required: false,
+    variability_required: true,
 );
 
 impl StetsonK {
@@ -60,9 +61,8 @@ impl<T> FeatureEvaluator<T> for StetsonK
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
-        let chi2 = get_nonzero_reduced_chi2(ts)? * (ts.lenf() - T::one());
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
+        let chi2 = ts.get_m_reduced_chi2() * (ts.lenf() - T::one());
         let mean = ts.get_m_weighted_mean();
         let value = Zip::from(&ts.m.sample)
             .and(&ts.w.sample)

--- a/src/features/time_mean.rs
+++ b/src/features/time_mean.rs
@@ -39,6 +39,7 @@ lazy_info!(
     m_required: false,
     w_required: false,
     sorting_required: false,
+    variability_required: false,
 );
 impl FeatureNamesDescriptionsTrait for TimeMean {
     fn get_names(&self) -> Vec<&str> {
@@ -53,8 +54,7 @@ impl<T> FeatureEvaluator<T> for TimeMean
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         Ok(vec![ts.t.get_mean()])
     }
 }

--- a/src/features/time_standard_deviation.rs
+++ b/src/features/time_standard_deviation.rs
@@ -39,6 +39,7 @@ lazy_info!(
     m_required: false,
     w_required: false,
     sorting_required: false,
+    variability_required: false,
 );
 
 impl FeatureNamesDescriptionsTrait for TimeStandardDeviation {
@@ -55,8 +56,7 @@ impl<T> FeatureEvaluator<T> for TimeStandardDeviation
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         Ok(vec![ts.t.get_std()])
     }
 }

--- a/src/features/villar_fit.rs
+++ b/src/features/villar_fit.rs
@@ -127,6 +127,7 @@ lazy_info!(
     m_required: true,
     w_required: true,
     sorting_required: true, // improve reproducibility
+    variability_required: false,
 );
 
 impl<T, U> FitModelTrait<T, U, NPARAMS> for VillarFit

--- a/src/features/weighted_mean.rs
+++ b/src/features/weighted_mean.rs
@@ -28,6 +28,7 @@ lazy_info!(
     m_required: true,
     w_required: true,
     sorting_required: false,
+    variability_required: false,
 );
 
 impl WeightedMean {
@@ -54,8 +55,7 @@ impl<T> FeatureEvaluator<T> for WeightedMean
 where
     T: Float,
 {
-    fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
         Ok(vec![ts.get_m_weighted_mean()])
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -8,6 +8,7 @@ macro_rules! lazy_info {
         m_required: $m: expr,
         w_required: $w: expr,
         sorting_required: $sort: expr,
+        variability_required: $var: expr,
     ) => {
         lazy_static! {
             static ref $name: EvaluatorInfo = EvaluatorInfo {
@@ -17,6 +18,7 @@ macro_rules! lazy_info {
                 m_required: $m,
                 w_required: $w,
                 sorting_required: $sort,
+                variability_required: $var,
             };
         }
     };
@@ -29,6 +31,7 @@ macro_rules! lazy_info {
         m_required: $m: expr,
         w_required: $w: expr,
         sorting_required: $sort: expr,
+        variability_required: $var: expr,
     ) => {
         lazy_info!(
             $name,
@@ -38,6 +41,7 @@ macro_rules! lazy_info {
             m_required: $m,
             w_required: $w,
             sorting_required: $sort,
+            variability_required: $var,
         );
 
         impl EvaluatorInfoTrait for $feature {
@@ -56,6 +60,7 @@ macro_rules! lazy_info {
         m_required: $m: expr,
         w_required: $w: expr,
         sorting_required: $sort: expr,
+        variability_required: $var: expr,
     ) => {
         lazy_info!(
             $name,
@@ -65,6 +70,7 @@ macro_rules! lazy_info {
             m_required: $m,
             w_required: $w,
             sorting_required: $sort,
+            variability_required: $var,
         );
 
         impl<T: Float> EvaluatorInfoTrait for $feature {
@@ -80,7 +86,7 @@ macro_rules! lazy_info {
 /// - `transform_ts(&self, ts: &mut TimeSeries<T>) -> Result<impl OwnedArrays<T>, EvaluatorError>`
 macro_rules! transformer_eval {
     () => {
-        fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
+        fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
             let arrays = self.transform_ts(ts)?;
             let mut new_ts = arrays.ts();
             self.feature_extractor.eval(&mut new_ts)
@@ -121,9 +127,7 @@ macro_rules! json_schema {
 /// - declare `const NPARAMS: usize` in your code
 macro_rules! fit_eval {
     () => {
-        fn eval(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
-            self.check_ts_length(ts)?;
-
+        fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
             let norm_data = NormalizedData::<f64>::from_ts(ts);
 
             let (x0, lower, upper) = {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -102,6 +102,8 @@ pub fn eval_info_tests(eval: Feature<f64>) {
     eval_info_sorting_required_test(&eval, &baseline, &t, &m, &w)
         .as_ref()
         .map(check_size);
+
+    eval_info_variability_required_test(&eval, &t_sorted, &w, &mut rng);
 }
 
 fn eval_info_ts_length_test(
@@ -246,6 +248,43 @@ fn eval_info_sorting_required_test(
         v, baseline, is_sorting_required,
     );
     Some(v)
+}
+
+fn eval_info_variability_required_test(
+    eval: &Feature<f64>,
+    t: &[f64],
+    w: &[f64],
+    rng: &mut StdRng,
+) {
+    assert!(
+        !eval.is_variability_required() || eval.is_m_required(),
+        "variability_required is treu, but m_required is false"
+    );
+
+    let m = vec![rng.sample::<f64, StandardNormal>(StandardNormal).abs(); t.len()];
+    let mut ts = TimeSeries::new(t, &m, w);
+    assert_eq!(eval.is_variability_required(), eval.eval(&mut ts).is_err());
+
+    match (
+        std::panic::catch_unwind(|| eval.eval_no_ts_check(&mut TimeSeries::new(t, &m, w))),
+        eval.is_variability_required(),
+    ) {
+        (Ok(_result), true) => {}
+        // |-- This doesn't work sometimes because of float rounding issues
+        // v
+        // (Ok(result), true) => assert!(result
+        //     .map(|v| assert!(
+        //         !v.iter().copied().all(f64::is_finite),
+        //         "{:?} are all finite",
+        //         v
+        //     ))
+        //     .is_err()),
+        (Ok(result), false) => assert!(result
+            .map(|v| assert!(v.into_iter().all(f64::is_finite)))
+            .is_ok()),
+        (Err(_err), true) => {}
+        (Err(err), false) => panic!("{:?}", err),
+    }
 }
 
 #[macro_export]


### PR DESCRIPTION
It also introduces new `FeatureInfo` attribute `variability_required` and more convenient time-series checking. Also it gives a small performance gain for extractor built on cheap features.