### PR TITLE
MSRV 1.57 -> 1.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
---
+- **Build breaking** Minimum supported Rust version (MSRV) 1.57 -> 1.61 (released 2022-05-19)
 
 ### Deprecated
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/light-curve/light-curve-feature"
 readme = "README.md"
 authors = ["Konstantin Malanchev <hombit@gmail.com>"]
 license = "GPL-3.0-or-later"
-rust-version = "1.57"
+rust-version = "1.61"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ anyhow = "<1.0.49"
 ceres-solver = { version = "0.2.1", optional = true }
 conv = "^0.3.3"
 emcee = "^0.3.0"
+# Transitive dependency of emcee
 emcee_rand = { version = "^0.3.15", package = "rand" }
 enum_dispatch = "^0.3.9"
 fftw = { version = "^0.7", default-features = false }
@@ -56,6 +57,12 @@ serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 thread_local = "1.1,<1.1.7" # 1.1.7 requires rust 1.59
 unzip3 = "1"
+
+#[patch.crates-io]
+### Pinned transitive dependencies
+# Required by emcee
+backtrace = "<0.3.69" # 0.3.69 requires rust 1.65
+flate2 = "<1.0.27" # 1.0.27 requires rust >1.61
 
 [dev-dependencies]
 light-curve-feature-test-util = { path = "test-util" }


### PR DESCRIPTION
Update minimum supported Rust version to 1.61 which was released on May 19, 2022