### PR TITLE
docs: update README and CLAUDE.md for v0.13.x changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,9 @@ This document provides comprehensive guidance for AI assistants working with the
 `light-curve-feature` is a Rust library for extracting numerous light curve features used in astrophysics. It processes noisy time series data from astronomical observations to compute statistical and model-fit features used for anomaly detection and classification of variable stars and transient objects.
 
 **Repository**: https://github.com/light-curve/light-curve-feature
-**Current Version**: 0.10.0
+**Current Version**: 0.13.1
 **Rust Edition**: 2024
-**MSRV**: 1.85
+**MSRV**: 1.88
 **License**: GPL-3.0-or-later
 
 Python bindings are available separately at https://github.com/light-curve/light-curve-python
@@ -43,9 +43,11 @@ light-curve-feature/
 │   │   ├── bins.rs            # Meta-feature for binning
 │   │   └── ...                # Other statistical/model features
 │   │
-│   ├── periodogram/           # FFT-based periodogram (7 modules)
+│   ├── periodogram/           # FFT-based periodogram (9 modules)
 │   │   ├── mod.rs             # Main periodogram module
-│   │   ├── fft.rs             # FFT wrapper using FFTW
+│   │   ├── fft_trait.rs       # Abstract Fft<T> trait for pluggable backends
+│   │   ├── fft_rustfft.rs     # RustFFT backend (default, no system libs)
+│   │   ├── fft_fftw.rs        # FFTW backend (requires fftw-* feature)
 │   │   ├── freq.rs            # FreqGridStrategy implementations
 │   │   ├── power_fft.rs       # FFT-based power calculation
 │   │   ├── power_direct.rs    # Direct power calculation
@@ -61,7 +63,7 @@ light-curve-feature/
 │   │   ├── mcmc.rs            # MCMC fitting algorithm
 │   │   ├── ceres.rs           # Ceres Solver (optional)
 │   │   ├── lmsder.rs          # LMSDER/GSL (optional)
-│   │   ├── nuts.rs            # NUTS sampler (optional)
+│   │   ├── nuts.rs            # NUTS sampler (NutsCurveFit, always available)
 │   │   └── prior/             # Prior probability distributions
 │   │
 │   └── transformers/          # Feature transformation pipeline (7 modules)
@@ -111,11 +113,11 @@ light-curve-feature/
 ## Cargo Features
 
 ```toml
-# Default: fftw-source only
-default = ["fftw-source"]
+# Default: empty (RustFFT is always available, no feature flag needed)
+default = []
 
 # FFTW options (mutually exclusive preference: mkl > source > system)
-fftw-source    # Build FFTW from source (default)
+fftw-source    # Build FFTW from source
 fftw-system    # Use system FFTW installation
 fftw-mkl       # Use Intel MKL
 
@@ -123,11 +125,13 @@ fftw-mkl       # Use Intel MKL
 ceres-source   # Build Ceres Solver from source
 ceres-system   # Use system Ceres installation
 gsl            # GNU Scientific Library for LMSDER algorithm
-nuts           # NUTS sampler for Bayesian fitting
+
+# NutsCurveFit is always available (no feature flag since 0.13.0)
 
 # Common feature combinations for development:
 # --features ceres-source,fftw-source,gsl     # Full features, source builds
 # --features ceres-system,fftw-system,gsl     # Full features, system libs
+# (no flags needed)                           # Minimal build with RustFFT
 ```
 
 ## Development Setup
@@ -135,12 +139,14 @@ nuts           # NUTS sampler for Bayesian fitting
 ### System Dependencies
 
 ```bash
-# macOS
+# macOS (full features; FFTW only needed for fftw-* features)
 brew install ceres-solver cmake fftw gsl fontconfig
 
 # Debian/Ubuntu
 sudo apt-get install build-essential cmake libceres-dev libfftw3-dev libgsl-dev libfontconfig-dev
 ```
+
+For a minimal build using the default RustFFT backend, no system libraries are required beyond a Rust toolchain.
 
 ### Clone and Build
 
@@ -148,11 +154,17 @@ sudo apt-get install build-essential cmake libceres-dev libfftw3-dev libgsl-dev 
 git clone --recursive https://github.com/light-curve/light-curve-feature
 cd light-curve-feature
 
-# Build with all features
+# Build with all features (FFTW + Ceres + GSL)
 cargo build --no-default-features --features ceres-source,fftw-source,gsl
 
-# Run tests
+# Build minimal (RustFFT only, no system deps)
+cargo build
+
+# Run tests (full features)
 cargo test --no-default-features --features ceres-source,fftw-source,gsl
+
+# Run tests (minimal)
+cargo test
 ```
 
 Note: On ARM macOS, Ceres may require `CPATH=/opt/homebrew/include`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you are looking for Python bindings for this package, please see <https://git
 
 [![docs.rs badge](https://docs.rs/light-curve-feature/badge.svg)](https://docs.rs/light-curve-feature)
 ![testing](https://github.com/light-curve/light-curve-feature/actions/workflows/test.yml/badge.svg)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/light-curve/light-curve-feature/master.svg)](https://results.pre-commit.ci/latest/github/light-curve/light-curve-feature/master)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/light-curve/light-curve-feature/main.svg)](https://results.pre-commit.ci/latest/github/light-curve/light-curve-feature/main)
 
 All features are available in [Feature](crate::Feature) enum, and the recommended way to extract multiple features at
 once is [FeatureExtractor](crate::FeatureExtractor) struct built from a `Vec<Feature>`. Data is represented by
@@ -65,10 +65,12 @@ println!("{:?}", result);
 The crate is configured with the following Cargo features:
 - `ceres-system` and `ceres-source` - enable [Ceres Solver](http://ceres-solver.org) support for non-linear fitting. The former
   uses system-wide installation of Ceres, the latter builds Ceres from source and links it statically. The latter overrides the former. See [`ceres-solver-rs` crate](https://github.com/light-curve/ceres-solver-rs) for details
-- `fftw-system`, `fftw-source` (enabled by default) and `fftw-mkl` - enable [FFTW](http://www.fftw.org) support for Fourier transforms needed by `Periodogram`. The
-  first uses system-wide installation of FFTW, the second builds FFTW from source and links it statically, the last downloads and links statically Intel MKL instead of FFTW.
-- `gsl` - enables [GNU Scientific Library](https://www.gnu.org/software/gsl/) support for non-linear fitting.
-- `default` - enables `fftw-source` feature only, has no side effects.
+- `fftw-system`, `fftw-source`, and `fftw-mkl` - enable [FFTW](http://www.fftw.org) as the FFT backend for `Periodogram`.
+  The first uses system-wide installation of FFTW, the second builds FFTW from source and links it statically,
+  the last downloads and links Intel MKL instead. When none of these are enabled (the default), the pure-Rust
+  [RustFFT](https://github.com/ejmahler/RustFFT) backend is used — no system libraries required.
+- `gsl` - enables [GNU Scientific Library](https://www.gnu.org/software/gsl/) support for LMSDER non-linear fitting.
+- `default` - empty; RustFFT is always available without any feature flag.
 
 ### Development
 
@@ -77,8 +79,9 @@ The crate is configured with the following Cargo features:
 Install Rust toolchain, the preferred way is [rustup](https://rustup.rs).
 
 Install the required system libraries.
-For main project you need Ceres Solver, FFTW and GSL, as well as C++ compiler and CMake.
+For the full feature set you need Ceres Solver, FFTW, and GSL, as well as a C++ compiler and CMake.
 The example script plots some stuff so it requires fontconfig.
+FFTW is only needed for the `fftw-*` features; the default RustFFT backend requires no system libraries.
 ```bash
 # On macOS:
 brew install ceres-solver cmake fftw gsl fontconfig
@@ -93,15 +96,20 @@ cd light-curve-feature
 ```
 
 Run tests with native libraries.
-Note that Ceres could require manual `CPATH` specification on some systems, like `CPATH=/opt/homebrew/include` on ARM macOS:
+Note that Ceres may require manual `CPATH` specification on some systems, e.g. `CPATH=/opt/homebrew/include` on ARM macOS:
 ```bash
+# Full feature set with system libraries (FFTW + Ceres + GSL)
 cargo test --no-default-features --features ceres-system,fftw-system,gsl
+# Minimal build using RustFFT (no FFTW needed)
+cargo test
 ```
 
 You may also run benchmarks, but be patient
 ```bash
 cargo bench --no-default-features --features ceres-system,fftw-system,gsl
 ```
+
+The minimum supported Rust version (MSRV) is 1.88.
 
 See `examples`, `.github/workflows` and tests for examples of the code usage.
 


### PR DESCRIPTION
README:
- Default features are now empty; RustFFT is always available (no system libs needed for basic use)
- FFTW is optional via fftw-system/fftw-source/fftw-mkl features
- Remove nuts cargo feature mention (NutsCurveFit always available since 0.13.0)
- Add minimal cargo test command (RustFFT, no flags needed)
- Add MSRV 1.88 mention
- Fix pre-commit.ci badge URL: master -> main

CLAUDE.md:
- Bump version 0.10.0 -> 0.13.1 and MSRV 1.85 -> 1.88
- Update Cargo features: default empty, remove nuts feature
- Update periodogram/ structure: fft_trait.rs, fft_rustfft.rs, fft_fftw.rs
- Mark NutsCurveFit as always available (not optional)
- Add minimal build commands using RustFFT