### PR TITLE
MSRV 1.57 -> 1.65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
---
+- **Build breaking** Minimum supported Rust version (MSRV) 1.57 -> 1.65 (released 2022-11-03)
 
 ### Deprecated
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/light-curve/light-curve-feature"
 readme = "README.md"
 authors = ["Konstantin Malanchev <hombit@gmail.com>"]
 license = "GPL-3.0-or-later"
-rust-version = "1.57"
+rust-version = "1.65"
 edition = "2021"
 
 [lib]
@@ -38,6 +38,7 @@ anyhow = "<1.0.49"
 ceres-solver = { version = "0.2.1", optional = true }
 conv = "^0.3.3"
 emcee = "^0.3.0"
+# Transitive dependency of emcee
 emcee_rand = { version = "^0.3.15", package = "rand" }
 enum_dispatch = "^0.3.9"
 fftw = { version = "^0.7", default-features = false }


### PR DESCRIPTION
Change minimum supported Rust version to 1.65 (released November 3, 2022)