### PR TITLE
Require explicit passband set for all multicolor features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking** Bump `nuts-rs` from `^0.17` to `^0.18` and `nuts-storable` from `^0.2` to `^0.3`: `NutsCurveFit` results will differ numerically due to nuts-rs 0.18 switching its internal RNG to ChaCha8 https://github.com/light-curve/light-curve-feature/pull/270
+- **Breaking** `MonochromeFeature<P, T, F>` renamed to `PerBandFeature<P, T, F>`; `MultiColorFeature::from_monochrome_feature` renamed to `from_per_band_feature` https://github.com/light-curve/light-curve-feature/pull/269
+- **Breaking** `ColorSpread` is now generic over passband type `P` and requires a passband set at construction via `ColorSpread::new(passbands)`. Input data is subsampled to the specified bands https://github.com/light-curve/light-curve-feature/pull/269
+- **Breaking** `MultiColorPeriodogram<T, F>` is now `MultiColorPeriodogram<P, T, F>` and requires a passband set at construction via `MultiColorPeriodogram::new(peaks, normalization, passbands)`. Input data is subsampled to the specified bands. `Default` impl removed https://github.com/light-curve/light-curve-feature/pull/269
+- **Breaking** `PassbandSet::AllAvailable` variant removed; all multicolor features must now declare their required passbands upfront https://github.com/light-curve/light-curve-feature/pull/269
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking** Bump `nuts-rs` from `^0.17` to `^0.18` and `nuts-storable` from `^0.2` to `^0.3`: `NutsCurveFit` results will differ numerically due to nuts-rs 0.18 switching its internal RNG to ChaCha8 https://github.com/light-curve/light-curve-feature/pull/270
+- `MultiColorExtractor` no longer performs an upfront union-passband check; each constituent feature validates its own required passbands independently, so features with different passband sets can coexist in one extractor. `eval_or_fill_multicolor` fills only the outputs of features whose passbands are absent, leaving the rest unaffected https://github.com/light-curve/light-curve-feature/pull/269
 - **Breaking** `MonochromeFeature<P, T, F>` renamed to `PerBandFeature<P, T, F>`; `MultiColorFeature::from_monochrome_feature` renamed to `from_per_band_feature` https://github.com/light-curve/light-curve-feature/pull/269
 - **Breaking** `ColorSpread` is now generic over passband type `P` and requires a passband set at construction via `ColorSpread::new(passbands)`. Input data is subsampled to the specified bands https://github.com/light-curve/light-curve-feature/pull/269
 - **Breaking** `MultiColorPeriodogram<T, F>` is now `MultiColorPeriodogram<P, T, F>` and requires a passband set at construction via `MultiColorPeriodogram::new(peaks, normalization, passbands)`. Input data is subsampled to the specified bands. `Default` impl removed https://github.com/light-curve/light-curve-feature/pull/269

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -16,6 +16,9 @@ use sin_cos::bench_sin_cos;
 mod peak_indices;
 use peak_indices::bench_peak_indices;
 
+mod multicolor;
+use multicolor::bench_multicolor;
+
 criterion_group!(benches_extractor, bench_extractor<f64>);
 criterion_group!(benches_fit, bench_fit_straight_line, bench_fit_snia);
 criterion_group!(
@@ -26,11 +29,13 @@ criterion_group!(
 );
 criterion_group!(benches_recurrent_sin_cos, bench_sin_cos);
 criterion_group!(benches_statistics, bench_peak_indices);
+criterion_group!(benches_multicolor, bench_multicolor);
 
 criterion_main!(
     benches_extractor,
     benches_fit,
     benches_periodogram,
     benches_recurrent_sin_cos,
-    benches_statistics
+    benches_statistics,
+    benches_multicolor
 );

--- a/benches/multicolor.rs
+++ b/benches/multicolor.rs
@@ -1,0 +1,100 @@
+use criterion::Criterion;
+use light_curve_feature::multicolor::features::{
+    ColorOfMaximum, ColorOfMedian, ColorOfMinimum, ColorSpread, MultiColorPeriodogram,
+    MultiColorPeriodogramNormalisation,
+};
+use light_curve_feature::*;
+use light_curve_feature_test_util::SNIA_LIGHT_CURVES_FLUX_F64;
+use std::collections::BTreeSet;
+use std::hint::black_box;
+
+pub fn bench_multicolor(c: &mut Criterion) {
+    let passbands = [StringPassband::from("R"), StringPassband::from("g")];
+    let required: BTreeSet<_> = passbands.iter().cloned().collect();
+
+    // All SNIa data
+    let all_data: Vec<_> = SNIA_LIGHT_CURVES_FLUX_F64
+        .iter()
+        .map(|(_name, mclc)| {
+            let (t, m, w, bands) = mclc.clone().into_quadruple();
+            let bands: Vec<StringPassband> = bands
+                .iter()
+                .map(|s| StringPassband::from(s.as_str()))
+                .collect();
+            (t, m, w, bands)
+        })
+        .collect();
+
+    // Only curves with both required passbands (for ColorOf* and MultiColorPeriodogram)
+    let two_band_data: Vec<_> = all_data
+        .iter()
+        .filter(|(_, _, _, bands)| {
+            let present: BTreeSet<_> = bands.iter().cloned().collect();
+            required.is_subset(&present)
+        })
+        .collect();
+
+    let color_spread: MultiColorFeature<StringPassband, f64> =
+        ColorSpread::new(passbands.clone()).into();
+    let color_of_median: MultiColorFeature<StringPassband, f64> =
+        ColorOfMedian::new(passbands.clone()).into();
+    let color_of_maximum: MultiColorFeature<StringPassband, f64> =
+        ColorOfMaximum::new(passbands.clone()).into();
+    let color_of_minimum: MultiColorFeature<StringPassband, f64> =
+        ColorOfMinimum::new(passbands.clone()).into();
+    let extractor: MultiColorExtractor<StringPassband, f64> = MultiColorExtractor::new(vec![
+        ColorSpread::new(passbands.clone()).into(),
+        ColorOfMedian::new(passbands.clone()).into(),
+        ColorOfMaximum::new(passbands.clone()).into(),
+        ColorOfMinimum::new(passbands.clone()).into(),
+    ]);
+    let mcperiodogram: MultiColorFeature<StringPassband, f64> =
+        MultiColorPeriodogram::<StringPassband, f64, Feature<f64>>::new(
+            5,
+            MultiColorPeriodogramNormalisation::Count,
+            passbands.clone(),
+        )
+        .into();
+
+    macro_rules! bench_feature {
+        ($name:expr, $feat:expr, $data:expr) => {
+            c.bench_function(&format!("MultiColor {} [SNIa flux f64]", $name), |b| {
+                b.iter(|| {
+                    for (t, m, w, bands) in $data {
+                        let mut mcts = MultiColorTimeSeries::from_flat(
+                            t.view(),
+                            m.view(),
+                            w.view(),
+                            black_box(bands.as_slice()),
+                        );
+                        let _v = $feat.eval_multicolor(black_box(&mut mcts)).ok();
+                    }
+                });
+            });
+        };
+    }
+
+    bench_feature!("ColorSpread", color_spread, &two_band_data);
+    bench_feature!("ColorOfMedian", color_of_median, &two_band_data);
+    bench_feature!("ColorOfMaximum", color_of_maximum, &two_band_data);
+    bench_feature!("ColorOfMinimum", color_of_minimum, &two_band_data);
+
+    c.bench_function(
+        "MultiColor MultiColorExtractor (all color features) [SNIa flux f64]",
+        |b| {
+            b.iter(|| {
+                for (t, m, w, bands) in &two_band_data {
+                    let mut mcts = MultiColorTimeSeries::from_flat(
+                        t.view(),
+                        m.view(),
+                        w.view(),
+                        black_box(bands.as_slice()),
+                    );
+                    let _v = extractor.eval_multicolor(black_box(&mut mcts)).ok();
+                }
+            });
+        },
+    );
+
+    bench_feature!("MultiColorPeriodogram", mcperiodogram, &two_band_data);
+}

--- a/src/data/multi_color_time_series.rs
+++ b/src/data/multi_color_time_series.rs
@@ -268,31 +268,25 @@ where
     pub fn iter_passband_set<'slf, 'ps>(
         &'slf self,
         passband_set: &'ps PassbandSet<P>,
-    ) -> impl Iterator<Item = (&'slf P, Option<&'slf TimeSeries<'a, T>>)> + 'slf
+    ) -> impl Iterator<Item = (&'ps P, Option<&'slf TimeSeries<'a, T>>)> + 'slf
     where
         'a: 'slf,
-        'ps: 'a,
+        'ps: 'slf,
     {
-        match passband_set {
-            PassbandSet::AllAvailable => Either::Left(self.iter().map(|(p, ts)| (p, Some(ts)))),
-            PassbandSet::FixedSet(set) => Either::Right(self.iter_matched_passbands(set.iter())),
-        }
+        let PassbandSet::FixedSet(set) = passband_set;
+        self.iter_matched_passbands(set.iter())
     }
 
     pub fn iter_passband_set_mut<'slf, 'ps>(
         &'slf mut self,
         passband_set: &'ps PassbandSet<P>,
-    ) -> impl Iterator<Item = (&'slf P, Option<&'slf mut TimeSeries<'a, T>>)> + 'slf
+    ) -> impl Iterator<Item = (&'ps P, Option<&'slf mut TimeSeries<'a, T>>)> + 'slf
     where
         'a: 'slf,
-        'ps: 'a,
+        'ps: 'slf,
     {
-        match passband_set {
-            PassbandSet::AllAvailable => Either::Left(self.iter_mut().map(|(p, ts)| (p, Some(ts)))),
-            PassbandSet::FixedSet(set) => {
-                Either::Right(self.iter_matched_passbands_mut(set.iter()))
-            }
-        }
+        let PassbandSet::FixedSet(set) = passband_set;
+        self.iter_matched_passbands_mut(set.iter())
     }
 
     pub fn iter_matched_passbands(

--- a/src/data/multi_color_time_series.rs
+++ b/src/data/multi_color_time_series.rs
@@ -273,7 +273,7 @@ where
         'a: 'slf,
         'ps: 'slf,
     {
-        let PassbandSet::FixedSet(set) = passband_set;
+        let PassbandSet(set) = passband_set;
         self.iter_matched_passbands(set.iter())
     }
 
@@ -285,7 +285,7 @@ where
         'a: 'slf,
         'ps: 'slf,
     {
-        let PassbandSet::FixedSet(set) = passband_set;
+        let PassbandSet(set) = passband_set;
         self.iter_matched_passbands_mut(set.iter())
     }
 

--- a/src/multicolor/features/color_spread.rs
+++ b/src/multicolor/features/color_spread.rs
@@ -1,6 +1,6 @@
 use crate::data::MultiColorTimeSeries;
 use crate::error::MultiColorEvaluatorError;
-use crate::evaluator::{EvaluatorInfoTrait, FeatureNamesDescriptionsTrait};
+use crate::evaluator::{EvaluatorInfo, EvaluatorInfoTrait, FeatureNamesDescriptionsTrait};
 use crate::float_trait::Float;
 use crate::multicolor::multicolor_evaluator::*;
 use crate::multicolor::{PassbandSet, PassbandTrait};
@@ -24,13 +24,37 @@ use std::fmt::Debug;
 /// (e.g. a red star bright in the infrared and faint in the blue).
 /// A value of zero means all bands have the same mean magnitude.
 ///
-/// The feature operates on **all available passbands** and returns a single value.
+/// The set of passbands to include must be specified at construction time via
+/// [`ColorSpread::new`]. Input data is subsampled to the specified bands.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct ColorSpread;
+#[serde(bound(
+    serialize = "P: PassbandTrait",
+    deserialize = "P: PassbandTrait + Deserialize<'de>"
+))]
+pub struct ColorSpread<P>
+where
+    P: PassbandTrait,
+{
+    passband_set: PassbandSet<P>,
+}
+
+impl<P> ColorSpread<P>
+where
+    P: PassbandTrait,
+{
+    /// Create a new `ColorSpread` evaluator for the given set of passbands.
+    ///
+    /// Input [MultiColorTimeSeries](crate::data::MultiColorTimeSeries) is subsampled
+    /// to the specified passbands when this feature is evaluated.
+    pub fn new(passbands: impl IntoIterator<Item = P>) -> Self {
+        Self {
+            passband_set: PassbandSet::FixedSet(passbands.into_iter().collect()),
+        }
+    }
+}
 
 lazy_info!(
     COLOR_SPREAD_INFO,
-    ColorSpread,
     size: 1,
     min_ts_length: 1,
     t_required: false,
@@ -40,7 +64,19 @@ lazy_info!(
     variability_required: false,
 );
 
-impl FeatureNamesDescriptionsTrait for ColorSpread {
+impl<P> EvaluatorInfoTrait for ColorSpread<P>
+where
+    P: PassbandTrait,
+{
+    fn get_info(&self) -> &EvaluatorInfo {
+        &COLOR_SPREAD_INFO
+    }
+}
+
+impl<P> FeatureNamesDescriptionsTrait for ColorSpread<P>
+where
+    P: PassbandTrait,
+{
     fn get_names(&self) -> Vec<&str> {
         vec!["color_spread"]
     }
@@ -50,16 +86,16 @@ impl FeatureNamesDescriptionsTrait for ColorSpread {
     }
 }
 
-impl<P> MultiColorPassbandSetTrait<P> for ColorSpread
+impl<P> MultiColorPassbandSetTrait<P> for ColorSpread<P>
 where
     P: PassbandTrait,
 {
     fn get_passband_set(&self) -> &PassbandSet<P> {
-        &PassbandSet::AllAvailable
+        &self.passband_set
     }
 }
 
-impl<P, T> MultiColorEvaluator<P, T> for ColorSpread
+impl<P, T> MultiColorEvaluator<P, T> for ColorSpread<P>
 where
     P: PassbandTrait,
     T: Float,
@@ -72,12 +108,16 @@ where
         'slf: 'a,
         'a: 'mcts,
     {
+        let PassbandSet::FixedSet(set) = &self.passband_set;
         let mapping = mcts.mapping_mut();
 
-        // Compute weighted mean magnitude for each passband
-        let band_means: Vec<T> = mapping
-            .values_mut()
-            .map(|ts| {
+        // Compute weighted mean magnitude for each specified passband (in sorted order)
+        let band_means: Vec<T> = set
+            .iter()
+            .map(|p| {
+                let ts = mapping
+                    .get_mut(p)
+                    .expect("passband must be present after check_mcts");
                 let m = ts.m.as_slice();
                 let w = ts.w.as_slice();
                 let sum_wm = m
@@ -104,10 +144,15 @@ where
 mod tests {
     use super::*;
     use crate::{MultiColorTimeSeries, StringPassband};
+    use std::collections::BTreeSet;
+
+    fn make_passbands(names: &[&str]) -> BTreeSet<StringPassband> {
+        names.iter().map(|&s| StringPassband::from(s)).collect()
+    }
 
     #[test]
     fn color_spread_values() {
-        let eval = ColorSpread;
+        let eval = ColorSpread::new(make_passbands(&["g", "i", "r"]));
         // g band: [10.0, 12.0] w=[1.0, 1.0] -> mu_g = 11.0
         // i band: [14.0, 16.0] w=[1.0, 1.0] -> mu_i = 15.0
         // r band: [17.0, 19.0] w=[1.0, 1.0] -> mu_r = 18.0
@@ -135,9 +180,31 @@ mod tests {
     }
 
     #[test]
+    fn color_spread_subsamples_bands() {
+        // Data has g, i, r but we only request g and r — result should match two-band computation
+        let eval = ColorSpread::new(make_passbands(&["g", "r"]));
+        let t = vec![0.0_f64; 6];
+        let m = vec![10.0, 12.0, 14.0, 16.0, 17.0, 19.0];
+        let w = vec![1.0_f64; 6];
+        let bands: Vec<StringPassband> = vec!["g", "g", "i", "i", "r", "r"]
+            .into_iter()
+            .map(StringPassband::from)
+            .collect();
+        let mut mcts = MultiColorTimeSeries::from_flat(t, m, w, bands);
+        let result = eval.eval_multicolor(&mut mcts).unwrap();
+
+        // Only g (mu=11) and r (mu=18) used
+        let mu_g = 11.0_f64;
+        let mu_r = 18.0_f64;
+        let mean_mu = (mu_g + mu_r) / 2.0;
+        let expected = (((mu_g - mean_mu).powi(2) + (mu_r - mean_mu).powi(2)) / 2.0).sqrt();
+        assert!((result[0] - expected).abs() < 1e-10);
+    }
+
+    #[test]
     fn color_spread_uniform_bands() {
         // All bands have the same weighted mean -> spread should be 0
-        let eval = ColorSpread;
+        let eval = ColorSpread::new(make_passbands(&["g", "r"]));
         let t = vec![0.0_f64; 4];
         let m = vec![5.0, 5.0, 5.0, 5.0];
         let w = vec![1.0_f64; 4];
@@ -152,16 +219,16 @@ mod tests {
 
     #[test]
     fn color_spread_names() {
-        let eval = ColorSpread;
+        let eval = ColorSpread::new(make_passbands(&["g", "r"]));
         assert_eq!(eval.get_names(), vec!["color_spread"]);
         assert_eq!(eval.size_hint(), 1);
     }
 
     #[test]
     fn color_spread_serde() {
-        let eval = ColorSpread;
+        let eval = ColorSpread::new(make_passbands(&["g", "r"]));
         let json = serde_json::to_string(&eval).unwrap();
-        let eval2: ColorSpread = serde_json::from_str(&json).unwrap();
+        let eval2: ColorSpread<StringPassband> = serde_json::from_str(&json).unwrap();
         assert_eq!(json, serde_json::to_string(&eval2).unwrap());
     }
 }

--- a/src/multicolor/features/color_spread.rs
+++ b/src/multicolor/features/color_spread.rs
@@ -48,7 +48,7 @@ where
     /// to the specified passbands when this feature is evaluated.
     pub fn new(passbands: impl IntoIterator<Item = P>) -> Self {
         Self {
-            passband_set: PassbandSet::FixedSet(passbands.into_iter().collect()),
+            passband_set: PassbandSet(passbands.into_iter().collect()),
         }
     }
 }
@@ -108,7 +108,7 @@ where
         'slf: 'a,
         'a: 'mcts,
     {
-        let PassbandSet::FixedSet(set) = &self.passband_set;
+        let PassbandSet(set) = &self.passband_set;
         let mapping = mcts.mapping_mut();
 
         // Compute weighted mean magnitude for each specified passband (in sorted order)

--- a/src/multicolor/features/multi_color_periodogram.rs
+++ b/src/multicolor/features/multi_color_periodogram.rs
@@ -42,8 +42,11 @@ pub enum MultiColorPeriodogramNormalisation {
 ///
 /// Combines per-band Lomb-Scargle periodograms into a single power spectrum
 /// using a common frequency grid derived from the union of all observation
-/// times. Individual band powers are weighted and summed according to the
-/// chosen [`MultiColorPeriodogramNormalisation`] strategy.
+/// times in the specified passbands. Individual band powers are weighted and
+/// summed according to the chosen [`MultiColorPeriodogramNormalisation`] strategy.
+///
+/// The set of passbands to include must be specified at construction time via
+/// [`MultiColorPeriodogram::new`]. Input data is subsampled to the specified bands.
 ///
 /// The frequency grid, peak-extraction features, and periodogram algorithm are
 /// inherited from the underlying [`Periodogram`] and can be configured through
@@ -58,9 +61,12 @@ pub enum MultiColorPeriodogramNormalisation {
 /// # Example
 ///
 /// ```rust,ignore
+/// use std::collections::BTreeSet;
+/// let passbands = ["g", "r"].iter().map(|&s| StringPassband::from(s)).collect::<BTreeSet<_>>();
 /// let mut eval = MultiColorPeriodogram::<StringPassband, f64, Feature<f64>>::new(
 ///     1,
 ///     MultiColorPeriodogramNormalisation::Count,
+///     passbands,
 /// );
 /// eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
 /// let result = eval.eval_multicolor(&mut mcts)?;
@@ -75,6 +81,7 @@ where
     // We use it to not reimplement some internals
     monochrome: Periodogram<T, F>,
     normalization: MultiColorPeriodogramNormalisation,
+    passband_set: PassbandSet<P>,
     /// Passbands on which phase features are evaluated. Empty = no phase features.
     phase_bands: Vec<P>,
     phase_extractor: FeatureExtractor<T, F>,
@@ -100,6 +107,7 @@ where
 {
     monochrome: Periodogram<T, F>,
     normalization: MultiColorPeriodogramNormalisation,
+    passband_set: PassbandSet<P>,
     #[serde(default)]
     phase_bands: Vec<P>,
     #[serde(default)]
@@ -117,6 +125,7 @@ where
         Self {
             monochrome: v.monochrome,
             normalization: v.normalization,
+            passband_set: v.passband_set,
             phase_bands: v.phase_bands,
             phase_features: v.phase_extractor.into_vec(),
         }
@@ -131,7 +140,7 @@ where
     <F as TryInto<PeriodogramPeaks>>::Error: Debug,
 {
     fn from(p: MultiColorPeriodogramParameters<P, T, F>) -> Self {
-        let mut mcp = Self::new_with_monochrome(p.monochrome, p.normalization);
+        let mut mcp = Self::new_with_monochrome(p.monochrome, p.normalization, p.passband_set);
         if !p.phase_bands.is_empty() {
             mcp.set_phase_bands(p.phase_bands);
         }
@@ -200,22 +209,31 @@ where
     F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>,
     <F as TryInto<PeriodogramPeaks>>::Error: Debug,
 {
-    /// Create a new multi-colour periodogram.
+    /// Create a new multi-colour periodogram for the given set of passbands.
     ///
     /// `peaks` sets the number of highest-power peaks whose period and
     /// signal-to-noise ratio are returned as features.
-    pub fn new(peaks: usize, normalization: MultiColorPeriodogramNormalisation) -> Self {
+    ///
+    /// Input [MultiColorTimeSeries](crate::data::MultiColorTimeSeries) is subsampled
+    /// to the specified passbands when this feature is evaluated.
+    pub fn new(
+        peaks: usize,
+        normalization: MultiColorPeriodogramNormalisation,
+        passbands: impl IntoIterator<Item = P>,
+    ) -> Self {
         let monochrome = Periodogram::with_name_description(
             peaks,
             "multicolor_periodogram",
             "of multi-color periodogram (interpreting frequency as time, power as magnitude)",
         );
-        Self::new_with_monochrome(monochrome, normalization)
+        let passband_set = PassbandSet::FixedSet(passbands.into_iter().collect());
+        Self::new_with_monochrome(monochrome, normalization, passband_set)
     }
 
     fn new_with_monochrome(
         monochrome: Periodogram<T, F>,
         normalization: MultiColorPeriodogramNormalisation,
+        passband_set: PassbandSet<P>,
     ) -> Self {
         let properties = EvaluatorProperties {
             info: monochrome.get_info().clone(),
@@ -234,6 +252,7 @@ where
         Self {
             monochrome,
             normalization,
+            passband_set,
             phase_bands: vec![],
             phase_extractor: FeatureExtractor::new(vec![]),
             properties,
@@ -411,21 +430,6 @@ where
     }
 }
 
-impl<P, T, F> Default for MultiColorPeriodogram<P, T, F>
-where
-    P: PassbandTrait,
-    T: Float,
-    F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>,
-    <F as TryInto<PeriodogramPeaks>>::Error: Debug,
-{
-    fn default() -> Self {
-        Self::new(
-            Self::default_peaks(),
-            MultiColorPeriodogramNormalisation::Count,
-        )
-    }
-}
-
 // ── EvaluatorInfoTrait / FeatureNamesDescriptionsTrait ────────────────────────
 
 impl<P, T, F> EvaluatorInfoTrait for MultiColorPeriodogram<P, T, F>
@@ -469,8 +473,27 @@ where
     F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>,
     <F as TryInto<PeriodogramPeaks>>::Error: Debug,
 {
+    /// Build a [Periodogram] from the observation times of the specified passbands only.
+    fn periodogram_from_mcts<'slf>(
+        &'slf self,
+        mcts: &mut MultiColorTimeSeries<'_, P, T>,
+    ) -> Result<periodogram::Periodogram<'slf, T>, MultiColorEvaluatorError> {
+        let PassbandSet::FixedSet(passband_set) = &self.passband_set;
+        let t_filtered: Vec<T> = {
+            let mapping = mcts.mapping_mut();
+            mapping
+                .iter_matched_passbands_mut(passband_set.iter())
+                .filter_map(|(_, ts)| ts)
+                .flat_map(|ts| ts.t.as_slice().to_vec())
+                .collect()
+        };
+        self.monochrome
+            .periodogram_from_t(&t_filtered)
+            .map_err(|e| MultiColorEvaluatorError::UnderlyingEvaluatorError(e.into()))
+    }
+
     fn power_from_periodogram<'slf, 'a, 'mcts>(
-        &self,
+        &'slf self,
         p: &periodogram::Periodogram<T>,
         mcts: &'mcts mut MultiColorTimeSeries<'a, P, T>,
     ) -> Result<Array1<T>, MultiColorEvaluatorError>
@@ -478,15 +501,24 @@ where
         'slf: 'a,
         'a: 'mcts,
     {
+        let PassbandSet::FixedSet(passband_set) = &self.passband_set;
         let mapping = mcts.mapping_mut();
         let ts_weights = {
             let mut a: Array1<_> = match self.normalization {
-                MultiColorPeriodogramNormalisation::Count => {
-                    mapping.values().map(|ts| ts.lenf()).collect()
-                }
-                MultiColorPeriodogramNormalisation::Chi2 => {
-                    mapping.values_mut().map(|ts| ts.get_m_chi2()).collect()
-                }
+                MultiColorPeriodogramNormalisation::Count => mapping
+                    .iter_matched_passbands_mut(passband_set.iter())
+                    .map(|(_, ts)| {
+                        ts.expect("passband must be present after check_mcts")
+                            .lenf()
+                    })
+                    .collect(),
+                MultiColorPeriodogramNormalisation::Chi2 => mapping
+                    .iter_matched_passbands_mut(passband_set.iter())
+                    .map(|(_, ts)| {
+                        ts.expect("passband must be present after check_mcts")
+                            .get_m_chi2()
+                    })
+                    .collect(),
             };
             let norm = a.sum();
             if norm.is_zero() {
@@ -506,7 +538,8 @@ where
             a
         };
         let combined = mapping
-            .values_mut()
+            .iter_matched_passbands_mut(passband_set.iter())
+            .filter_map(|(_, ts)| ts)
             .zip(ts_weights.iter())
             .filter(|(ts, _ts_weight)| self.monochrome.check_ts_length(ts).is_ok())
             .map(|(ts, &ts_weight)| {
@@ -524,43 +557,50 @@ where
     }
 
     /// Compute the combined multi-band Lomb-Scargle power spectrum.
+    ///
+    /// The frequency grid is derived from all observation times across the
+    /// specified passbands. Returns a 1-D array of power values, one per
+    /// frequency grid point.
     pub fn power<'slf, 'a, 'mcts>(
-        &self,
+        &'slf self,
         mcts: &'mcts mut MultiColorTimeSeries<'a, P, T>,
     ) -> Result<Array1<T>, MultiColorEvaluatorError>
     where
         'slf: 'a,
         'a: 'mcts,
     {
-        let p = self
-            .monochrome
-            .periodogram_from_t(mcts.flat_mut().t.as_slice())
-            .map_err(|e| MultiColorEvaluatorError::UnderlyingEvaluatorError(e.into()))?;
+        let p = self.periodogram_from_mcts(mcts)?;
         self.power_from_periodogram(&p, mcts)
     }
 
-    /// Compute the combined multi-band power spectrum together with the frequency grid.
+    /// Compute the combined multi-band power spectrum together with the
+    /// frequency grid.
+    ///
+    /// Returns `(frequencies, powers)` as a pair of 1-D arrays. The
+    /// frequencies are in the same units as the reciprocal of the time axis
+    /// (rad per time unit when using the default angular-frequency convention).
     pub fn freq_power<'slf, 'a, 'mcts>(
-        &self,
+        &'slf self,
         mcts: &'mcts mut MultiColorTimeSeries<'a, P, T>,
     ) -> Result<(Array1<T>, Array1<T>), MultiColorEvaluatorError>
     where
         'slf: 'a,
         'a: 'mcts,
     {
-        let p = self
-            .monochrome
-            .periodogram_from_t(mcts.flat_mut().t.as_slice())
-            .map_err(|e| MultiColorEvaluatorError::UnderlyingEvaluatorError(e.into()))?;
+        let p = self.periodogram_from_mcts(mcts)?;
         let power = self.power_from_periodogram(&p, mcts)?;
         let freq = (0..power.len()).map(|i| p.freq(i)).collect();
         Ok((freq, power))
     }
 
-    fn transform_mcts_to_ts<'a>(
-        &self,
-        mcts: &mut MultiColorTimeSeries<'a, P, T>,
-    ) -> Result<TmArrays<T>, MultiColorEvaluatorError> {
+    fn transform_mcts_to_ts<'slf, 'a, 'mcts>(
+        &'slf self,
+        mcts: &'mcts mut MultiColorTimeSeries<'a, P, T>,
+    ) -> Result<TmArrays<T>, MultiColorEvaluatorError>
+    where
+        'slf: 'a,
+        'a: 'mcts,
+    {
         let (freq, power) = self.freq_power(mcts)?;
         Ok(TmArrays { t: freq, m: power })
     }
@@ -575,7 +615,7 @@ where
     F: FeatureEvaluator<T>,
 {
     fn get_passband_set(&self) -> &PassbandSet<P> {
-        &PassbandSet::AllAvailable
+        &self.passband_set
     }
 }
 
@@ -724,17 +764,26 @@ where
 mod tests {
     use super::*;
     use crate::{Feature, MultiColorTimeSeries, StringPassband};
+    use std::collections::BTreeSet;
 
     type McPeriodogram = MultiColorPeriodogram<StringPassband, f64, Feature<f64>>;
 
+    fn passbands_from_array(bands: &ndarray::Array1<String>) -> BTreeSet<StringPassband> {
+        bands
+            .iter()
+            .map(|b| StringPassband::from(b.as_str()))
+            .collect()
+    }
+
     fn check_finite_with_norm(norm: MultiColorPeriodogramNormalisation) {
-        let eval = McPeriodogram::new(1, norm);
         for (name, mclc) in light_curve_feature_test_util::RRLYR_LIGHT_CURVES_MAG_F64.iter() {
             let (t, m, w, bands) = mclc.clone().into_quadruple();
             let passbands: Vec<StringPassband> = bands
                 .iter()
                 .map(|b| StringPassband::from(b.as_str()))
                 .collect();
+            let unique_passbands = passbands_from_array(&bands);
+            let eval = McPeriodogram::new(1, norm.clone(), unique_passbands);
             let mut mcts = MultiColorTimeSeries::from_flat(
                 t.into_raw_vec_and_offset().0,
                 m.into_raw_vec_and_offset().0,
@@ -763,8 +812,6 @@ mod tests {
     fn check_period_recovery() {
         use crate::{LinearFreqGrid, PeriodogramPowerDirect};
 
-        let mut eval = McPeriodogram::new(2, MultiColorPeriodogramNormalisation::Count);
-
         let n_tested = 10;
 
         let baseline = light_curve_feature_test_util::RR_LYRAE_F64
@@ -784,8 +831,6 @@ mod tests {
         let step = std::f64::consts::TAU / (resolution * baseline);
         let size = ((max_freq - min_freq) / step).ceil() as usize + 1;
         let grid = LinearFreqGrid::new(min_freq, step, size);
-        eval.set_freq_grid(grid);
-        eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
 
         let tolerance = 0.01;
 
@@ -799,6 +844,16 @@ mod tests {
                 .iter()
                 .map(|b| StringPassband::from(b.as_str()))
                 .collect();
+            let unique_passbands = passbands_from_array(&bands);
+            // Use 2 peaks: for short-period RRc stars the 2-day alias may rank higher than
+            // the true period, but the true period appears as the 2nd-highest peak.
+            let mut eval = McPeriodogram::new(
+                2,
+                MultiColorPeriodogramNormalisation::Count,
+                unique_passbands,
+            );
+            eval.set_freq_grid(grid.clone());
+            eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
             let mut mcts = MultiColorTimeSeries::from_flat(
                 t.into_raw_vec_and_offset().0,
                 m.into_raw_vec_and_offset().0,
@@ -821,9 +876,20 @@ mod tests {
         );
     }
 
+    fn make_gr_passbands() -> BTreeSet<StringPassband> {
+        ["g", "r"]
+            .iter()
+            .map(|&s| StringPassband::from(s))
+            .collect()
+    }
+
     #[test]
-    fn serde_json_default() {
-        let eval = McPeriodogram::default();
+    fn serde_json_roundtrip() {
+        let eval = McPeriodogram::new(
+            1,
+            MultiColorPeriodogramNormalisation::Count,
+            make_gr_passbands(),
+        );
         let json = serde_json::to_string(&eval).unwrap();
         let eval2: McPeriodogram = serde_json::from_str(&json).unwrap();
         assert_eq!(json, serde_json::to_string(&eval2).unwrap());
@@ -831,7 +897,11 @@ mod tests {
 
     #[test]
     fn serde_json_chi2_norm() {
-        let eval = McPeriodogram::new(2, MultiColorPeriodogramNormalisation::Chi2);
+        let eval = McPeriodogram::new(
+            2,
+            MultiColorPeriodogramNormalisation::Chi2,
+            make_gr_passbands(),
+        );
         let json = serde_json::to_string(&eval).unwrap();
         let eval2: McPeriodogram = serde_json::from_str(&json).unwrap();
         assert_eq!(json, serde_json::to_string(&eval2).unwrap());
@@ -840,7 +910,11 @@ mod tests {
     #[test]
     fn serde_json_direct_algorithm() {
         use crate::PeriodogramPowerDirect;
-        let mut eval = McPeriodogram::default();
+        let mut eval = McPeriodogram::new(
+            1,
+            MultiColorPeriodogramNormalisation::Count,
+            make_gr_passbands(),
+        );
         eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
         let json = serde_json::to_string(&eval).unwrap();
         let eval2: McPeriodogram = serde_json::from_str(&json).unwrap();
@@ -850,7 +924,7 @@ mod tests {
     #[test]
     fn serde_json_with_phase_features() {
         use crate::features::LaflerKinmanStringLength;
-        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count);
+        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count, make_gr_passbands());
         eval.set_phase_bands(vec![StringPassband::from("g"), StringPassband::from("r")]);
         eval.add_phase_feature(LaflerKinmanStringLength::new().into());
         let json = serde_json::to_string(&eval).unwrap();
@@ -865,7 +939,7 @@ mod tests {
     fn phase_feature_names_and_size() {
         use crate::features::LaflerKinmanStringLength;
 
-        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count);
+        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count, make_gr_passbands());
         eval.set_phase_bands(vec![StringPassband::from("g"), StringPassband::from("r")]);
         eval.add_phase_feature(LaflerKinmanStringLength::new().into());
 
@@ -913,7 +987,7 @@ mod tests {
         };
 
         let make_eval = |norm| {
-            let mut eval = McPeriodogram::new(1, norm);
+            let mut eval = McPeriodogram::new(1, norm, make_gr_passbands());
             eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
             eval.set_freq_grid(LinearFreqGrid::new(1.0 / 2.0, 1.0 / 0.1, 200));
             eval
@@ -965,6 +1039,10 @@ mod tests {
         );
     }
 
+    fn make_g_passband() -> BTreeSet<StringPassband> {
+        [StringPassband::from("g")].into_iter().collect()
+    }
+
     // Case 1: !t_required && !sorting_required — raw band_ts evaluated, no phase folding.
     // Amplitude only needs magnitudes; phase_fold_or_compute returns None and the extractor
     // is called directly on the original (unfolded) band time series.
@@ -989,7 +1067,7 @@ mod tests {
         );
         let mut mcts = MultiColorTimeSeries::from_map(map);
 
-        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count);
+        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count, make_g_passband());
         eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
         eval.set_phase_bands(vec![StringPassband::from("g")]);
         eval.add_phase_feature(Amplitude::default().into());
@@ -1032,7 +1110,7 @@ mod tests {
         );
         let mut mcts = MultiColorTimeSeries::from_map(map);
 
-        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count);
+        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count, make_g_passband());
         eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
         eval.set_phase_bands(vec![StringPassband::from("g")]);
         eval.add_phase_feature(TimeMean::default().into());
@@ -1072,7 +1150,7 @@ mod tests {
         );
         let mut mcts = MultiColorTimeSeries::from_map(map);
 
-        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count);
+        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count, make_g_passband());
         eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
         // Fixed grid: single frequency whose period equals 1.0 → all phases collapse to 0.0
         eval.set_freq_grid(crate::periodogram::FreqGrid::linear(
@@ -1115,7 +1193,7 @@ mod tests {
         );
         let mut mcts = MultiColorTimeSeries::from_map(map);
 
-        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count);
+        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count, make_g_passband());
         eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
         eval.set_phase_bands(vec![StringPassband::from("g")]);
         eval.add_phase_feature(LaflerKinmanStringLength::new().into());
@@ -1132,6 +1210,78 @@ mod tests {
         assert!(
             theta < 0.01,
             "phase-folded LaflerKinmanStringLength = {theta}, expected < 0.01 for smooth curve"
+        );
+    }
+
+    /// Verify that MultiColorPeriodogram ignores bands not in its passband set.
+    ///
+    /// Setup: three bands g, r, i with a sinusoidal signal in g, constant in r, constant in i.
+    /// An evaluator configured for only {g, r} must produce the same result regardless of
+    /// whether the i-band data is present in the MultiColorTimeSeries.
+    #[test]
+    fn subsamples_to_requested_passbands() {
+        use crate::data::TimeSeries;
+        use crate::{LinearFreqGrid, PeriodogramPowerDirect};
+
+        let n = 20usize;
+        let period = 0.3_f64;
+        let t: Vec<f64> = (0..n).map(|i| i as f64 * 0.05).collect();
+        let m_g: Vec<f64> = t
+            .iter()
+            .map(|&ti| (2.0 * std::f64::consts::PI * ti / period).sin())
+            .collect();
+        let m_r: Vec<f64> = vec![0.0; n];
+        let m_i: Vec<f64> = vec![99.0; n]; // large constant — should be ignored
+
+        let make_eval = || {
+            let passbands: BTreeSet<StringPassband> = ["g", "r"]
+                .iter()
+                .map(|&s| StringPassband::from(s))
+                .collect();
+            let mut eval =
+                McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count, passbands);
+            eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
+            eval.set_freq_grid(LinearFreqGrid::new(1.0 / 2.0, 1.0 / 0.1, 200));
+            eval
+        };
+
+        // mcts with only g and r
+        let mut mcts_gr = {
+            let mut map = std::collections::BTreeMap::new();
+            map.insert(
+                StringPassband::from("g"),
+                TimeSeries::new_without_weight(t.as_slice(), m_g.as_slice()),
+            );
+            map.insert(
+                StringPassband::from("r"),
+                TimeSeries::new_without_weight(t.as_slice(), m_r.as_slice()),
+            );
+            MultiColorTimeSeries::from_map(map)
+        };
+
+        // mcts with g, r, and extra i band — evaluator should ignore i
+        let mut mcts_gri = {
+            let mut map = std::collections::BTreeMap::new();
+            map.insert(
+                StringPassband::from("g"),
+                TimeSeries::new_without_weight(t.as_slice(), m_g.as_slice()),
+            );
+            map.insert(
+                StringPassband::from("r"),
+                TimeSeries::new_without_weight(t.as_slice(), m_r.as_slice()),
+            );
+            map.insert(
+                StringPassband::from("i"),
+                TimeSeries::new_without_weight(t.as_slice(), m_i.as_slice()),
+            );
+            MultiColorTimeSeries::from_map(map)
+        };
+
+        let result_gr = make_eval().eval_multicolor(&mut mcts_gr).unwrap();
+        let result_gri = make_eval().eval_multicolor(&mut mcts_gri).unwrap();
+        assert_eq!(
+            result_gr, result_gri,
+            "Extra i band must not affect the result"
         );
     }
 }

--- a/src/multicolor/features/multi_color_periodogram.rs
+++ b/src/multicolor/features/multi_color_periodogram.rs
@@ -226,7 +226,7 @@ where
             "multicolor_periodogram",
             "of multi-color periodogram (interpreting frequency as time, power as magnitude)",
         );
-        let passband_set = PassbandSet::FixedSet(passbands.into_iter().collect());
+        let passband_set = PassbandSet(passbands.into_iter().collect());
         Self::new_with_monochrome(monochrome, normalization, passband_set)
     }
 
@@ -337,9 +337,7 @@ where
 
     /// Register the passbands on which phase features will be evaluated.
     ///
-    /// Must be called before [Self::add_phase_feature]. The passband set
-    /// switches from `AllAvailable` to `FixedSet` for phase evaluation;
-    /// spectrum evaluation still uses all available bands.
+    /// Must be called before [Self::add_phase_feature].
     ///
     /// # Panics
     /// Panics if phase features have already been added.
@@ -478,7 +476,7 @@ where
         &'slf self,
         mcts: &mut MultiColorTimeSeries<'_, P, T>,
     ) -> Result<periodogram::Periodogram<'slf, T>, MultiColorEvaluatorError> {
-        let PassbandSet::FixedSet(passband_set) = &self.passband_set;
+        let PassbandSet(passband_set) = &self.passband_set;
         let t_filtered: Vec<T> = {
             let mapping = mcts.mapping_mut();
             mapping
@@ -501,7 +499,7 @@ where
         'slf: 'a,
         'a: 'mcts,
     {
-        let PassbandSet::FixedSet(passband_set) = &self.passband_set;
+        let PassbandSet(passband_set) = &self.passband_set;
         let mapping = mcts.mapping_mut();
         let ts_weights = {
             let mut a: Array1<_> = match self.normalization {

--- a/src/multicolor/features/multi_color_periodogram.rs
+++ b/src/multicolor/features/multi_color_periodogram.rs
@@ -924,7 +924,11 @@ mod tests {
     #[test]
     fn serde_json_with_phase_features() {
         use crate::features::LaflerKinmanStringLength;
-        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count, make_gr_passbands());
+        let mut eval = McPeriodogram::new(
+            1,
+            MultiColorPeriodogramNormalisation::Count,
+            make_gr_passbands(),
+        );
         eval.set_phase_bands(vec![StringPassband::from("g"), StringPassband::from("r")]);
         eval.add_phase_feature(LaflerKinmanStringLength::new().into());
         let json = serde_json::to_string(&eval).unwrap();
@@ -939,7 +943,11 @@ mod tests {
     fn phase_feature_names_and_size() {
         use crate::features::LaflerKinmanStringLength;
 
-        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count, make_gr_passbands());
+        let mut eval = McPeriodogram::new(
+            1,
+            MultiColorPeriodogramNormalisation::Count,
+            make_gr_passbands(),
+        );
         eval.set_phase_bands(vec![StringPassband::from("g"), StringPassband::from("r")]);
         eval.add_phase_feature(LaflerKinmanStringLength::new().into());
 
@@ -1067,7 +1075,11 @@ mod tests {
         );
         let mut mcts = MultiColorTimeSeries::from_map(map);
 
-        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count, make_g_passband());
+        let mut eval = McPeriodogram::new(
+            1,
+            MultiColorPeriodogramNormalisation::Count,
+            make_g_passband(),
+        );
         eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
         eval.set_phase_bands(vec![StringPassband::from("g")]);
         eval.add_phase_feature(Amplitude::default().into());
@@ -1110,7 +1122,11 @@ mod tests {
         );
         let mut mcts = MultiColorTimeSeries::from_map(map);
 
-        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count, make_g_passband());
+        let mut eval = McPeriodogram::new(
+            1,
+            MultiColorPeriodogramNormalisation::Count,
+            make_g_passband(),
+        );
         eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
         eval.set_phase_bands(vec![StringPassband::from("g")]);
         eval.add_phase_feature(TimeMean::default().into());
@@ -1150,7 +1166,11 @@ mod tests {
         );
         let mut mcts = MultiColorTimeSeries::from_map(map);
 
-        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count, make_g_passband());
+        let mut eval = McPeriodogram::new(
+            1,
+            MultiColorPeriodogramNormalisation::Count,
+            make_g_passband(),
+        );
         eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
         // Fixed grid: single frequency whose period equals 1.0 → all phases collapse to 0.0
         eval.set_freq_grid(crate::periodogram::FreqGrid::linear(
@@ -1193,7 +1213,11 @@ mod tests {
         );
         let mut mcts = MultiColorTimeSeries::from_map(map);
 
-        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count, make_g_passband());
+        let mut eval = McPeriodogram::new(
+            1,
+            MultiColorPeriodogramNormalisation::Count,
+            make_g_passband(),
+        );
         eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
         eval.set_phase_bands(vec![StringPassband::from("g")]);
         eval.add_phase_feature(LaflerKinmanStringLength::new().into());

--- a/src/multicolor/mod.rs
+++ b/src/multicolor/mod.rs
@@ -1,7 +1,7 @@
 pub mod features;
 
-mod monochrome_feature;
-pub use monochrome_feature::MonochromeFeature;
+mod per_band_feature;
+pub use per_band_feature::PerBandFeature;
 
 mod multicolor_evaluator;
 pub use multicolor_evaluator::{MultiColorEvaluator, MultiColorPassbandSetTrait, PassbandSet};

--- a/src/multicolor/multicolor_evaluator.rs
+++ b/src/multicolor/multicolor_evaluator.rs
@@ -24,10 +24,10 @@ where
     fn get_passband_set(&self) -> &PassbandSet<P>;
 }
 
-/// Enum for passband set, which can be either fixed set or all available passbands.
-/// This is used for [MultiColorEvaluator]s, which can be evaluated on all available passbands
-/// (for example [MultiColorPeriodogram](super::features::MultiColorPeriodogram)) or on fixed set of
-/// passbands (for example [ColorOfMaximum](super::ColorOfMaximum)).
+/// Enum for passband set.
+/// This is used for [MultiColorEvaluator]s to declare which passbands they require.
+/// Input [MultiColorTimeSeries](crate::data::MultiColorTimeSeries) data is subsampled to
+/// contain only the passbands in this set when the evaluator is applied.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(bound(deserialize = "P: PassbandTrait + Deserialize<'de>"))]
 #[non_exhaustive]
@@ -37,8 +37,6 @@ where
 {
     /// Fixed set of passbands
     FixedSet(BTreeSet<P>),
-    /// All available passbands
-    AllAvailable,
 }
 
 impl<P> From<BTreeSet<P>> for PassbandSet<P>
@@ -75,9 +73,6 @@ impl InternalMctsError {
                     mcts.passbands(),
                     match ps {
                         PassbandSet::FixedSet(ps) => ps.iter(),
-                        PassbandSet::AllAvailable => {
-                            panic!("PassbandSet cannot be ::AllAvailable here")
-                        }
                     },
                 )
             }
@@ -248,11 +243,6 @@ mod tests {
             );
             MultiColorTimeSeries::from_map(mapping)
         };
-
-        let feature = TestTimeMultiColorFeature {
-            passband_set: PassbandSet::AllAvailable,
-        };
-        assert!(feature.eval_multicolor(&mut mcts).is_ok());
 
         let feature = TestTimeMultiColorFeature {
             passband_set: PassbandSet::FixedSet(

--- a/src/multicolor/multicolor_evaluator.rs
+++ b/src/multicolor/multicolor_evaluator.rs
@@ -24,27 +24,21 @@ where
     fn get_passband_set(&self) -> &PassbandSet<P>;
 }
 
-/// Enum for passband set.
-/// This is used for [MultiColorEvaluator]s to declare which passbands they require.
+/// Set of passbands required by a [MultiColorEvaluator].
 /// Input [MultiColorTimeSeries](crate::data::MultiColorTimeSeries) data is subsampled to
 /// contain only the passbands in this set when the evaluator is applied.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(bound(deserialize = "P: PassbandTrait + Deserialize<'de>"))]
-#[non_exhaustive]
-pub enum PassbandSet<P>
+pub struct PassbandSet<P>(pub BTreeSet<P>)
 where
-    P: Ord,
-{
-    /// Fixed set of passbands
-    FixedSet(BTreeSet<P>),
-}
+    P: Ord;
 
 impl<P> From<BTreeSet<P>> for PassbandSet<P>
 where
     P: Ord,
 {
     fn from(value: BTreeSet<P>) -> Self {
-        Self::FixedSet(value)
+        Self(value)
     }
 }
 
@@ -69,12 +63,7 @@ impl InternalMctsError {
         match self {
             InternalMctsError::MultiColorEvaluatorError(e) => e,
             InternalMctsError::InternalWrongPassbandSet => {
-                MultiColorEvaluatorError::wrong_passbands_error(
-                    mcts.passbands(),
-                    match ps {
-                        PassbandSet::FixedSet(ps) => ps.iter(),
-                    },
-                )
+                MultiColorEvaluatorError::wrong_passbands_error(mcts.passbands(), ps.0.iter())
             }
         }
     }
@@ -245,24 +234,24 @@ mod tests {
         };
 
         let feature = TestTimeMultiColorFeature {
-            passband_set: PassbandSet::FixedSet(
+            passband_set: PassbandSet(
                 [passband_b_capital.clone(), passband_v_capital.clone()].into(),
             ),
         };
         assert!(feature.eval_multicolor(&mut mcts).is_ok());
 
         let feature = TestTimeMultiColorFeature {
-            passband_set: PassbandSet::FixedSet([passband_b_capital.clone()].into()),
+            passband_set: PassbandSet([passband_b_capital.clone()].into()),
         };
         assert!(feature.eval_multicolor(&mut mcts).is_ok());
 
         let feature = TestTimeMultiColorFeature {
-            passband_set: PassbandSet::FixedSet([passband_r_capital.clone()].into()),
+            passband_set: PassbandSet([passband_r_capital.clone()].into()),
         };
         assert!(feature.eval_multicolor(&mut mcts).is_err());
 
         let feature = TestTimeMultiColorFeature {
-            passband_set: PassbandSet::FixedSet(
+            passband_set: PassbandSet(
                 [
                     passband_b_capital.clone(),
                     passband_r_capital.clone(),
@@ -289,7 +278,7 @@ mod tests {
         };
 
         let feature = TestTimeMultiColorFeature {
-            passband_set: PassbandSet::FixedSet([passband_r.clone()].into()),
+            passband_set: PassbandSet([passband_r.clone()].into()),
         };
 
         // eval_multicolor should fail (missing passband R)

--- a/src/multicolor/multicolor_extractor.rs
+++ b/src/multicolor/multicolor_extractor.rs
@@ -47,18 +47,13 @@ where
         let passband_set = {
             let set: BTreeSet<_> = features
                 .iter()
-                .filter_map(|f| match f.get_passband_set() {
-                    PassbandSet::AllAvailable => None,
-                    PassbandSet::FixedSet(set) => Some(set),
+                .flat_map(|f| {
+                    let PassbandSet::FixedSet(set) = f.get_passband_set();
+                    set
                 })
-                .flatten()
                 .cloned()
                 .collect();
-            if set.is_empty() {
-                PassbandSet::AllAvailable
-            } else {
-                PassbandSet::FixedSet(set)
-            }
+            PassbandSet::FixedSet(set)
         };
 
         let info = EvaluatorInfo {

--- a/src/multicolor/multicolor_extractor.rs
+++ b/src/multicolor/multicolor_extractor.rs
@@ -123,6 +123,24 @@ where
     P: PassbandTrait,
     T: Float,
 {
+    fn eval_multicolor<'slf, 'a, 'mcts>(
+        &'slf self,
+        mcts: &'mcts mut MultiColorTimeSeries<'a, P, T>,
+    ) -> Result<Vec<T>, MultiColorEvaluatorError>
+    where
+        'slf: 'a,
+        'a: 'mcts,
+        P: 'a,
+    {
+        // No extractor-level union check: each feature validates its own passband set
+        // independently, so features with different passband requirements can coexist.
+        let mut vec = Vec::with_capacity(self.size_hint());
+        for x in &self.features {
+            vec.extend(x.eval_multicolor(mcts)?);
+        }
+        Ok(vec)
+    }
+
     fn eval_multicolor_no_mcts_check<'slf, 'a, 'mcts>(
         &'slf self,
         mcts: &'mcts mut MultiColorTimeSeries<'a, P, T>,
@@ -131,9 +149,11 @@ where
         'slf: 'a,
         'a: 'mcts,
     {
+        // The extractor has no meaningful pre-checked state at the union level —
+        // delegate to each feature's own eval_multicolor (which includes its own check).
         let mut vec = Vec::with_capacity(self.size_hint());
         for x in &self.features {
-            vec.extend(x.eval_multicolor_no_mcts_check(mcts)?);
+            vec.extend(x.eval_multicolor(mcts)?);
         }
         Ok(vec)
     }
@@ -254,5 +274,63 @@ mod tests {
         let json = serde_json::to_string(&extractor).unwrap();
         let extractor2: McExtractor = serde_json::from_str(&json).unwrap();
         assert_eq!(json, serde_json::to_string(&extractor2).unwrap());
+    }
+
+    #[test]
+    fn extractor_different_passband_sets_partial_mcts() {
+        // Feature A needs {g, r}, Feature B needs {r, i}.
+        // mcts only has {g, r} → Feature A succeeds, Feature B fails.
+        // eval_or_fill_multicolor should return real values for A and fill for B.
+        use crate::multicolor::features::{ColorOfMaximum, ColorOfMinimum};
+
+        let gr = [StringPassband::from("g"), StringPassband::from("r")];
+        let ri = [StringPassband::from("r"), StringPassband::from("i")];
+
+        let extractor = McExtractor::new(vec![
+            ColorOfMaximum::new(gr.clone()).into(), // needs g, r
+            ColorOfMinimum::new(ri.clone()).into(), // needs r, i
+        ]);
+
+        // passband_set on the extractor is the union {g, i, r}
+        let PassbandSet::FixedSet(union) = extractor.get_passband_set();
+        assert_eq!(union.len(), 3);
+
+        let t = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0];
+        let m = vec![4.0_f64, 5.0, 6.0, 1.0, 3.0, 2.0];
+        let w = vec![1.0_f64; 6];
+        let bands: Vec<StringPassband> = ["g", "g", "g", "r", "r", "r"]
+            .iter()
+            .map(|&s| StringPassband::from(s))
+            .collect();
+        let mut mcts = MultiColorTimeSeries::from_flat(t, m, w, bands);
+
+        // eval_multicolor: Feature B fails because "i" is absent
+        assert!(extractor.eval_multicolor(&mut mcts).is_err());
+
+        // eval_or_fill_multicolor: Feature A succeeds, Feature B is filled
+        let fill = f64::NAN;
+        let result = extractor.eval_or_fill_multicolor(&mut mcts, fill).unwrap();
+        assert_eq!(result.len(), 2);
+        // color_max_g_r = max(g) - max(r) = 6 - 3 = 3
+        assert!((result[0] - 3.0).abs() < 1e-10);
+        // color_min_r_i: i absent → fill
+        assert!(result[1].is_nan());
+    }
+
+    #[test]
+    fn extractor_passband_set_is_union() {
+        use crate::multicolor::features::{ColorOfMaximum, ColorOfMinimum};
+
+        let gr = [StringPassband::from("g"), StringPassband::from("r")];
+        let ri = [StringPassband::from("r"), StringPassband::from("i")];
+
+        let extractor = McExtractor::new(vec![
+            ColorOfMaximum::new(gr).into(),
+            ColorOfMinimum::new(ri).into(),
+        ]);
+
+        let PassbandSet::FixedSet(union) = extractor.get_passband_set();
+        let names: Vec<_> = union.iter().map(|p| p.name()).collect();
+        assert_eq!(names, vec!["g", "i", "r"]);
     }
 }

--- a/src/multicolor/multicolor_extractor.rs
+++ b/src/multicolor/multicolor_extractor.rs
@@ -48,12 +48,12 @@ where
             let set: BTreeSet<_> = features
                 .iter()
                 .flat_map(|f| {
-                    let PassbandSet::FixedSet(set) = f.get_passband_set();
+                    let PassbandSet(set) = f.get_passband_set();
                     set
                 })
                 .cloned()
                 .collect();
-            PassbandSet::FixedSet(set)
+            PassbandSet(set)
         };
 
         let info = EvaluatorInfo {
@@ -292,7 +292,7 @@ mod tests {
         ]);
 
         // passband_set on the extractor is the union {g, i, r}
-        let PassbandSet::FixedSet(union) = extractor.get_passband_set();
+        let PassbandSet(union) = extractor.get_passband_set();
         assert_eq!(union.len(), 3);
 
         let t = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0];
@@ -329,7 +329,7 @@ mod tests {
             ColorOfMinimum::new(ri).into(),
         ]);
 
-        let PassbandSet::FixedSet(union) = extractor.get_passband_set();
+        let PassbandSet(union) = extractor.get_passband_set();
         let names: Vec<_> = union.iter().map(|p| p.name()).collect();
         assert_eq!(names, vec!["g", "i", "r"]);
     }

--- a/src/multicolor/multicolor_feature.rs
+++ b/src/multicolor/multicolor_feature.rs
@@ -6,7 +6,7 @@ use crate::multicolor::features::{
     ColorOfMaximum, ColorOfMedian, ColorOfMinimum, ColorSpread, MultiColorPeriodogram,
 };
 use crate::multicolor::multicolor_evaluator::*;
-use crate::multicolor::{MonochromeFeature, MultiColorExtractor};
+use crate::multicolor::{MultiColorExtractor, PerBandFeature};
 
 use enum_dispatch::enum_dispatch;
 use schemars::JsonSchema;
@@ -26,12 +26,12 @@ where
     // Extractor
     MultiColorExtractor(MultiColorExtractor<P, T>),
     // Monochrome Features
-    MonochromeFeature(MonochromeFeature<P, T, Feature<T>>),
+    PerBandFeature(PerBandFeature<P, T, Feature<T>>),
     // Features
     ColorOfMaximum(ColorOfMaximum<P>),
     ColorOfMedian(ColorOfMedian<P>),
     ColorOfMinimum(ColorOfMinimum<P>),
-    ColorSpread(ColorSpread),
+    ColorSpread(ColorSpread<P>),
     MultiColorPeriodogram(MultiColorPeriodogram<P, T, Feature<T>>),
 }
 
@@ -40,10 +40,10 @@ where
     P: PassbandTrait,
     T: Float,
 {
-    pub fn from_monochrome_feature<F>(feature: F, passband_set: BTreeSet<P>) -> Self
+    pub fn from_per_band_feature<F>(feature: F, passband_set: BTreeSet<P>) -> Self
     where
         F: Into<Feature<T>>,
     {
-        MonochromeFeature::new(feature.into(), passband_set).into()
+        PerBandFeature::new(feature.into(), passband_set).into()
     }
 }

--- a/src/multicolor/per_band_feature.rs
+++ b/src/multicolor/per_band_feature.rs
@@ -13,12 +13,12 @@ use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-/// Multi-color feature which evaluates non-color dependent feature for each passband.
+/// Multi-color feature which evaluates a monochrome feature independently for each passband.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(bound(
     deserialize = "P: PassbandTrait + Deserialize<'de>, T: Float, F: FeatureEvaluator<T>"
 ))]
-pub struct MonochromeFeature<P, T, F>
+pub struct PerBandFeature<P, T, F>
 where
     P: Ord,
 {
@@ -28,13 +28,13 @@ where
     phantom: PhantomData<T>,
 }
 
-impl<P, T, F> MonochromeFeature<P, T, F>
+impl<P, T, F> PerBandFeature<P, T, F>
 where
     P: PassbandTrait,
     T: Float,
     F: FeatureEvaluator<T>,
 {
-    /// Creates a new instance of `MonochromeFeature`.
+    /// Creates a new instance of `PerBandFeature`.
     ///
     /// # Arguments
     /// - `feature` - non-multi-color feature to evaluate for each passband.
@@ -69,7 +69,7 @@ where
     }
 }
 
-impl<P, T, F> FeatureNamesDescriptionsTrait for MonochromeFeature<P, T, F>
+impl<P, T, F> FeatureNamesDescriptionsTrait for PerBandFeature<P, T, F>
 where
     P: Ord,
 {
@@ -86,7 +86,7 @@ where
     }
 }
 
-impl<P, T, F> EvaluatorInfoTrait for MonochromeFeature<P, T, F>
+impl<P, T, F> EvaluatorInfoTrait for PerBandFeature<P, T, F>
 where
     P: Ord,
 {
@@ -95,7 +95,7 @@ where
     }
 }
 
-impl<P, T, F> MultiColorPassbandSetTrait<P> for MonochromeFeature<P, T, F>
+impl<P, T, F> MultiColorPassbandSetTrait<P> for PerBandFeature<P, T, F>
 where
     P: PassbandTrait,
 {
@@ -104,7 +104,7 @@ where
     }
 }
 
-impl<P, T, F> MultiColorEvaluator<P, T> for MonochromeFeature<P, T, F>
+impl<P, T, F> MultiColorEvaluator<P, T> for PerBandFeature<P, T, F>
 where
     P: PassbandTrait,
     T: Float,
@@ -118,20 +118,21 @@ where
         'slf: 'a,
         'a: 'mcts,
     {
-        match &self.passband_set {
-            PassbandSet::FixedSet(set) => {
-                mcts.mapping_mut().iter_matched_passbands_mut(set.iter())
-                    .map(|(passband, ts)| {
-                        self.feature.eval_no_ts_check(
-                                ts.expect("we checked all needed passbands are in mcts, but we still cannot find one")
-                        ).map_err(|error| MultiColorEvaluatorError::MonochromeEvaluatorError {
-                            passband: passband.name().into(),
-                            error,
-                        })
-                    }).flatten_ok().collect()
-            }
-            PassbandSet::AllAvailable => panic!("passband_set must be FixedSet variant here"),
-        }
+        let PassbandSet::FixedSet(set) = &self.passband_set;
+        mcts.mapping_mut()
+            .iter_matched_passbands_mut(set.iter())
+            .map(|(passband, ts)| {
+                self.feature
+                    .eval_no_ts_check(ts.expect(
+                        "we checked all needed passbands are in mcts, but we still cannot find one",
+                    ))
+                    .map_err(|error| MultiColorEvaluatorError::MonochromeEvaluatorError {
+                        passband: passband.name().into(),
+                        error,
+                    })
+            })
+            .flatten_ok()
+            .collect()
     }
 }
 
@@ -140,21 +141,23 @@ mod tests {
     use super::*;
 
     use crate::Feature;
+    use crate::MultiColorTimeSeries;
+    use crate::StringPassband;
     use crate::features::Mean;
+    use crate::multicolor::multicolor_evaluator::MultiColorEvaluator;
     use crate::multicolor::passband::MonochromePassband;
 
     #[test]
-    fn test_monochrome_feature() {
-        let feature: MonochromeFeature<MonochromePassband<_>, f64, Feature<_>> =
-            MonochromeFeature::new(
-                Mean::default().into(),
-                [
-                    MonochromePassband::new(4700e-8, "g"),
-                    MonochromePassband::new(6200e-8, "r"),
-                ]
-                .into_iter()
-                .collect(),
-            );
+    fn test_per_band_feature() {
+        let feature: PerBandFeature<MonochromePassband<_>, f64, Feature<_>> = PerBandFeature::new(
+            Mean::default().into(),
+            [
+                MonochromePassband::new(4700e-8, "g"),
+                MonochromePassband::new(6200e-8, "r"),
+            ]
+            .into_iter()
+            .collect(),
+        );
         assert_eq!(feature.get_names(), vec!["mean_g", "mean_r"]);
         assert_eq!(
             feature.get_descriptions(),
@@ -164,10 +167,8 @@ mod tests {
     }
 
     #[test]
-    fn test_monochrome_feature_values() {
-        use crate::MultiColorTimeSeries;
+    fn test_per_band_feature_values() {
         use crate::data::TimeSeries;
-        use crate::multicolor::multicolor_evaluator::MultiColorEvaluator;
         use std::collections::BTreeMap;
 
         let passband_g = MonochromePassband::new(4700e-8, "g");
@@ -184,16 +185,57 @@ mod tests {
             MultiColorTimeSeries::from_map(map)
         };
 
-        let feature: MonochromeFeature<MonochromePassband<_>, f64, Feature<_>> =
-            MonochromeFeature::new(
-                Mean::default().into(),
-                [passband_g.clone(), passband_r.clone()]
-                    .into_iter()
-                    .collect(),
-            );
+        let feature: PerBandFeature<MonochromePassband<_>, f64, Feature<_>> = PerBandFeature::new(
+            Mean::default().into(),
+            [passband_g.clone(), passband_r.clone()]
+                .into_iter()
+                .collect(),
+        );
 
         let result = feature.eval_multicolor(&mut mcts).unwrap();
         // Passbands are ordered by wavelength (g before r), so mean_g=2.0 comes first
         assert_eq!(result, vec![2.0_f64, 5.0_f64]);
+    }
+
+    #[test]
+    fn test_per_band_feature_subsamples_bands() {
+        // Data has g, r, i but feature only requests g and r — i band must be ignored.
+        let t = vec![0.0_f64; 6];
+        let m = vec![1.0, 2.0, 4.0, 5.0, 10.0, 20.0];
+        let w = vec![1.0_f64; 6];
+        let bands: Vec<StringPassband> = ["g", "g", "r", "r", "i", "i"]
+            .iter()
+            .map(|&s| StringPassband::from(s))
+            .collect();
+        let mut mcts = MultiColorTimeSeries::from_flat(t, m, w, bands);
+
+        let feature: PerBandFeature<StringPassband, f64, Feature<f64>> = PerBandFeature::new(
+            Mean::default().into(),
+            ["g", "r"]
+                .iter()
+                .map(|&s| StringPassband::from(s))
+                .collect(),
+        );
+        let result = feature.eval_multicolor(&mut mcts).unwrap();
+        // mean_g = 1.5, mean_r = 4.5; i band ignored
+        assert!((result[0] - 1.5).abs() < 1e-10);
+        assert!((result[1] - 4.5).abs() < 1e-10);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_per_band_feature_serde() {
+        let feature: PerBandFeature<StringPassband, f64, Feature<f64>> = PerBandFeature::new(
+            Mean::default().into(),
+            ["g", "r"]
+                .iter()
+                .map(|&s| StringPassband::from(s))
+                .collect(),
+        );
+        let json = serde_json::to_string(&feature).unwrap();
+        let feature2: PerBandFeature<StringPassband, f64, Feature<f64>> =
+            serde_json::from_str(&json).unwrap();
+        assert_eq!(feature.get_names(), feature2.get_names());
+        assert_eq!(feature.get_descriptions(), feature2.get_descriptions());
     }
 }

--- a/src/multicolor/per_band_feature.rs
+++ b/src/multicolor/per_band_feature.rs
@@ -118,7 +118,7 @@ where
         'slf: 'a,
         'a: 'mcts,
     {
-        let PassbandSet::FixedSet(set) = &self.passband_set;
+        let PassbandSet(set) = &self.passband_set;
         mcts.mapping_mut()
             .iter_matched_passbands_mut(set.iter())
             .map(|(passband, ts)| {


### PR DESCRIPTION
All multicolor features must now declare their required passbands at construction time. Input MultiColorTimeSeries is subsampled to the specified bands during evaluation.

Breaking changes:
- ColorSpread is now ColorSpread<P>; construct with ColorSpread::new(passbands)
- MultiColorPeriodogram<T,F> is now MultiColorPeriodogram<P,T,F>; construct with MultiColorPeriodogram::new(peaks, normalization, passbands)
- MultiColorPeriodogram no longer implements Default
- PassbandSet::AllAvailable variant removed