### PR TITLE
CI: build normal target only for MSRV

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,8 @@ jobs:
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ steps.get_msrv.outputs.msrv }}
-    - run: cargo +${{ steps.get_msrv.outputs.msrv }} build --all-targets --features gsl,fftw-source --no-default-features
+    # Build "normal" target only, see https://github.com/light-curve/light-curve-feature/issues/74
+    - run: cargo +${{ steps.get_msrv.outputs.msrv }} build --no-default-features --features gsl,fftw-source
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We actually don't need to check that tests, benchmarks and examples could be built on minimum supported Rust version (MSRV)

Fix https://github.com/light-curve/light-curve-feature/issues/74