### PR TITLE
Add spectrum_features and phase_features to Periodogram and MultiColorPeriodogram

### DIFF
--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -65,6 +65,13 @@ where
     }
 
     pub fn add_feature(&mut self, feature: F) {
+        self.info.size += feature.size_hint();
+        self.info.min_ts_length = self.info.min_ts_length.max(feature.min_ts_length());
+        self.info.t_required |= feature.is_t_required();
+        self.info.m_required |= feature.is_m_required();
+        self.info.w_required |= feature.is_w_required();
+        self.info.sorting_required |= feature.is_sorting_required();
+        self.info.variability_required |= feature.is_variability_required();
         self.features.push(feature);
     }
 }

--- a/src/features/bins.rs
+++ b/src/features/bins.rs
@@ -157,7 +157,10 @@ where
         DOC
     }
 
-    fn transform_ts(&self, ts: &mut TimeSeries<T>) -> Result<TmwArrays<T>, EvaluatorError> {
+    pub(crate) fn transform_ts(
+        &self,
+        ts: &mut TimeSeries<T>,
+    ) -> Result<TmwArrays<T>, EvaluatorError> {
         // These conversions should never fail because we validated the range in new() and set methods
         let window = self.window.into_inner().approx_as::<T>().unwrap();
         let offset = self.offset.into_inner().approx_as::<T>().unwrap();

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -95,6 +95,7 @@ pub use percent_difference_magnitude_percentile::PercentDifferenceMagnitudePerce
 mod periodogram;
 pub use _periodogram_peaks::PeriodogramPeaks as _PeriodogramPeaks;
 pub use periodogram::Periodogram;
+pub(crate) use periodogram::phase_fold_ts;
 
 mod reduced_chi2;
 pub use reduced_chi2::ReducedChi2;

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -95,7 +95,7 @@ pub use percent_difference_magnitude_percentile::PercentDifferenceMagnitudePerce
 mod periodogram;
 pub use _periodogram_peaks::PeriodogramPeaks as _PeriodogramPeaks;
 pub use periodogram::Periodogram;
-pub(crate) use periodogram::phase_fold_ts;
+pub(crate) use periodogram::{eval_phase_ts, eval_phase_ts_or_fill, phase_fold_or_compute};
 
 mod reduced_chi2;
 pub use reduced_chi2::ReducedChi2;

--- a/src/features/periodogram.rs
+++ b/src/features/periodogram.rs
@@ -1009,6 +1009,112 @@ mod tests {
         assert!(result[2] < 0.01, "lafler_kinman = {}", result[2]);
     }
 
+    // ── Phase dispatch case tests ─────────────────────────────────────────────
+
+    // Case 1: !t_required && !sorting_required — raw ts, no phase fold
+    // Amplitude depends only on magnitude; its value must equal (max-min)/2 of the
+    // original magnitude array regardless of period.
+    #[test]
+    fn phase_feature_case1_no_t_no_sort_amplitude() {
+        use crate::features::amplitude::Amplitude;
+        let period = 0.17_f64;
+        let mut rng = StdRng::seed_from_u64(1);
+        let mut t: Vec<f64> = (0..50).map(|_| rng.random()).collect();
+        t.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+        let m: Vec<f64> = t
+            .iter()
+            .map(|&ti| (2.0 * std::f64::consts::PI / period * ti).sin())
+            .collect();
+
+        let mut periodogram: Periodogram<f64, Feature<f64>> = Periodogram::new(1);
+        periodogram.add_phase_feature(Amplitude::default().into());
+        periodogram.set_periodogram_algorithm(PeriodogramPowerDirect.into());
+
+        let mut ts = TimeSeries::new_without_weight(&t, &m);
+        let result = periodogram.eval(&mut ts).unwrap();
+
+        // result = [period_0, snr_0, period_folded_amplitude]
+        assert_eq!(result.len(), 3);
+        // Amplitude = (max - min) / 2; must equal the full-ts value
+        let expected = (m.iter().cloned().fold(f64::NEG_INFINITY, f64::max)
+            - m.iter().cloned().fold(f64::INFINITY, f64::min))
+            / 2.0;
+        assert!(
+            (result[2] - expected).abs() < 1e-12,
+            "amplitude {}, expected {}",
+            result[2],
+            expected
+        );
+    }
+
+    // Case 2: t_required && !sorting_required — phases as time, no sort
+    // TimeMean computes mean(t); when used as a phase feature the "time" values
+    // are phases in [0, 1), so the result must lie in that interval.
+    #[test]
+    fn phase_feature_case2_t_required_no_sort_time_mean() {
+        use crate::features::time_mean::TimeMean;
+        let period = 0.17_f64;
+        let mut rng = StdRng::seed_from_u64(2);
+        let mut t: Vec<f64> = (0..80).map(|_| rng.random()).collect();
+        t.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+        let m: Vec<f64> = t
+            .iter()
+            .map(|&ti| (2.0 * std::f64::consts::PI / period * ti).sin())
+            .collect();
+
+        let mut periodogram: Periodogram<f64, Feature<f64>> = Periodogram::new(1);
+        periodogram.add_phase_feature(TimeMean::default().into());
+        periodogram.set_periodogram_algorithm(PeriodogramPowerDirect.into());
+
+        let mut ts = TimeSeries::new_without_weight(&t, &m);
+        let result = periodogram.eval(&mut ts).unwrap();
+
+        // result = [period_0, snr_0, period_folded_time_mean]
+        assert_eq!(result.len(), 3);
+        // Mean phase must be in (0, 1)
+        assert!(
+            result[2] > 0.0 && result[2] < 1.0,
+            "mean phase {} not in (0, 1)",
+            result[2]
+        );
+        // Must differ from the mean of the original timestamps (which is ~0.5 here
+        // but for a different reason than phases)
+        let mean_t: f64 = t.iter().sum::<f64>() / t.len() as f64;
+        assert!(
+            (result[2] - mean_t).abs() > 1e-6,
+            "mean phase {} suspiciously equal to mean t {}",
+            result[2],
+            mean_t
+        );
+    }
+
+    // Case 4: sorting_required && t_required with near-duplicate phases
+    // When all observations share the same phase (t = k*period), Bins(1e-6) merges
+    // them into a single point.  MaximumSlope requires ≥2 points, so eval_or_fill
+    // must return the fill value rather than panicking.
+    #[test]
+    fn phase_feature_case4_duplicate_phases_fill_not_panic() {
+        use crate::features::maximum_slope::MaximumSlope;
+        // t=[0.0,1.0,2.0,3.0], period=1.0 → all phases collapse to 0.0
+        let t = vec![0.0_f64, 1.0, 2.0, 3.0, 4.0];
+        let m = vec![1.0_f64, 1.5, 0.5, 1.2, 0.8];
+        let mut ts = TimeSeries::new_without_weight(&t, &m);
+
+        let mut periodogram: Periodogram<f64, Feature<f64>> = Periodogram::new(1);
+        periodogram.add_phase_feature(MaximumSlope::default().into());
+        // Fix the frequency grid so we always pick period≈1
+        let freq_grid = crate::periodogram::FreqGrid::linear(0.9, 0.1, 3);
+        periodogram.set_freq_grid(freq_grid);
+        periodogram.set_periodogram_algorithm(PeriodogramPowerDirect.into());
+
+        let fill = f64::NAN;
+        let result = periodogram.eval_or_fill(&mut ts, fill);
+        // result = [period_0, snr_0, period_folded_maximum_slope]
+        assert_eq!(result.len(), 3);
+        // The phase feature slot must be fill (merged to 1 bin, too short for MaximumSlope)
+        assert!(result[2].is_nan(), "expected fill NaN, got {}", result[2]);
+    }
+
     mod phase_fold_ts_tests {
         use super::*;
 

--- a/src/features/periodogram.rs
+++ b/src/features/periodogram.rs
@@ -41,12 +41,15 @@ Phase feature names are prefixed with `period_folded_`.
 /// Returns a new `TmwArrays` where `t` is the phase in `[0, 1)`, `m` is the magnitude,
 /// and `w` are the original weights, all sorted by phase.
 pub(crate) fn phase_fold_ts<T: Float>(ts: &mut TimeSeries<T>, period: T) -> TmwArrays<T> {
+    use unzip3::Unzip3;
+
+    let n = ts.lenu();
     let t = ts.t.as_slice();
     let m = ts.m.as_slice();
     let w = ts.w.as_slice();
 
-    // phase in [0, 1)
-    let mut phases: Vec<T> = t
+    // phase in [0, 1) for each observation
+    let phases: Vec<T> = t
         .iter()
         .map(|&ti| {
             let p = (ti / period) % T::one();
@@ -54,44 +57,34 @@ pub(crate) fn phase_fold_ts<T: Float>(ts: &mut TimeSeries<T>, period: T) -> TmwA
         })
         .collect();
 
-    // index of minimum m (zero phase is defined here)
-    let min_idx = m
+    // phase 0 is aligned to the minimum-m observation
+    let phase_offset = m
         .iter()
         .enumerate()
         .min_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-        .map(|(i, _)| i)
-        .unwrap_or(0);
-    let phase_offset = phases[min_idx];
+        .map(|(i, _)| phases[i])
+        .unwrap_or(T::zero());
 
-    // shift so minimum-m observation is at phase 0
-    for p in &mut phases {
-        *p = (*p - phase_offset + T::one()) % T::one();
-    }
-
-    // sort by phase
-    let mut triples: Vec<(T, T, T)> = phases
-        .into_iter()
-        .zip(m.iter().copied())
-        .zip(w.iter().copied())
-        .map(|((ph, mi), wi)| (ph, mi, wi))
-        .collect();
-    triples.sort_unstable_by(|(a, _, _), (b, _, _)| {
-        a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
+    // sort indices by shifted phase
+    let mut indices: Vec<usize> = (0..n).collect();
+    indices.sort_unstable_by(|&i, &j| {
+        let pi = (phases[i] - phase_offset + T::one()) % T::one();
+        let pj = (phases[j] - phase_offset + T::one()) % T::one();
+        pi.partial_cmp(&pj).unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    let (sorted_phases, sorted_m, sorted_w) = triples.into_iter().fold(
-        (Vec::new(), Vec::new(), Vec::new()),
-        |(mut ps, mut ms, mut ws), (p, m, w)| {
-            ps.push(p);
-            ms.push(m);
-            ws.push(w);
-            (ps, ms, ws)
-        },
-    );
+    let (sorted_phases, sorted_m, sorted_w): (Vec<T>, Vec<T>, Vec<T>) = indices
+        .iter()
+        .map(|&i| {
+            let p = (phases[i] - phase_offset + T::one()) % T::one();
+            (p, m[i], w[i])
+        })
+        .unzip3();
+
     TmwArrays {
-        t: ndarray::Array1::from_vec(sorted_phases),
-        m: ndarray::Array1::from_vec(sorted_m),
-        w: ndarray::Array1::from_vec(sorted_w),
+        t: sorted_phases.into(),
+        m: sorted_m.into(),
+        w: sorted_w.into(),
     }
 }
 
@@ -884,5 +877,78 @@ mod tests {
         );
         // smooth phase curve: theta << 1 (sine wave gives ~0.003)
         assert!(result[2] < 0.01, "lafler_kinman = {}", result[2]);
+    }
+
+    mod phase_fold_ts_tests {
+        use super::*;
+
+        // Helper: collect phases from TmwArrays into a Vec
+        fn phases(arr: &TmwArrays<f64>) -> Vec<f64> {
+            arr.t.to_vec()
+        }
+
+        #[test]
+        fn phases_sorted_in_range_min_at_zero() {
+            // t=[0.0,0.25,0.5,0.75], period=1.0 → phases=[0.0,0.25,0.5,0.75]
+            // min m at index 1 (m=0.5), phase_offset=0.25
+            // shifted: [0.75, 0.0, 0.25, 0.5] → sorted: [0.0,0.25,0.5,0.75]
+            let t = vec![0.0_f64, 0.25, 0.5, 0.75];
+            let m = vec![1.0_f64, 0.5, 0.8, 1.2];
+            let mut ts = TimeSeries::new_without_weight(&t, &m);
+            let result = phase_fold_ts(&mut ts, 1.0);
+
+            let ps = phases(&result);
+            assert_eq!(ps[0], 0.0, "min-m observation must be at phase 0");
+            for &p in &ps {
+                assert!(p >= 0.0 && p < 1.0, "phase {p} out of [0, 1)");
+            }
+            let mut sorted = ps.clone();
+            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            assert_eq!(ps, sorted, "phases must be sorted");
+        }
+
+        #[test]
+        fn unit_weights_when_no_weight_given() {
+            let t = vec![0.1_f64, 0.4, 0.7];
+            let m = vec![1.0_f64, 0.5, 0.8];
+            let mut ts = TimeSeries::new_without_weight(&t, &m);
+            let result = phase_fold_ts(&mut ts, 1.0);
+            for &w in result.w.iter() {
+                assert_eq!(w, 1.0_f64, "expected unity weight, got {w}");
+            }
+        }
+
+        #[test]
+        fn weights_stay_paired_with_observations() {
+            // min m at index 1 (m=0.5, w=3.0); it must be first in output
+            let t = vec![0.1_f64, 0.4, 0.7];
+            let m = vec![1.0_f64, 0.5, 0.8];
+            let w = vec![2.0_f64, 3.0, 4.0];
+            let mut ts = TimeSeries::new(&t, &m, &w);
+            let result = phase_fold_ts(&mut ts, 1.0);
+            assert_eq!(
+                result.w[0], 3.0_f64,
+                "weight of min-m obs must lead; got {}",
+                result.w[0]
+            );
+        }
+
+        #[test]
+        fn duplicate_phases_all_present_and_sorted() {
+            // t=[0.0,1.0,2.0], period=1.0 → all fold to phase 0.0
+            let t = vec![0.0_f64, 1.0, 2.0];
+            let m = vec![0.5_f64, 0.5, 1.0];
+            let mut ts = TimeSeries::new_without_weight(&t, &m);
+            let result = phase_fold_ts(&mut ts, 1.0);
+
+            assert_eq!(result.t.len(), 3, "all observations must be present");
+            for &p in result.t.iter() {
+                assert!(p >= 0.0 && p < 1.0, "phase {p} out of [0, 1)");
+            }
+            let ps = phases(&result);
+            for i in 1..ps.len() {
+                assert!(ps[i] >= ps[i - 1], "phases not non-decreasing at index {i}");
+            }
+        }
     }
 }

--- a/src/features/periodogram.rs
+++ b/src/features/periodogram.rs
@@ -613,6 +613,22 @@ where
     }
 }
 
+fn default_periodogram_name_prefix() -> String {
+    "periodogram".to_string()
+}
+
+fn is_default_periodogram_name_prefix(s: &str) -> bool {
+    s == "periodogram"
+}
+
+fn default_periodogram_description_suffix() -> String {
+    "of periodogram (interpreting frequency as time, power as magnitude)".to_string()
+}
+
+fn is_default_periodogram_description_suffix(s: &str) -> bool {
+    s == "of periodogram (interpreting frequency as time, power as magnitude)"
+}
+
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "Periodogram", bound = "T: Float, F: FeatureEvaluator<T>")]
 struct PeriodogramParameters<T, F>
@@ -628,6 +644,16 @@ where
     periodogram_algorithm: PeriodogramPower<T>,
     #[serde(default)]
     normalization: PeriodogramNormalization,
+    #[serde(
+        default = "default_periodogram_name_prefix",
+        skip_serializing_if = "is_default_periodogram_name_prefix"
+    )]
+    name_prefix: String,
+    #[serde(
+        default = "default_periodogram_description_suffix",
+        skip_serializing_if = "is_default_periodogram_description_suffix"
+    )]
+    description_suffix: String,
 }
 
 impl<T, F> From<Periodogram<T, F>> for PeriodogramParameters<T, F>
@@ -643,8 +669,9 @@ where
             phase_extractor,
             periodogram_algorithm,
             normalization,
+            name_prefix,
+            description_suffix,
             properties: _,
-            ..
         } = f;
 
         let mut features = spectrum_extractor.into_vec();
@@ -659,6 +686,8 @@ where
             peaks,
             periodogram_algorithm,
             normalization,
+            name_prefix,
+            description_suffix,
         }
     }
 }
@@ -676,9 +705,16 @@ where
             peaks,
             periodogram_algorithm,
             normalization,
+            name_prefix,
+            description_suffix,
         } = p;
 
-        let mut periodogram = Periodogram::with_freq_frid_strategy(peaks, freq_grid_strategy);
+        let mut periodogram = Periodogram::with_freq_grid_strategy_name_description(
+            peaks,
+            freq_grid_strategy,
+            name_prefix,
+            description_suffix,
+        );
         for feature in spectrum_features {
             periodogram.add_spectrum_feature(feature);
         }

--- a/src/features/periodogram.rs
+++ b/src/features/periodogram.rs
@@ -882,7 +882,7 @@ mod tests {
             "period {}",
             result[0]
         );
-        // smooth phase curve: theta < 0.5
-        assert!(result[2] < 0.5, "lafler_kinman = {}", result[2]);
+        // smooth phase curve: theta << 1 (sine wave gives ~0.003)
+        assert!(result[2] < 0.05, "lafler_kinman = {}", result[2]);
     }
 }

--- a/src/features/periodogram.rs
+++ b/src/features/periodogram.rs
@@ -26,10 +26,9 @@ $$
 series without observation errors (unity weights are used if required). You can even pass one
 [Periodogram] to another one if you are crazy enough.
 
-Additionally, [Periodogram] supports `phase_features`: features extracted from the light curve
+Additionally, [Periodogram] supports phase features: features extracted from the light curve
 phase-folded at the best period. The phase runs from 0 to 1, with phase 0 at the magnitude minimum.
-Use [Periodogram::add_phase_feature] to register these features; their names are prefixed with
-`period_folded_`.
+Phase feature names are prefixed with `period_folded_`.
 
 - Depends on: **time**, **magnitude**
 - Minimum number of observations: as required by sub-features, but at least two
@@ -80,12 +79,6 @@ pub(crate) fn phase_fold_ts<T: Float>(ts: &mut TimeSeries<T>, period: T) -> TmAr
 }
 
 #[doc = DOC!()]
-/// ### Example
-/// ```
-/// use light_curve_feature::*;
-///
-/// let mut periodogram: Periodogram<f64, Feature<f64>> = Periodogram::default();
-/// ```
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(
     bound = "T: Float, F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>, <F as TryInto<PeriodogramPeaks>>::Error: Debug,",

--- a/src/features/periodogram.rs
+++ b/src/features/periodogram.rs
@@ -38,6 +38,27 @@ Phase feature names are prefixed with `period_folded_`.
 "#;
 }
 
+/// Compute phases in `[0, 1)` for each observation, with phase 0 at the minimum-m observation.
+fn compute_adjusted_phases<T: Float>(t: &[T], m: &[T], period: T) -> Vec<T> {
+    let raw_phases: Vec<T> = t
+        .iter()
+        .map(|&ti| {
+            let p = (ti / period) % T::one();
+            if p < T::zero() { p + T::one() } else { p }
+        })
+        .collect();
+    let phase_offset = m
+        .iter()
+        .enumerate()
+        .min_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(i, _)| raw_phases[i])
+        .unwrap_or(T::zero());
+    raw_phases
+        .iter()
+        .map(|&p| (p - phase_offset + T::one()) % T::one())
+        .collect()
+}
+
 /// Phase-fold a time series at a given period, with phase 0 at the magnitude minimum.
 ///
 /// Returns a new `TmwArrays` where `t` is the phase in `[0, 1)`, `m` is the magnitude,
@@ -46,42 +67,19 @@ pub(crate) fn phase_fold_ts<T: Float>(ts: &mut TimeSeries<T>, period: T) -> TmwA
     use unzip3::Unzip3;
 
     let n = ts.lenu();
-    let t = ts.t.as_slice();
     let m = ts.m.as_slice();
     let w = ts.w.as_slice();
+    let phases = compute_adjusted_phases(ts.t.as_slice(), m, period);
 
-    // phase in [0, 1) for each observation
-    let phases: Vec<T> = t
-        .iter()
-        .map(|&ti| {
-            let p = (ti / period) % T::one();
-            if p < T::zero() { p + T::one() } else { p }
-        })
-        .collect();
-
-    // phase 0 is aligned to the minimum-m observation
-    let phase_offset = m
-        .iter()
-        .enumerate()
-        .min_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-        .map(|(i, _)| phases[i])
-        .unwrap_or(T::zero());
-
-    // sort indices by shifted phase
     let mut indices: Vec<usize> = (0..n).collect();
     indices.sort_unstable_by(|&i, &j| {
-        let pi = (phases[i] - phase_offset + T::one()) % T::one();
-        let pj = (phases[j] - phase_offset + T::one()) % T::one();
-        pi.partial_cmp(&pj).unwrap_or(std::cmp::Ordering::Equal)
+        phases[i]
+            .partial_cmp(&phases[j])
+            .unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    let (sorted_phases, sorted_m, sorted_w): (Vec<T>, Vec<T>, Vec<T>) = indices
-        .iter()
-        .map(|&i| {
-            let p = (phases[i] - phase_offset + T::one()) % T::one();
-            (p, m[i], w[i])
-        })
-        .unzip3();
+    let (sorted_phases, sorted_m, sorted_w): (Vec<T>, Vec<T>, Vec<T>) =
+        indices.iter().map(|&i| (phases[i], m[i], w[i])).unzip3();
 
     TmwArrays {
         t: sorted_phases.into(),
@@ -93,31 +91,11 @@ pub(crate) fn phase_fold_ts<T: Float>(ts: &mut TimeSeries<T>, period: T) -> TmwA
 /// Phase-fold without sorting: computes phases in [0, 1) with phase 0 at the minimum-m
 /// observation, but preserves the original observation order.
 pub(crate) fn phase_compute_ts<T: Float>(ts: &mut TimeSeries<T>, period: T) -> TmwArrays<T> {
-    let t = ts.t.as_slice();
     let m = ts.m.as_slice();
     let w = ts.w.as_slice();
-
-    let phases: Vec<T> = t
-        .iter()
-        .map(|&ti| {
-            let p = (ti / period) % T::one();
-            if p < T::zero() { p + T::one() } else { p }
-        })
-        .collect();
-
-    let phase_offset = m
-        .iter()
-        .enumerate()
-        .min_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-        .map(|(i, _)| phases[i])
-        .unwrap_or(T::zero());
-
+    let phases = compute_adjusted_phases(ts.t.as_slice(), m, period);
     TmwArrays {
-        t: phases
-            .iter()
-            .map(|&p| (p - phase_offset + T::one()) % T::one())
-            .collect::<Vec<_>>()
-            .into(),
+        t: phases.into(),
         m: m.to_vec().into(),
         w: w.to_vec().into(),
     }
@@ -143,6 +121,9 @@ pub(crate) fn phase_fold_or_compute<T: Float>(
     }
 }
 
+/// Bin window for merging near-duplicate phases: phase steps smaller than this are merged.
+const PHASE_DEDUP_WINDOW: f64 = 1e-6;
+
 /// Minimum consecutive time step in a sorted time series (infinity if fewer than 2 points).
 fn min_phase_step<T: Float>(phase_ts: &mut TimeSeries<T>) -> T {
     let t = phase_ts.t.as_slice();
@@ -152,8 +133,8 @@ fn min_phase_step<T: Float>(phase_ts: &mut TimeSeries<T>) -> T {
         .unwrap_or(T::infinity())
 }
 
-/// If the extractor requires time and the minimum phase step is below 1e-6, bin the phase time
-/// series with window=1e-6 to merge duplicate phases. Returns the binned arrays, or `Ok(None)`
+/// If the extractor requires time and the minimum phase step is below [`PHASE_DEDUP_WINDOW`], bin
+/// the phase time series to merge duplicate phases. Returns the binned arrays, or `Ok(None)`
 /// when no binning is needed.
 fn maybe_bin_phase_ts<T, F>(
     extractor: &FeatureExtractor<T, F>,
@@ -164,9 +145,11 @@ where
     F: FeatureEvaluator<T>,
 {
     if extractor.is_t_required() {
-        let window: T = 1e-6_f64.approx_as().unwrap();
+        let window: T = PHASE_DEDUP_WINDOW.approx_as().unwrap();
         if min_phase_step(phase_ts) < window {
-            return Ok(Some(Bins::<T, F>::new(1e-6, 0.0).transform_ts(phase_ts)?));
+            return Ok(Some(
+                Bins::<T, F>::new(PHASE_DEDUP_WINDOW, 0.0).transform_ts(phase_ts)?,
+            ));
         }
     }
     Ok(None)

--- a/src/features/periodogram.rs
+++ b/src/features/periodogram.rs
@@ -24,15 +24,68 @@ $$
 
 [Periodogram] can accept other features for feature extraction from periodogram as it was time
 series without observation errors (unity weights are used if required). You can even pass one
-[Periodogram] to another one if you are crazy enough
+[Periodogram] to another one if you are crazy enough.
+
+Additionally, [Periodogram] supports `phase_features`: features extracted from the light curve
+phase-folded at the best period. The phase runs from 0 to 1, with phase 0 at the magnitude minimum.
+Use [Periodogram::add_phase_feature] to register these features; their names are prefixed with
+`period_folded_`.
 
 - Depends on: **time**, **magnitude**
 - Minimum number of observations: as required by sub-features, but at least two
-- Number of features: **$2 \times \mathrm{peaks}$** plus sub-features
+- Number of features: **$2 \times \mathrm{peaks}$** plus spectrum sub-features plus phase sub-features
 "#;
 }
 
+/// Phase-fold a time series at a given period, with phase 0 at the magnitude minimum.
+///
+/// Returns a new `TmArrays` where `t` is the phase in `[0, 1)` and `m` is the magnitude,
+/// sorted by phase.
+pub(crate) fn phase_fold_ts<T: Float>(ts: &mut TimeSeries<T>, period: T) -> TmArrays<T> {
+    let t = ts.t.as_slice();
+    let m = ts.m.as_slice();
+
+    // phase in [0, 1)
+    let mut phases: Vec<T> = t
+        .iter()
+        .map(|&ti| {
+            let p = (ti / period) % T::one();
+            if p < T::zero() { p + T::one() } else { p }
+        })
+        .collect();
+
+    // index of minimum m (zero phase is defined here)
+    let min_idx = m
+        .iter()
+        .enumerate()
+        .min_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(i, _)| i)
+        .unwrap_or(0);
+    let phase_offset = phases[min_idx];
+
+    // shift so minimum-m observation is at phase 0
+    for p in &mut phases {
+        *p = (*p - phase_offset + T::one()) % T::one();
+    }
+
+    // sort by phase
+    let mut pairs: Vec<(T, T)> = phases.into_iter().zip(m.iter().copied()).collect();
+    pairs.sort_unstable_by(|(a, _), (b, _)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    let (sorted_phases, sorted_m): (Vec<T>, Vec<T>) = pairs.into_iter().unzip();
+    TmArrays {
+        t: ndarray::Array1::from_vec(sorted_phases),
+        m: ndarray::Array1::from_vec(sorted_m),
+    }
+}
+
 #[doc = DOC!()]
+/// ### Example
+/// ```
+/// use light_curve_feature::*;
+///
+/// let mut periodogram: Periodogram<f64, Feature<f64>> = Periodogram::default();
+/// ```
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(
     bound = "T: Float, F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>, <F as TryInto<PeriodogramPeaks>>::Error: Debug,",
@@ -44,7 +97,8 @@ where
     T: Float,
 {
     freq_grid_strategy: FreqGridStrategy<T>,
-    pub(crate) feature_extractor: FeatureExtractor<T, F>,
+    pub(crate) spectrum_extractor: FeatureExtractor<T, F>,
+    pub(crate) phase_extractor: FeatureExtractor<T, F>,
     // Can be re-defined in MultiColorPeriodogram
     pub(crate) name_prefix: String,
     // Can be re-defined in MultiColorPeriodogram
@@ -151,8 +205,8 @@ where
         self
     }
 
-    /// Extend a feature to extract from periodogram
-    pub fn add_feature(&mut self, feature: F) -> &mut Self {
+    /// Add a feature to extract from the periodogram spectrum (frequency as time, power as magnitude)
+    pub fn add_spectrum_feature(&mut self, feature: F) -> &mut Self {
         self.properties.info.size += feature.size_hint();
         self.properties.names.extend(
             feature
@@ -166,7 +220,34 @@ where
                 .into_iter()
                 .map(|desc| format!("{} {}", desc, self.description_suffix)),
         );
-        self.feature_extractor.add_feature(feature);
+        self.spectrum_extractor.add_feature(feature);
+        self
+    }
+
+    /// Add a feature to extract from the phase-folded light curve at the best period.
+    ///
+    /// Feature names are prefixed with `period_folded_`. Phase runs from 0 to 1 with phase 0
+    /// at the magnitude minimum. The phase-folded series is sorted by phase.
+    pub fn add_phase_feature(&mut self, feature: F) -> &mut Self {
+        self.properties.info.size += feature.size_hint();
+        self.properties.info.min_ts_length = self
+            .properties
+            .info
+            .min_ts_length
+            .max(feature.min_ts_length());
+        self.properties.names.extend(
+            feature
+                .get_names()
+                .iter()
+                .map(|name| format!("period_folded_{}", name)),
+        );
+        self.properties.descriptions.extend(
+            feature
+                .get_descriptions()
+                .into_iter()
+                .map(|desc| format!("{} (light curve folded at the best period)", desc)),
+        );
+        self.phase_extractor.add_feature(feature);
         self
     }
 
@@ -197,8 +278,13 @@ where
         )
     }
 
-    pub(crate) fn feature_extractor_ref(&self) -> &FeatureExtractor<T, F> {
-        &self.feature_extractor
+    pub(crate) fn spectrum_extractor_ref(&self) -> &FeatureExtractor<T, F> {
+        &self.spectrum_extractor
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn phase_extractor_ref(&self) -> &FeatureExtractor<T, F> {
+        &self.phase_extractor
     }
 
     pub fn power(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, PeriodogramPowerError> {
@@ -287,28 +373,13 @@ where
             freq_grid_strategy: freq_grid_strategy.into(),
             name_prefix: name_prefix.to_string(),
             description_suffix: description_suffix.to_string(),
-            feature_extractor: FeatureExtractor::new(vec![]),
+            spectrum_extractor: FeatureExtractor::new(vec![]),
+            phase_extractor: FeatureExtractor::new(vec![]),
             periodogram_algorithm: DefaultPeriodogramPowerFft::new().into(),
             normalization: PeriodogramNormalization::default(),
         };
-        slf.add_feature(PeriodogramPeaks::new(peaks).into());
+        slf.add_spectrum_feature(PeriodogramPeaks::new(peaks).into());
         slf
-    }
-}
-
-impl<T, F> Periodogram<T, F>
-where
-    T: Float,
-    F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>,
-    <F as TryInto<PeriodogramPeaks>>::Error: Debug,
-{
-    fn transform_ts(&self, ts: &mut TimeSeries<T>) -> Result<TmArrays<T>, EvaluatorError> {
-        self.check_ts_length(ts)?;
-        let (freq, power) = self.freq_power(ts)?;
-        Ok(TmArrays {
-            t: freq.into(),
-            m: power.into(),
-        })
     }
 }
 
@@ -367,7 +438,53 @@ where
     F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>,
     <F as TryInto<PeriodogramPeaks>>::Error: Debug,
 {
-    transformer_eval!();
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
+        let (freq, power) = self.freq_power(ts)?;
+        let mut spectrum_ts = TmArrays {
+            t: freq.into(),
+            m: power.into(),
+        }
+        .ts();
+        let mut result = self.spectrum_extractor.eval(&mut spectrum_ts)?;
+        if !self.phase_extractor.get_features().is_empty() {
+            let best_period = result[0];
+            if !best_period.is_finite() || best_period <= T::zero() {
+                return Err(EvaluatorError::ZeroDivision(
+                    "best period from periodogram is not positive, cannot phase-fold",
+                ));
+            }
+            let phase_arrays = phase_fold_ts(ts, best_period);
+            let mut phase_ts = phase_arrays.ts();
+            result.extend(self.phase_extractor.eval(&mut phase_ts)?);
+        }
+        Ok(result)
+    }
+
+    fn eval_or_fill(&self, ts: &mut TimeSeries<T>, fill_value: T) -> Vec<T> {
+        let (freq, power) = match self.freq_power(ts) {
+            Ok(x) => x,
+            Err(_) => return vec![fill_value; self.size_hint()],
+        };
+        let mut spectrum_ts = TmArrays {
+            t: freq.into(),
+            m: power.into(),
+        }
+        .ts();
+        let mut result = self
+            .spectrum_extractor
+            .eval_or_fill(&mut spectrum_ts, fill_value);
+        if !self.phase_extractor.get_features().is_empty() {
+            let best_period = result[0];
+            if best_period.is_finite() && best_period > T::zero() {
+                let phase_arrays = phase_fold_ts(ts, best_period);
+                let mut phase_ts = phase_arrays.ts();
+                result.extend(self.phase_extractor.eval_or_fill(&mut phase_ts, fill_value));
+            } else {
+                result.extend(vec![fill_value; self.phase_extractor.size_hint()]);
+            }
+        }
+        result
+    }
 }
 
 #[derive(Serialize, Deserialize, JsonSchema)]
@@ -378,7 +495,9 @@ where
     F: FeatureEvaluator<T>,
 {
     freq_grid_strategy: FreqGridStrategy<T>,
-    features: Vec<F>,
+    spectrum_features: Vec<F>,
+    #[serde(default)]
+    phase_features: Vec<F>,
     peaks: usize,
     periodogram_algorithm: PeriodogramPower<T>,
     #[serde(default)]
@@ -394,21 +513,23 @@ where
     fn from(f: Periodogram<T, F>) -> Self {
         let Periodogram {
             freq_grid_strategy,
-            feature_extractor,
+            spectrum_extractor,
+            phase_extractor,
             periodogram_algorithm,
             normalization,
             properties: _,
             ..
         } = f;
 
-        let mut features = feature_extractor.into_vec();
+        let mut features = spectrum_extractor.into_vec();
         let rest_of_features = features.split_off(1);
         let periodogram_peaks: PeriodogramPeaks = features.pop().unwrap().try_into().unwrap();
         let peaks = periodogram_peaks.get_peaks();
 
         Self {
             freq_grid_strategy,
-            features: rest_of_features,
+            spectrum_features: rest_of_features,
+            phase_features: phase_extractor.into_vec(),
             peaks,
             periodogram_algorithm,
             normalization,
@@ -424,15 +545,19 @@ where
     fn from(p: PeriodogramParameters<T, F>) -> Self {
         let PeriodogramParameters {
             freq_grid_strategy,
-            features,
+            spectrum_features,
+            phase_features,
             peaks,
             periodogram_algorithm,
             normalization,
         } = p;
 
         let mut periodogram = Periodogram::with_freq_frid_strategy(peaks, freq_grid_strategy);
-        for feature in features {
-            periodogram.add_feature(feature);
+        for feature in spectrum_features {
+            periodogram.add_spectrum_feature(feature);
+        }
+        for feature in phase_features {
+            periodogram.add_phase_feature(feature);
         }
         periodogram.set_periodogram_algorithm(periodogram_algorithm);
         periodogram.set_normalization(normalization);
@@ -454,6 +579,7 @@ where
 mod tests {
     use super::*;
     use crate::features::amplitude::Amplitude;
+    use crate::features::lafler_kinman::LaflerKinman;
     use crate::periodogram::{PeriodogramPowerDirect, QuantileNyquistFreq};
     use crate::tests::*;
     use rand_distr::StandardNormal;
@@ -465,7 +591,7 @@ mod tests {
         Periodogram<f64, Feature<f64>>,
         {
             let mut periodogram = Periodogram::default();
-            periodogram.add_feature(Amplitude::default().into());
+            periodogram.add_spectrum_feature(Amplitude::default().into());
             periodogram.set_periodogram_algorithm(PeriodogramPowerDirect.into());
             periodogram
         },
@@ -477,6 +603,17 @@ mod tests {
         {
             let freq_grid = FreqGrid::linear(0.5, 50.0, 200);
             let mut periodogram = Periodogram::with_freq_frid_strategy(4, freq_grid);
+            periodogram.set_periodogram_algorithm(PeriodogramPowerDirect.into());
+            periodogram
+        },
+    );
+
+    serde_json_test!(
+        periodogram_ser_json_de_with_phase_features,
+        Periodogram<f64, Feature<f64>>,
+        {
+            let mut periodogram = Periodogram::default();
+            periodogram.add_phase_feature(LaflerKinman::new().into());
             periodogram.set_periodogram_algorithm(PeriodogramPowerDirect.into());
             periodogram
         },
@@ -496,7 +633,7 @@ mod tests {
 
     eval_info_test!(periodogram_info_3, {
         let mut periodogram = Periodogram::default();
-        periodogram.add_feature(Amplitude::default().into());
+        periodogram.add_spectrum_feature(Amplitude::default().into());
         periodogram.set_periodogram_algorithm(PeriodogramPowerDirect.into());
         periodogram
     });
@@ -694,5 +831,48 @@ mod tests {
 
         // The results should be very close since we used the same frequency points
         all_close(&features_linear[..], &features_arbitrary[..], 1e-10);
+    }
+
+    #[test]
+    fn periodogram_phase_feature_names() {
+        let mut periodogram: Periodogram<f64, Feature<f64>> = Periodogram::new(1);
+        periodogram.add_phase_feature(LaflerKinman::new().into());
+        let names = periodogram.get_names();
+        // spectrum: period_0, period_s_to_n_0; phase: period_folded_lafler_kinman
+        assert_eq!(names[0], "periodogram_period_0");
+        assert_eq!(names[1], "periodogram_period_s_to_n_0");
+        assert_eq!(names[2], "period_folded_lafler_kinman");
+        assert_eq!(periodogram.size_hint(), 3);
+    }
+
+    #[test]
+    fn periodogram_phase_feature_recovery() {
+        use crate::features::lafler_kinman::LaflerKinman;
+        let period = 0.17_f64;
+        let mut rng = StdRng::seed_from_u64(0);
+        let mut x: Vec<f64> = (0..200).map(|_| rng.random()).collect();
+        x.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+        let y: Vec<f64> = x
+            .iter()
+            .map(|&t| 3.0 * f64::sin(2.0 * std::f64::consts::PI / period * t + 0.5) + 4.0)
+            .collect();
+
+        let mut periodogram: Periodogram<f64, Feature<f64>> = Periodogram::new(1);
+        periodogram.add_phase_feature(LaflerKinman::new().into());
+        periodogram.set_periodogram_algorithm(PeriodogramPowerDirect.into());
+
+        let mut ts = TimeSeries::new_without_weight(&x, &y);
+        let result = periodogram.eval(&mut ts).unwrap();
+
+        // result = [period_0, snr_0, period_folded_lafler_kinman]
+        assert_eq!(result.len(), 3);
+        // recovered period close to true
+        assert!(
+            (result[0] - period).abs() / period < 0.05,
+            "period {}",
+            result[0]
+        );
+        // smooth phase curve: theta < 0.5
+        assert!(result[2] < 0.5, "lafler_kinman = {}", result[2]);
     }
 }

--- a/src/features/periodogram.rs
+++ b/src/features/periodogram.rs
@@ -883,6 +883,6 @@ mod tests {
             result[0]
         );
         // smooth phase curve: theta << 1 (sine wave gives ~0.003)
-        assert!(result[2] < 0.05, "lafler_kinman = {}", result[2]);
+        assert!(result[2] < 0.01, "lafler_kinman = {}", result[2]);
     }
 }

--- a/src/features/periodogram.rs
+++ b/src/features/periodogram.rs
@@ -38,11 +38,12 @@ Phase feature names are prefixed with `period_folded_`.
 
 /// Phase-fold a time series at a given period, with phase 0 at the magnitude minimum.
 ///
-/// Returns a new `TmArrays` where `t` is the phase in `[0, 1)` and `m` is the magnitude,
-/// sorted by phase.
-pub(crate) fn phase_fold_ts<T: Float>(ts: &mut TimeSeries<T>, period: T) -> TmArrays<T> {
+/// Returns a new `TmwArrays` where `t` is the phase in `[0, 1)`, `m` is the magnitude,
+/// and `w` are the original weights, all sorted by phase.
+pub(crate) fn phase_fold_ts<T: Float>(ts: &mut TimeSeries<T>, period: T) -> TmwArrays<T> {
     let t = ts.t.as_slice();
     let m = ts.m.as_slice();
+    let w = ts.w.as_slice();
 
     // phase in [0, 1)
     let mut phases: Vec<T> = t
@@ -68,13 +69,29 @@ pub(crate) fn phase_fold_ts<T: Float>(ts: &mut TimeSeries<T>, period: T) -> TmAr
     }
 
     // sort by phase
-    let mut pairs: Vec<(T, T)> = phases.into_iter().zip(m.iter().copied()).collect();
-    pairs.sort_unstable_by(|(a, _), (b, _)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mut triples: Vec<(T, T, T)> = phases
+        .into_iter()
+        .zip(m.iter().copied())
+        .zip(w.iter().copied())
+        .map(|((ph, mi), wi)| (ph, mi, wi))
+        .collect();
+    triples.sort_unstable_by(|(a, _, _), (b, _, _)| {
+        a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
+    });
 
-    let (sorted_phases, sorted_m): (Vec<T>, Vec<T>) = pairs.into_iter().unzip();
-    TmArrays {
+    let (sorted_phases, sorted_m, sorted_w) = triples.into_iter().fold(
+        (Vec::new(), Vec::new(), Vec::new()),
+        |(mut ps, mut ms, mut ws), (p, m, w)| {
+            ps.push(p);
+            ms.push(m);
+            ws.push(w);
+            (ps, ms, ws)
+        },
+    );
+    TmwArrays {
         t: ndarray::Array1::from_vec(sorted_phases),
         m: ndarray::Array1::from_vec(sorted_m),
+        w: ndarray::Array1::from_vec(sorted_w),
     }
 }
 

--- a/src/features/periodogram.rs
+++ b/src/features/periodogram.rs
@@ -152,8 +152,27 @@ fn min_phase_step<T: Float>(phase_ts: &mut TimeSeries<T>) -> T {
         .unwrap_or(T::infinity())
 }
 
-/// Evaluate phase features on a phase-sorted time series, binning near-duplicate phases when
-/// the extractor requires time values (sorting_required && t_required).
+/// If the extractor requires time and the minimum phase step is below 1e-6, bin the phase time
+/// series with window=1e-6 to merge duplicate phases. Returns the binned arrays, or `Ok(None)`
+/// when no binning is needed.
+fn maybe_bin_phase_ts<T, F>(
+    extractor: &FeatureExtractor<T, F>,
+    phase_ts: &mut TimeSeries<T>,
+) -> Result<Option<TmwArrays<T>>, EvaluatorError>
+where
+    T: Float,
+    F: FeatureEvaluator<T>,
+{
+    if extractor.is_t_required() {
+        let window: T = 1e-6_f64.approx_as().unwrap();
+        if min_phase_step(phase_ts) < window {
+            return Ok(Some(Bins::<T, F>::new(1e-6, 0.0).transform_ts(phase_ts)?));
+        }
+    }
+    Ok(None)
+}
+
+/// Evaluate phase features on a phase-sorted time series, binning duplicate phases when needed.
 pub(crate) fn eval_phase_ts<T, F>(
     extractor: &FeatureExtractor<T, F>,
     phase_ts: &mut TimeSeries<T>,
@@ -162,14 +181,10 @@ where
     T: Float,
     F: FeatureEvaluator<T>,
 {
-    if extractor.is_t_required() {
-        let window: T = 1e-6_f64.approx_as().unwrap();
-        if min_phase_step(phase_ts) < window {
-            let binned = Bins::<T, F>::new(1e-6, 0.0).transform_ts(phase_ts)?;
-            return extractor.eval(&mut binned.ts());
-        }
+    match maybe_bin_phase_ts(extractor, phase_ts)? {
+        Some(binned) => extractor.eval(&mut binned.ts()),
+        None => extractor.eval(phase_ts),
     }
-    extractor.eval(phase_ts)
 }
 
 /// `eval_or_fill` variant of [`eval_phase_ts`].
@@ -182,16 +197,11 @@ where
     T: Float,
     F: FeatureEvaluator<T>,
 {
-    if extractor.is_t_required() {
-        let window: T = 1e-6_f64.approx_as().unwrap();
-        if min_phase_step(phase_ts) < window {
-            match Bins::<T, F>::new(1e-6, 0.0).transform_ts(phase_ts) {
-                Ok(binned) => return extractor.eval_or_fill(&mut binned.ts(), fill_value),
-                Err(_) => return vec![fill_value; extractor.size_hint()],
-            }
-        }
+    match maybe_bin_phase_ts(extractor, phase_ts) {
+        Ok(Some(binned)) => extractor.eval_or_fill(&mut binned.ts(), fill_value),
+        Ok(None) => extractor.eval_or_fill(phase_ts, fill_value),
+        Err(_) => vec![fill_value; extractor.size_hint()],
     }
-    extractor.eval_or_fill(phase_ts, fill_value)
 }
 
 #[doc = DOC!()]
@@ -1186,5 +1196,65 @@ mod tests {
                 assert!(ps[i] >= ps[i - 1], "phases not non-decreasing at index {i}");
             }
         }
+    }
+
+    mod phase_compute_ts_tests {
+        use super::*;
+
+        #[test]
+        fn phases_in_range_min_at_zero_order_preserved() {
+            // Same setup as phase_fold_ts basic test; min m at index 1, phase_offset=0.25
+            // phase_compute_ts must NOT sort — original observation order is kept.
+            let t = vec![0.0_f64, 0.25, 0.5, 0.75];
+            let m = vec![1.0_f64, 0.5, 0.8, 1.2];
+            let mut ts = TimeSeries::new_without_weight(&t, &m);
+            let result = phase_compute_ts(&mut ts, 1.0);
+
+            assert_eq!(result.t.len(), 4);
+            // min-m is at original index 1 → its phase must be 0.0
+            assert_eq!(result.t[1], 0.0_f64, "min-m obs must have phase 0");
+            // all phases in [0, 1)
+            for &p in result.t.iter() {
+                assert!((0.0..1.0).contains(&p), "phase {p} out of [0, 1)");
+            }
+            // magnitudes and weights stay in original order
+            assert_eq!(result.m.to_vec(), m);
+        }
+
+        #[test]
+        fn unit_weights_preserved() {
+            let t = vec![0.1_f64, 0.4, 0.7];
+            let m = vec![1.0_f64, 0.5, 0.8];
+            let mut ts = TimeSeries::new_without_weight(&t, &m);
+            let result = phase_compute_ts(&mut ts, 1.0);
+            for &w in result.w.iter() {
+                assert_eq!(w, 1.0_f64);
+            }
+        }
+    }
+
+    // eval_phase_ts binning path via eval() (not eval_or_fill) ──────────────
+    // With exact phase aliases the binned ts has 1 point; MaximumSlope (min 2)
+    // must propagate the ShortTimeSeries error rather than panic.
+    #[test]
+    fn phase_feature_case4_eval_errors_on_short_binned_ts() {
+        use crate::features::maximum_slope::MaximumSlope;
+        let t = vec![0.0_f64, 1.0, 2.0, 3.0, 4.0];
+        let m = vec![1.0_f64, 1.5, 0.5, 1.2, 0.8];
+        let mut ts = TimeSeries::new_without_weight(&t, &m);
+
+        let mut periodogram: Periodogram<f64, Feature<f64>> = Periodogram::new(1);
+        periodogram.add_phase_feature(MaximumSlope::default().into());
+        let freq_grid = crate::periodogram::FreqGrid::linear(0.9, 0.1, 3);
+        periodogram.set_freq_grid(freq_grid);
+        periodogram.set_periodogram_algorithm(PeriodogramPowerDirect.into());
+
+        // eval() propagates the error from MaximumSlope (too few points after binning)
+        let err = periodogram.eval(&mut ts);
+        assert!(
+            err.is_err(),
+            "expected error for short binned ts, got {:?}",
+            err
+        );
     }
 }

--- a/src/features/periodogram.rs
+++ b/src/features/periodogram.rs
@@ -1136,7 +1136,7 @@ mod tests {
             let ps = phases(&result);
             assert_eq!(ps[0], 0.0, "min-m observation must be at phase 0");
             for &p in &ps {
-                assert!(p >= 0.0 && p < 1.0, "phase {p} out of [0, 1)");
+                assert!((0.0..1.0).contains(&p), "phase {p} out of [0, 1)");
             }
             let mut sorted = ps.clone();
             sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
@@ -1179,7 +1179,7 @@ mod tests {
 
             assert_eq!(result.t.len(), 3, "all observations must be present");
             for &p in result.t.iter() {
-                assert!(p >= 0.0 && p < 1.0, "phase {p} out of [0, 1)");
+                assert!((0.0..1.0).contains(&p), "phase {p} out of [0, 1)");
             }
             let ps = phases(&result);
             for i in 1..ps.len() {

--- a/src/features/periodogram.rs
+++ b/src/features/periodogram.rs
@@ -1,12 +1,14 @@
 use crate::evaluator::*;
 use crate::extractor::FeatureExtractor;
 use crate::features::_periodogram_peaks::PeriodogramPeaks;
+use crate::features::bins::Bins;
 use crate::periodogram;
 use crate::periodogram::{
     AverageNyquistFreq, DefaultPeriodogramPowerFft, FreqGrid, FreqGridStrategy, NyquistFreq,
     PeriodogramNormalization, PeriodogramPower, PeriodogramPowerError,
 };
 
+use conv::ConvUtil;
 use std::convert::TryInto;
 use std::fmt::Debug;
 
@@ -86,6 +88,110 @@ pub(crate) fn phase_fold_ts<T: Float>(ts: &mut TimeSeries<T>, period: T) -> TmwA
         m: sorted_m.into(),
         w: sorted_w.into(),
     }
+}
+
+/// Phase-fold without sorting: computes phases in [0, 1) with phase 0 at the minimum-m
+/// observation, but preserves the original observation order.
+pub(crate) fn phase_compute_ts<T: Float>(ts: &mut TimeSeries<T>, period: T) -> TmwArrays<T> {
+    let t = ts.t.as_slice();
+    let m = ts.m.as_slice();
+    let w = ts.w.as_slice();
+
+    let phases: Vec<T> = t
+        .iter()
+        .map(|&ti| {
+            let p = (ti / period) % T::one();
+            if p < T::zero() { p + T::one() } else { p }
+        })
+        .collect();
+
+    let phase_offset = m
+        .iter()
+        .enumerate()
+        .min_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(i, _)| phases[i])
+        .unwrap_or(T::zero());
+
+    TmwArrays {
+        t: phases
+            .iter()
+            .map(|&p| (p - phase_offset + T::one()) % T::one())
+            .collect::<Vec<_>>()
+            .into(),
+        m: m.to_vec().into(),
+        w: w.to_vec().into(),
+    }
+}
+
+/// Dispatch helper: decides which phase representation to build based on what the extractor needs.
+///
+/// - `!t_required && !sorting_required` → `None` (caller uses the original ts)
+/// - `t_required && !sorting_required`  → `Some(phase_compute_ts)` (phases as time, no sort)
+/// - `sorting_required`                 → `Some(phase_fold_ts)` (sorted by phase)
+pub(crate) fn phase_fold_or_compute<T: Float>(
+    ts: &mut TimeSeries<T>,
+    period: T,
+    t_required: bool,
+    sorting_required: bool,
+) -> Option<TmwArrays<T>> {
+    if sorting_required {
+        Some(phase_fold_ts(ts, period))
+    } else if t_required {
+        Some(phase_compute_ts(ts, period))
+    } else {
+        None
+    }
+}
+
+/// Minimum consecutive time step in a sorted time series (infinity if fewer than 2 points).
+fn min_phase_step<T: Float>(phase_ts: &mut TimeSeries<T>) -> T {
+    let t = phase_ts.t.as_slice();
+    t.windows(2)
+        .map(|w| w[1] - w[0])
+        .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+        .unwrap_or(T::infinity())
+}
+
+/// Evaluate phase features on a phase-sorted time series, binning near-duplicate phases when
+/// the extractor requires time values (sorting_required && t_required).
+pub(crate) fn eval_phase_ts<T, F>(
+    extractor: &FeatureExtractor<T, F>,
+    phase_ts: &mut TimeSeries<T>,
+) -> Result<Vec<T>, EvaluatorError>
+where
+    T: Float,
+    F: FeatureEvaluator<T>,
+{
+    if extractor.is_t_required() {
+        let window: T = 1e-6_f64.approx_as().unwrap();
+        if min_phase_step(phase_ts) < window {
+            let binned = Bins::<T, F>::new(1e-6, 0.0).transform_ts(phase_ts)?;
+            return extractor.eval(&mut binned.ts());
+        }
+    }
+    extractor.eval(phase_ts)
+}
+
+/// `eval_or_fill` variant of [`eval_phase_ts`].
+pub(crate) fn eval_phase_ts_or_fill<T, F>(
+    extractor: &FeatureExtractor<T, F>,
+    phase_ts: &mut TimeSeries<T>,
+    fill_value: T,
+) -> Vec<T>
+where
+    T: Float,
+    F: FeatureEvaluator<T>,
+{
+    if extractor.is_t_required() {
+        let window: T = 1e-6_f64.approx_as().unwrap();
+        if min_phase_step(phase_ts) < window {
+            match Bins::<T, F>::new(1e-6, 0.0).transform_ts(phase_ts) {
+                Ok(binned) => return extractor.eval_or_fill(&mut binned.ts(), fill_value),
+                Err(_) => return vec![fill_value; extractor.size_hint()],
+            }
+        }
+    }
+    extractor.eval_or_fill(phase_ts, fill_value)
 }
 
 #[doc = DOC!()]
@@ -456,9 +562,19 @@ where
                     "best period from periodogram is not positive, cannot phase-fold",
                 ));
             }
-            let phase_arrays = phase_fold_ts(ts, best_period);
-            let mut phase_ts = phase_arrays.ts();
-            result.extend(self.phase_extractor.eval(&mut phase_ts)?);
+            let phase_arrays = phase_fold_or_compute(
+                ts,
+                best_period,
+                self.phase_extractor.is_t_required(),
+                self.phase_extractor.is_sorting_required(),
+            );
+            match phase_arrays {
+                Some(arrays) => {
+                    let mut phase_ts = arrays.ts();
+                    result.extend(eval_phase_ts(&self.phase_extractor, &mut phase_ts)?);
+                }
+                None => result.extend(self.phase_extractor.eval(ts)?),
+            }
         }
         Ok(result)
     }
@@ -479,9 +595,23 @@ where
         if !self.phase_extractor.get_features().is_empty() {
             let best_period = result[0];
             if best_period.is_finite() && best_period > T::zero() {
-                let phase_arrays = phase_fold_ts(ts, best_period);
-                let mut phase_ts = phase_arrays.ts();
-                result.extend(self.phase_extractor.eval_or_fill(&mut phase_ts, fill_value));
+                let phase_arrays = phase_fold_or_compute(
+                    ts,
+                    best_period,
+                    self.phase_extractor.is_t_required(),
+                    self.phase_extractor.is_sorting_required(),
+                );
+                match phase_arrays {
+                    Some(arrays) => {
+                        let mut phase_ts = arrays.ts();
+                        result.extend(eval_phase_ts_or_fill(
+                            &self.phase_extractor,
+                            &mut phase_ts,
+                            fill_value,
+                        ));
+                    }
+                    None => result.extend(self.phase_extractor.eval_or_fill(ts, fill_value)),
+                }
             } else {
                 result.extend(vec![fill_value; self.phase_extractor.size_hint()]);
             }

--- a/src/features/periodogram.rs
+++ b/src/features/periodogram.rs
@@ -741,7 +741,7 @@ where
 mod tests {
     use super::*;
     use crate::features::amplitude::Amplitude;
-    use crate::features::lafler_kinman::LaflerKinman;
+    use crate::features::lafler_kinman_string_length::LaflerKinmanStringLength;
     use crate::periodogram::{PeriodogramPowerDirect, QuantileNyquistFreq};
     use crate::tests::*;
     use rand_distr::StandardNormal;
@@ -775,7 +775,7 @@ mod tests {
         Periodogram<f64, Feature<f64>>,
         {
             let mut periodogram = Periodogram::default();
-            periodogram.add_phase_feature(LaflerKinman::new().into());
+            periodogram.add_phase_feature(LaflerKinmanStringLength::new().into());
             periodogram.set_periodogram_algorithm(PeriodogramPowerDirect.into());
             periodogram
         },
@@ -998,18 +998,17 @@ mod tests {
     #[test]
     fn periodogram_phase_feature_names() {
         let mut periodogram: Periodogram<f64, Feature<f64>> = Periodogram::new(1);
-        periodogram.add_phase_feature(LaflerKinman::new().into());
+        periodogram.add_phase_feature(LaflerKinmanStringLength::new().into());
         let names = periodogram.get_names();
-        // spectrum: period_0, period_s_to_n_0; phase: period_folded_lafler_kinman
+        // spectrum: period_0, period_s_to_n_0; phase: period_folded_lafler_kinman_string_length
         assert_eq!(names[0], "periodogram_period_0");
         assert_eq!(names[1], "periodogram_period_s_to_n_0");
-        assert_eq!(names[2], "period_folded_lafler_kinman");
+        assert_eq!(names[2], "period_folded_lafler_kinman_string_length");
         assert_eq!(periodogram.size_hint(), 3);
     }
 
     #[test]
     fn periodogram_phase_feature_recovery() {
-        use crate::features::lafler_kinman::LaflerKinman;
         let period = 0.17_f64;
         let mut rng = StdRng::seed_from_u64(0);
         let mut x: Vec<f64> = (0..200).map(|_| rng.random()).collect();
@@ -1020,13 +1019,13 @@ mod tests {
             .collect();
 
         let mut periodogram: Periodogram<f64, Feature<f64>> = Periodogram::new(1);
-        periodogram.add_phase_feature(LaflerKinman::new().into());
+        periodogram.add_phase_feature(LaflerKinmanStringLength::new().into());
         periodogram.set_periodogram_algorithm(PeriodogramPowerDirect.into());
 
         let mut ts = TimeSeries::new_without_weight(&x, &y);
         let result = periodogram.eval(&mut ts).unwrap();
 
-        // result = [period_0, snr_0, period_folded_lafler_kinman]
+        // result = [period_0, snr_0, period_folded_lafler_kinman_string_length]
         assert_eq!(result.len(), 3);
         // recovered period close to true
         assert!(
@@ -1035,7 +1034,11 @@ mod tests {
             result[0]
         );
         // smooth phase curve: theta << 1 (sine wave gives ~0.003)
-        assert!(result[2] < 0.01, "lafler_kinman = {}", result[2]);
+        assert!(
+            result[2] < 0.01,
+            "lafler_kinman_string_length = {}",
+            result[2]
+        );
     }
 
     // ── Phase dispatch case tests ─────────────────────────────────────────────

--- a/src/multicolor/features/multi_color_periodogram.rs
+++ b/src/multicolor/features/multi_color_periodogram.rs
@@ -1,9 +1,11 @@
 use crate::data::MultiColorTimeSeries;
 use crate::error::MultiColorEvaluatorError;
-use crate::evaluator::TmArrays;
 use crate::evaluator::{
-    EvaluatorInfo, EvaluatorInfoTrait, FeatureEvaluator, FeatureNamesDescriptionsTrait, OwnedArrays,
+    EvaluatorInfo, EvaluatorInfoTrait, EvaluatorProperties, FeatureEvaluator,
+    FeatureNamesDescriptionsTrait, OwnedArrays, TmArrays,
 };
+use crate::extractor::FeatureExtractor;
+use crate::features::phase_fold_ts;
 use crate::features::{Periodogram, PeriodogramPeaks};
 use crate::float_trait::Float;
 use crate::multicolor::multicolor_evaluator::*;
@@ -46,34 +48,156 @@ pub enum MultiColorPeriodogramNormalisation {
 /// inherited from the underlying [`Periodogram`] and can be configured through
 /// the same builder methods.
 ///
+/// Phase features (added via [`MultiColorPeriodogram::add_phase_feature`]) are
+/// applied per-band at the best period from the combined periodogram. A fixed
+/// set of passbands must be registered with
+/// [`MultiColorPeriodogram::set_phase_bands`] before adding phase features.
+/// Phase feature names are prefixed with `period_folded_{band}_`.
+///
 /// # Example
 ///
 /// ```rust,ignore
-/// let mut eval = MultiColorPeriodogram::<f64, Feature<f64>>::new(
+/// let mut eval = MultiColorPeriodogram::<StringPassband, f64, Feature<f64>>::new(
 ///     1,
 ///     MultiColorPeriodogramNormalisation::Count,
 /// );
 /// eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
 /// let result = eval.eval_multicolor(&mut mcts)?;
 /// ```
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(
-    bound = "T: Float, F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>, <F as TryInto<PeriodogramPeaks>>::Error: Debug,"
-)]
-pub struct MultiColorPeriodogram<T, F>
+#[derive(Clone, Debug)]
+pub struct MultiColorPeriodogram<P, T, F>
 where
+    P: PassbandTrait,
     T: Float,
     F: FeatureEvaluator<T>,
 {
     // We use it to not reimplement some internals
     monochrome: Periodogram<T, F>,
     normalization: MultiColorPeriodogramNormalisation,
+    /// Passbands on which phase features are evaluated. Empty = no phase features.
+    phase_bands: Vec<P>,
+    phase_extractor: FeatureExtractor<T, F>,
+    /// Combined properties (spectrum + phase). Updated whenever features/bands change.
+    properties: Box<EvaluatorProperties>,
 }
 
-impl<T, F> MultiColorPeriodogram<T, F>
+// ── Serialization ─────────────────────────────────────────────────────────────
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(
+    rename = "MultiColorPeriodogram",
+    bound(
+        serialize = "P: PassbandTrait, T: Float, F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>, <F as TryInto<PeriodogramPeaks>>::Error: Debug",
+        deserialize = "P: PassbandTrait + Deserialize<'de>, T: Float, F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>, <F as TryInto<PeriodogramPeaks>>::Error: Debug",
+    )
+)]
+struct MultiColorPeriodogramParameters<P, T, F>
 where
+    P: PassbandTrait,
     T: Float,
-    F: FeatureEvaluator<T> + From<PeriodogramPeaks>,
+    F: FeatureEvaluator<T>,
+{
+    monochrome: Periodogram<T, F>,
+    normalization: MultiColorPeriodogramNormalisation,
+    #[serde(default)]
+    phase_bands: Vec<P>,
+    #[serde(default)]
+    phase_features: Vec<F>,
+}
+
+impl<P, T, F> From<MultiColorPeriodogram<P, T, F>> for MultiColorPeriodogramParameters<P, T, F>
+where
+    P: PassbandTrait,
+    T: Float,
+    F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>,
+    <F as TryInto<PeriodogramPeaks>>::Error: Debug,
+{
+    fn from(v: MultiColorPeriodogram<P, T, F>) -> Self {
+        Self {
+            monochrome: v.monochrome,
+            normalization: v.normalization,
+            phase_bands: v.phase_bands,
+            phase_features: v.phase_extractor.into_vec(),
+        }
+    }
+}
+
+impl<P, T, F> From<MultiColorPeriodogramParameters<P, T, F>> for MultiColorPeriodogram<P, T, F>
+where
+    P: PassbandTrait,
+    T: Float,
+    F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>,
+    <F as TryInto<PeriodogramPeaks>>::Error: Debug,
+{
+    fn from(p: MultiColorPeriodogramParameters<P, T, F>) -> Self {
+        let mut mcp = Self::new_with_monochrome(p.monochrome, p.normalization);
+        if !p.phase_bands.is_empty() {
+            mcp.set_phase_bands(p.phase_bands);
+        }
+        for feature in p.phase_features {
+            mcp.add_phase_feature(feature);
+        }
+        mcp
+    }
+}
+
+impl<P, T, F> Serialize for MultiColorPeriodogram<P, T, F>
+where
+    P: PassbandTrait + Serialize,
+    T: Float,
+    F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks> + Serialize,
+    <F as TryInto<PeriodogramPeaks>>::Error: Debug,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        MultiColorPeriodogramParameters::from(self.clone()).serialize(serializer)
+    }
+}
+
+impl<'de, P, T, F> Deserialize<'de> for MultiColorPeriodogram<P, T, F>
+where
+    P: PassbandTrait + Deserialize<'de>,
+    T: Float,
+    F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>,
+    <F as TryInto<PeriodogramPeaks>>::Error: Debug,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        MultiColorPeriodogramParameters::<P, T, F>::deserialize(deserializer).map(Self::from)
+    }
+}
+
+impl<P, T, F> JsonSchema for MultiColorPeriodogram<P, T, F>
+where
+    P: PassbandTrait + JsonSchema,
+    T: Float,
+    F: FeatureEvaluator<T> + JsonSchema,
+{
+    fn is_referenceable() -> bool {
+        false
+    }
+
+    fn schema_name() -> String {
+        MultiColorPeriodogramParameters::<P, T, F>::schema_name()
+    }
+
+    fn json_schema(g: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        MultiColorPeriodogramParameters::<P, T, F>::json_schema(g)
+    }
+}
+
+// ── Constructors & builders ───────────────────────────────────────────────────
+
+impl<P, T, F> MultiColorPeriodogram<P, T, F>
+where
+    P: PassbandTrait,
+    T: Float,
+    F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>,
+    <F as TryInto<PeriodogramPeaks>>::Error: Debug,
 {
     /// Create a new multi-colour periodogram.
     ///
@@ -85,9 +209,33 @@ where
             "multicolor_periodogram",
             "of multi-color periodogram (interpreting frequency as time, power as magnitude)",
         );
+        Self::new_with_monochrome(monochrome, normalization)
+    }
+
+    fn new_with_monochrome(
+        monochrome: Periodogram<T, F>,
+        normalization: MultiColorPeriodogramNormalisation,
+    ) -> Self {
+        let properties = EvaluatorProperties {
+            info: monochrome.get_info().clone(),
+            names: monochrome
+                .get_names()
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            descriptions: monochrome
+                .get_descriptions()
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        }
+        .into();
         Self {
             monochrome,
             normalization,
+            phase_bands: vec![],
+            phase_extractor: FeatureExtractor::new(vec![]),
+            properties,
         }
     }
 
@@ -116,47 +264,24 @@ where
     }
 
     /// Set frequency resolution.
-    ///
-    /// A larger resolution allows peak periods to be found with better
-    /// precision.
-    ///
-    /// Returns [`None`] if the underlying frequency-grid strategy is
-    /// [`FreqGridStrategy::Fixed`]; otherwise applies the change and returns
-    /// [`Some`].
     pub fn set_freq_resolution(&mut self, resolution: f32) -> Option<&mut Self> {
         self.monochrome.set_freq_resolution(resolution)?;
         Some(self)
     }
 
     /// Set the maximum-frequency multiplier.
-    ///
-    /// The maximum frequency is the Nyquist frequency multiplied by this
-    /// factor. A larger factor lets [`PeriodogramPowerFft`] find higher
-    /// frequencies more precisely, but also risks spurious peaks.
-    ///
-    /// Returns [`None`] if the underlying frequency-grid strategy is
-    /// [`FreqGridStrategy::Fixed`]; otherwise applies the change and returns
-    /// [`Some`].
     pub fn set_max_freq_factor(&mut self, max_freq_factor: f32) -> Option<&mut Self> {
         self.monochrome.set_max_freq_factor(max_freq_factor)?;
         Some(self)
     }
 
     /// Set the Nyquist frequency strategy.
-    ///
-    /// Returns [`None`] if the underlying frequency-grid strategy is
-    /// [`FreqGridStrategy::Fixed`]; otherwise applies the change and returns
-    /// [`Some`].
     pub fn set_nyquist(&mut self, nyquist: impl Into<NyquistFreq>) -> Option<&mut Self> {
         self.monochrome.set_nyquist(nyquist)?;
         Some(self)
     }
 
-    /// Set a fixed frequency grid, overriding the dynamic Nyquist-based grid.
-    ///
-    /// Use [`crate::LinearFreqGrid`] with [`crate::PeriodogramPowerDirect`] to
-    /// search a custom frequency range, e.g. to avoid ground-based daily
-    /// aliases.
+    /// Set a fixed frequency grid.
     pub fn set_freq_grid(
         &mut self,
         freq_grid: impl Into<crate::periodogram::FreqGrid<T>>,
@@ -165,10 +290,7 @@ where
         self
     }
 
-    /// Set a new frequency-grid strategy (either dynamic or fixed).
-    ///
-    /// This is the most general way to control the frequency grid; see
-    /// [`FreqGridStrategy`] for the available variants.
+    /// Set a new frequency-grid strategy.
     pub fn set_freq_grid_strategy(
         &mut self,
         freq_grid_strategy: impl Into<FreqGridStrategy<T>>,
@@ -186,17 +308,114 @@ where
         self
     }
 
-    /// Extend the set of features extracted from the periodogram.
-    pub fn add_feature(&mut self, feature: F) -> &mut Self {
-        self.monochrome.add_feature(feature);
+    /// Add a feature to extract from the combined periodogram spectrum.
+    pub fn add_spectrum_feature(&mut self, feature: F) -> &mut Self {
+        self.monochrome.add_spectrum_feature(feature);
+        self.rebuild_properties();
         self
+    }
+
+    /// Register the passbands on which phase features will be evaluated.
+    ///
+    /// Must be called before [Self::add_phase_feature]. The passband set
+    /// switches from `AllAvailable` to `FixedSet` for phase evaluation;
+    /// spectrum evaluation still uses all available bands.
+    ///
+    /// # Panics
+    /// Panics if phase features have already been added.
+    pub fn set_phase_bands(&mut self, bands: impl Into<Vec<P>>) -> &mut Self {
+        assert!(
+            self.phase_extractor.get_features().is_empty(),
+            "set_phase_bands must be called before add_phase_feature"
+        );
+        self.phase_bands = bands.into();
+        self
+    }
+
+    /// Add a feature to extract from each band's phase-folded light curve.
+    ///
+    /// The light curve of each registered passband is folded at the best period
+    /// from the combined periodogram, with phase 0 at the magnitude minimum.
+    /// Feature names are prefixed with `period_folded_{band}_`.
+    ///
+    /// # Panics
+    /// Panics if [Self::set_phase_bands] has not been called first.
+    pub fn add_phase_feature(&mut self, feature: F) -> &mut Self {
+        assert!(
+            !self.phase_bands.is_empty(),
+            "call set_phase_bands before add_phase_feature"
+        );
+        self.phase_extractor.add_feature(feature);
+        self.rebuild_properties();
+        self
+    }
+
+    fn rebuild_properties(&mut self) {
+        let monochrome_info = self.monochrome.get_info();
+        let n_bands = self.phase_bands.len();
+        // FeatureExtractor::add_feature does not update its cached info.size, so
+        // we must compute the phase feature size by summing over features directly.
+        let phase_feature_size: usize = self
+            .phase_extractor
+            .get_features()
+            .iter()
+            .map(|f| f.size_hint())
+            .sum();
+        let phase_size = n_bands * phase_feature_size;
+        let phase_min_ts = if n_bands > 0 {
+            self.phase_extractor
+                .get_features()
+                .iter()
+                .map(|f| f.min_ts_length())
+                .max()
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        let mut names: Vec<String> = self
+            .monochrome
+            .get_names()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let mut descriptions: Vec<String> = self
+            .monochrome
+            .get_descriptions()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        for band in &self.phase_bands {
+            for name in self.phase_extractor.get_names() {
+                names.push(format!("period_folded_{}_{}", band.name(), name));
+            }
+            for desc in self.phase_extractor.get_descriptions() {
+                descriptions.push(format!(
+                    "{} (light curve of {} band folded at best period)",
+                    desc,
+                    band.name()
+                ));
+            }
+        }
+
+        *self.properties = EvaluatorProperties {
+            info: EvaluatorInfo {
+                size: monochrome_info.size + phase_size,
+                min_ts_length: monochrome_info.min_ts_length.max(phase_min_ts),
+                ..*monochrome_info
+            },
+            names,
+            descriptions,
+        };
     }
 }
 
-impl<T, F> Default for MultiColorPeriodogram<T, F>
+impl<P, T, F> Default for MultiColorPeriodogram<P, T, F>
 where
+    P: PassbandTrait,
     T: Float,
-    F: FeatureEvaluator<T> + From<PeriodogramPeaks>,
+    F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>,
+    <F as TryInto<PeriodogramPeaks>>::Error: Debug,
 {
     fn default() -> Self {
         Self::new(
@@ -206,13 +425,50 @@ where
     }
 }
 
-impl<T, F> MultiColorPeriodogram<T, F>
+// ── EvaluatorInfoTrait / FeatureNamesDescriptionsTrait ────────────────────────
+
+impl<P, T, F> EvaluatorInfoTrait for MultiColorPeriodogram<P, T, F>
 where
+    P: PassbandTrait,
     T: Float,
     F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>,
     <F as TryInto<PeriodogramPeaks>>::Error: Debug,
 {
-    fn power_from_periodogram<'slf, 'a, 'mcts, P>(
+    fn get_info(&self) -> &EvaluatorInfo {
+        &self.properties.info
+    }
+}
+
+impl<P, T, F> FeatureNamesDescriptionsTrait for MultiColorPeriodogram<P, T, F>
+where
+    P: PassbandTrait,
+    T: Float,
+    F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>,
+    <F as TryInto<PeriodogramPeaks>>::Error: Debug,
+{
+    fn get_names(&self) -> Vec<&str> {
+        self.properties.names.iter().map(String::as_str).collect()
+    }
+
+    fn get_descriptions(&self) -> Vec<&str> {
+        self.properties
+            .descriptions
+            .iter()
+            .map(String::as_str)
+            .collect()
+    }
+}
+
+// ── Power helpers ─────────────────────────────────────────────────────────────
+
+impl<P, T, F> MultiColorPeriodogram<P, T, F>
+where
+    P: PassbandTrait,
+    T: Float,
+    F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>,
+    <F as TryInto<PeriodogramPeaks>>::Error: Debug,
+{
+    fn power_from_periodogram<'slf, 'a, 'mcts>(
         &self,
         p: &periodogram::Periodogram<T>,
         mcts: &'mcts mut MultiColorTimeSeries<'a, P, T>,
@@ -220,7 +476,6 @@ where
     where
         'slf: 'a,
         'a: 'mcts,
-        P: PassbandTrait,
     {
         let mapping = mcts.mapping_mut();
         let ts_weights = {
@@ -268,18 +523,13 @@ where
     }
 
     /// Compute the combined multi-band Lomb-Scargle power spectrum.
-    ///
-    /// The frequency grid is derived from all observation times across every
-    /// passband. Returns a 1-D array of power values, one per frequency grid
-    /// point.
-    pub fn power<'slf, 'a, 'mcts, P>(
+    pub fn power<'slf, 'a, 'mcts>(
         &self,
         mcts: &'mcts mut MultiColorTimeSeries<'a, P, T>,
     ) -> Result<Array1<T>, MultiColorEvaluatorError>
     where
         'slf: 'a,
         'a: 'mcts,
-        P: PassbandTrait,
     {
         let p = self
             .monochrome
@@ -288,20 +538,14 @@ where
         self.power_from_periodogram(&p, mcts)
     }
 
-    /// Compute the combined multi-band power spectrum together with the
-    /// frequency grid.
-    ///
-    /// Returns `(frequencies, powers)` as a pair of 1-D arrays. The
-    /// frequencies are in the same units as the reciprocal of the time axis
-    /// (rad per time unit when using the default angular-frequency convention).
-    pub fn freq_power<'slf, 'a, 'mcts, P>(
+    /// Compute the combined multi-band power spectrum together with the frequency grid.
+    pub fn freq_power<'slf, 'a, 'mcts>(
         &self,
         mcts: &'mcts mut MultiColorTimeSeries<'a, P, T>,
     ) -> Result<(Array1<T>, Array1<T>), MultiColorEvaluatorError>
     where
         'slf: 'a,
         'a: 'mcts,
-        P: PassbandTrait,
     {
         let p = self
             .monochrome
@@ -311,56 +555,22 @@ where
         let freq = (0..power.len()).map(|i| p.freq(i)).collect();
         Ok((freq, power))
     }
-}
 
-impl<T, F> MultiColorPeriodogram<T, F>
-where
-    T: Float,
-    F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>,
-    <F as TryInto<PeriodogramPeaks>>::Error: Debug,
-{
-    fn transform_mcts_to_ts<P>(
+    fn transform_mcts_to_ts<'a>(
         &self,
-        mcts: &mut MultiColorTimeSeries<P, T>,
-    ) -> Result<TmArrays<T>, MultiColorEvaluatorError>
-    where
-        P: PassbandTrait,
-    {
+        mcts: &mut MultiColorTimeSeries<'a, P, T>,
+    ) -> Result<TmArrays<T>, MultiColorEvaluatorError> {
         let (freq, power) = self.freq_power(mcts)?;
         Ok(TmArrays { t: freq, m: power })
     }
 }
 
-impl<T, F> EvaluatorInfoTrait for MultiColorPeriodogram<T, F>
-where
-    T: Float,
-    F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>,
-    <F as TryInto<PeriodogramPeaks>>::Error: Debug,
-{
-    fn get_info(&self) -> &EvaluatorInfo {
-        self.monochrome.get_info()
-    }
-}
+// ── PassbandSetTrait / MultiColorEvaluator ────────────────────────────────────
 
-impl<T, F> FeatureNamesDescriptionsTrait for MultiColorPeriodogram<T, F>
+impl<P, T, F> MultiColorPassbandSetTrait<P> for MultiColorPeriodogram<P, T, F>
 where
-    T: Float,
-    F: FeatureEvaluator<T> + From<PeriodogramPeaks> + TryInto<PeriodogramPeaks>,
-    <F as TryInto<PeriodogramPeaks>>::Error: Debug,
-{
-    fn get_names(&self) -> Vec<&str> {
-        self.monochrome.get_names()
-    }
-
-    fn get_descriptions(&self) -> Vec<&str> {
-        self.monochrome.get_descriptions()
-    }
-}
-
-impl<P, T, F> MultiColorPassbandSetTrait<P> for MultiColorPeriodogram<T, F>
-where
-    T: Float,
     P: PassbandTrait,
+    T: Float,
     F: FeatureEvaluator<T>,
 {
     fn get_passband_set(&self) -> &PassbandSet<P> {
@@ -368,7 +578,7 @@ where
     }
 }
 
-impl<P, T, F> MultiColorEvaluator<P, T> for MultiColorPeriodogram<T, F>
+impl<P, T, F> MultiColorEvaluator<P, T> for MultiColorPeriodogram<P, T, F>
 where
     P: PassbandTrait,
     T: Float,
@@ -385,13 +595,47 @@ where
     {
         let arrays = self.transform_mcts_to_ts(mcts)?;
         let mut ts = arrays.ts();
-        self.monochrome
-            .feature_extractor_ref()
+        let mut result = self
+            .monochrome
+            .spectrum_extractor_ref()
             .eval(&mut ts)
-            .map_err(From::from)
+            .map_err(MultiColorEvaluatorError::from)?;
+
+        if !self.phase_bands.is_empty() && !self.phase_extractor.get_features().is_empty() {
+            let best_period = result[0];
+            if !best_period.is_finite() || best_period <= T::zero() {
+                return Err(MultiColorEvaluatorError::UnderlyingEvaluatorError(
+                    crate::EvaluatorError::ZeroDivision(
+                        "best period from periodogram is not positive, cannot phase-fold",
+                    ),
+                ));
+            }
+            let actual_passbands: std::collections::BTreeSet<String> =
+                mcts.passbands().map(|p| p.name().into()).collect();
+            let desired_passbands: std::collections::BTreeSet<String> =
+                self.phase_bands.iter().map(|p| p.name().into()).collect();
+            for (band, maybe_ts) in mcts
+                .mapping_mut()
+                .iter_matched_passbands_mut(self.phase_bands.iter())
+            {
+                let band_ts =
+                    maybe_ts.ok_or_else(|| MultiColorEvaluatorError::WrongPassbandsError {
+                        actual: actual_passbands.clone(),
+                        desired: desired_passbands.clone(),
+                    })?;
+                let phase_arrays = phase_fold_ts(band_ts, best_period);
+                let mut phase_ts = phase_arrays.ts();
+                result.extend(self.phase_extractor.eval(&mut phase_ts).map_err(|e| {
+                    MultiColorEvaluatorError::MonochromeEvaluatorError {
+                        error: e,
+                        passband: band.name().to_string(),
+                    }
+                })?);
+            }
+        }
+        Ok(result)
     }
 
-    /// Returns vector of feature values and fill invalid components with given value
     fn eval_or_fill_multicolor<'slf, 'a, 'mcts>(
         &'slf self,
         mcts: &'mcts mut MultiColorTimeSeries<'a, P, T>,
@@ -406,10 +650,38 @@ where
             Err(_) => return Ok(vec![fill_value; self.size_hint()]),
         };
         let mut ts = arrays.ts();
-        Ok(self
+        let mut result = self
             .monochrome
-            .feature_extractor_ref()
-            .eval_or_fill(&mut ts, fill_value))
+            .spectrum_extractor_ref()
+            .eval_or_fill(&mut ts, fill_value);
+
+        if !self.phase_bands.is_empty() && !self.phase_extractor.get_features().is_empty() {
+            let best_period = result[0];
+            let phase_feature_size: usize = self
+                .phase_extractor
+                .get_features()
+                .iter()
+                .map(|f| f.size_hint())
+                .sum();
+            if best_period.is_finite() && best_period > T::zero() {
+                for (_band, maybe_ts) in mcts
+                    .mapping_mut()
+                    .iter_matched_passbands_mut(self.phase_bands.iter())
+                {
+                    if let Some(band_ts) = maybe_ts {
+                        let phase_arrays = phase_fold_ts(band_ts, best_period);
+                        let mut phase_ts = phase_arrays.ts();
+                        result.extend(self.phase_extractor.eval_or_fill(&mut phase_ts, fill_value));
+                    } else {
+                        result.extend(vec![fill_value; phase_feature_size]);
+                    }
+                }
+            } else {
+                let phase_total = self.phase_bands.len() * phase_feature_size;
+                result.extend(vec![fill_value; phase_total]);
+            }
+        }
+        Ok(result)
     }
 }
 
@@ -418,7 +690,7 @@ mod tests {
     use super::*;
     use crate::{Feature, MultiColorTimeSeries, StringPassband};
 
-    type McPeriodogram = MultiColorPeriodogram<f64, Feature<f64>>;
+    type McPeriodogram = MultiColorPeriodogram<StringPassband, f64, Feature<f64>>;
 
     fn check_finite_with_norm(norm: MultiColorPeriodogramNormalisation) {
         let eval = McPeriodogram::new(1, norm);
@@ -456,14 +728,10 @@ mod tests {
     fn check_period_recovery() {
         use crate::{LinearFreqGrid, PeriodogramPowerDirect};
 
-        // Use 2 peaks: for short-period RRc stars the 2-day alias may rank higher than
-        // the true period, but the true period appears as the 2nd-highest peak.
         let mut eval = McPeriodogram::new(2, MultiColorPeriodogramNormalisation::Count);
 
         let n_tested = 10;
 
-        // Compute the maximum time baseline across the test light curves so the
-        // frequency step adapts to the actual data rather than a hard-coded constant.
         let baseline = light_curve_feature_test_util::RR_LYRAE_F64
             .iter()
             .take(n_tested)
@@ -475,18 +743,16 @@ mod tests {
             })
             .fold(0.0_f64, f64::max);
 
-        // Use Direct periodogram with a linear frequency grid covering RRLyrae periods
-        // (0.2-1.0 days), skipping ground-based 1-day aliases.
         let resolution = 10.0_f64;
-        let min_freq = std::f64::consts::TAU / 1.0; // max period = 1 day
-        let max_freq = std::f64::consts::TAU / 0.2; // min period = 0.2 days
+        let min_freq = std::f64::consts::TAU / 1.0;
+        let max_freq = std::f64::consts::TAU / 0.2;
         let step = std::f64::consts::TAU / (resolution * baseline);
         let size = ((max_freq - min_freq) / step).ceil() as usize + 1;
         let grid = LinearFreqGrid::new(min_freq, step, size);
         eval.set_freq_grid(grid);
         eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
 
-        let tolerance = 0.01; // 1%
+        let tolerance = 0.01;
 
         let mut n_recovered = 0usize;
         for rrlyr in light_curve_feature_test_util::RR_LYRAE_F64
@@ -506,7 +772,6 @@ mod tests {
             );
             let result = eval.eval_multicolor(&mut mcts).unwrap();
             let known = rrlyr.period;
-            // result = [period_0, snr_0, period_1, snr_1, ...]
             let recovered_periods = [result[0], result[2]];
             if recovered_periods
                 .iter()
@@ -547,18 +812,30 @@ mod tests {
         assert_eq!(json, serde_json::to_string(&eval2).unwrap());
     }
 
-    /// Verify Chi2 normalization with unity weights weights by magnitude variance,
-    /// which is different from Count normalization (which weights by observation count).
-    ///
-    /// Setup: two bands with the same number of observations.
-    ///   - Band "g": sinusoidal — non-zero variance, gets all the Chi2 weight.
-    ///   - Band "r": constant  — zero variance, gets weight 0 under Chi2.
-    ///
-    /// With Count:  power = 0.5·power_g + 0.5·power_r
-    /// With Chi2:   power = 1.0·power_g  (r contributes 0)
-    ///
-    /// Since power_r ≈ 0 for a constant signal, the two combined power spectra
-    /// differ by a factor of ~2.  We also verify that all-flat bands are rejected.
+    #[test]
+    fn phase_feature_names_and_size() {
+        use crate::features::LaflerKinman;
+
+        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count);
+        eval.set_phase_bands(vec![StringPassband::from("g"), StringPassband::from("r")]);
+        eval.add_phase_feature(LaflerKinman::new().into());
+
+        let names = eval.get_names();
+        // spectrum: multicolor_periodogram_period_0, multicolor_periodogram_period_s_to_n_0
+        assert_eq!(names[0], "multicolor_periodogram_period_0");
+        // phase per band
+        assert!(
+            names.contains(&"period_folded_g_lafler_kinman"),
+            "names = {names:?}"
+        );
+        assert!(
+            names.contains(&"period_folded_r_lafler_kinman"),
+            "names = {names:?}"
+        );
+        // total size = 2 spectrum + 2 phase (1 per band)
+        assert_eq!(eval.size_hint(), 4);
+    }
+
     #[test]
     fn chi2_norm_unity_weights_differ_from_count() {
         use crate::data::TimeSeries;
@@ -567,12 +844,10 @@ mod tests {
         let n = 20usize;
         let period = 0.3_f64;
         let t: Vec<f64> = (0..n).map(|i| i as f64 * 0.05).collect();
-        // Band g: sinusoidal — non-zero variance
         let m_g: Vec<f64> = t
             .iter()
             .map(|&ti| (2.0 * std::f64::consts::PI * ti / period).sin())
             .collect();
-        // Band r: constant — zero variance → chi2 = 0 with unity weights
         let m_r: Vec<f64> = vec![1.0; n];
 
         let make_mcts = || {
@@ -601,11 +876,9 @@ mod tests {
         let eval_count = make_eval(MultiColorPeriodogramNormalisation::Count);
         let eval_chi2 = make_eval(MultiColorPeriodogramNormalisation::Chi2);
 
-        // Compare raw power arrays (not extracted peaks, whose SNR would cancel the scale factor)
         let power_count = eval_count.power(&mut mcts_count).unwrap();
         let power_chi2 = eval_chi2.power(&mut mcts_chi2).unwrap();
 
-        // Both should be finite
         assert!(
             power_count.iter().all(|v| v.is_finite()),
             "Count: non-finite power"
@@ -615,10 +888,6 @@ mod tests {
             "Chi2: non-finite power"
         );
 
-        // The constant band r contributes zero LS power, so:
-        //   Count power ≈ 0.5 · power_g
-        //   Chi2  power ≈ 1.0 · power_g
-        // → Chi2 power should be ≈ 2× Count power at every frequency.
         for (&pc, &pchi2) in power_count.iter().zip(power_chi2.iter()) {
             let ratio = pchi2 / pc;
             assert!(
@@ -627,7 +896,6 @@ mod tests {
             );
         }
 
-        // All-flat bands → Chi2 must return an error
         let m_flat: Vec<f64> = vec![1.0; n];
         let mut mcts_flat = {
             let mut map = std::collections::BTreeMap::new();
@@ -645,6 +913,50 @@ mod tests {
         assert!(
             eval_chi2_flat.eval_multicolor(&mut mcts_flat).is_err(),
             "Chi2 with all-flat bands should return an error"
+        );
+    }
+
+    #[test]
+    fn single_band_phase_feature_sine_recovery() {
+        use crate::PeriodogramPowerDirect;
+        use crate::data::TimeSeries;
+        use crate::features::LaflerKinman;
+        use rand::prelude::*;
+
+        let period = 0.17_f64;
+        let n = 200usize;
+        let mut rng = StdRng::seed_from_u64(0);
+        let mut t: Vec<f64> = (0..n).map(|_| rng.random::<f64>()).collect();
+        t.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+        let m: Vec<f64> = t
+            .iter()
+            .map(|&ti| 3.0 * (2.0 * std::f64::consts::PI * ti / period).sin() + 4.0)
+            .collect();
+
+        let mut map = std::collections::BTreeMap::new();
+        map.insert(
+            StringPassband::from("g"),
+            TimeSeries::new_without_weight(t.as_slice(), m.as_slice()),
+        );
+        let mut mcts = MultiColorTimeSeries::from_map(map);
+
+        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count);
+        eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
+        eval.set_phase_bands(vec![StringPassband::from("g")]);
+        eval.add_phase_feature(LaflerKinman::new().into());
+
+        let result = eval.eval_multicolor(&mut mcts).unwrap();
+        // result = [period_0, snr_0, period_folded_g_lafler_kinman]
+        assert_eq!(result.len(), 3);
+        let recovered_period = result[0];
+        assert!(
+            (recovered_period - period).abs() / period < 0.05,
+            "period recovery failed: got {recovered_period}, expected {period}"
+        );
+        let theta = result[2];
+        assert!(
+            theta < 0.5,
+            "phase-folded LaflerKinman = {theta}, expected < 0.5 for smooth curve"
         );
     }
 }

--- a/src/multicolor/features/multi_color_periodogram.rs
+++ b/src/multicolor/features/multi_color_periodogram.rs
@@ -848,6 +848,20 @@ mod tests {
     }
 
     #[test]
+    fn serde_json_with_phase_features() {
+        use crate::features::LaflerKinman;
+        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count);
+        eval.set_phase_bands(vec![StringPassband::from("g"), StringPassband::from("r")]);
+        eval.add_phase_feature(LaflerKinman::new().into());
+        let json = serde_json::to_string(&eval).unwrap();
+        let eval2: McPeriodogram = serde_json::from_str(&json).unwrap();
+        assert_eq!(json, serde_json::to_string(&eval2).unwrap());
+        // Names and size survive the round-trip
+        assert_eq!(eval.get_names(), eval2.get_names());
+        assert_eq!(eval.size_hint(), eval2.size_hint());
+    }
+
+    #[test]
     fn phase_feature_names_and_size() {
         use crate::features::LaflerKinman;
 

--- a/src/multicolor/features/multi_color_periodogram.rs
+++ b/src/multicolor/features/multi_color_periodogram.rs
@@ -849,10 +849,10 @@ mod tests {
 
     #[test]
     fn serde_json_with_phase_features() {
-        use crate::features::LaflerKinman;
+        use crate::features::LaflerKinmanStringLength;
         let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count);
         eval.set_phase_bands(vec![StringPassband::from("g"), StringPassband::from("r")]);
-        eval.add_phase_feature(LaflerKinman::new().into());
+        eval.add_phase_feature(LaflerKinmanStringLength::new().into());
         let json = serde_json::to_string(&eval).unwrap();
         let eval2: McPeriodogram = serde_json::from_str(&json).unwrap();
         assert_eq!(json, serde_json::to_string(&eval2).unwrap());
@@ -863,22 +863,22 @@ mod tests {
 
     #[test]
     fn phase_feature_names_and_size() {
-        use crate::features::LaflerKinman;
+        use crate::features::LaflerKinmanStringLength;
 
         let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count);
         eval.set_phase_bands(vec![StringPassband::from("g"), StringPassband::from("r")]);
-        eval.add_phase_feature(LaflerKinman::new().into());
+        eval.add_phase_feature(LaflerKinmanStringLength::new().into());
 
         let names = eval.get_names();
         // spectrum: multicolor_periodogram_period_0, multicolor_periodogram_period_s_to_n_0
         assert_eq!(names[0], "multicolor_periodogram_period_0");
         // phase per band
         assert!(
-            names.contains(&"period_folded_g_lafler_kinman"),
+            names.contains(&"period_folded_g_lafler_kinman_string_length"),
             "names = {names:?}"
         );
         assert!(
-            names.contains(&"period_folded_r_lafler_kinman"),
+            names.contains(&"period_folded_r_lafler_kinman_string_length"),
             "names = {names:?}"
         );
         // total size = 2 spectrum + 2 phase (1 per band)
@@ -1095,7 +1095,7 @@ mod tests {
     fn single_band_phase_feature_sine_recovery() {
         use crate::PeriodogramPowerDirect;
         use crate::data::TimeSeries;
-        use crate::features::LaflerKinman;
+        use crate::features::LaflerKinmanStringLength;
         use rand::prelude::*;
 
         let period = 0.17_f64;
@@ -1118,10 +1118,10 @@ mod tests {
         let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count);
         eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
         eval.set_phase_bands(vec![StringPassband::from("g")]);
-        eval.add_phase_feature(LaflerKinman::new().into());
+        eval.add_phase_feature(LaflerKinmanStringLength::new().into());
 
         let result = eval.eval_multicolor(&mut mcts).unwrap();
-        // result = [period_0, snr_0, period_folded_g_lafler_kinman]
+        // result = [period_0, snr_0, period_folded_g_lafler_kinman_string_length]
         assert_eq!(result.len(), 3);
         let recovered_period = result[0];
         assert!(
@@ -1131,7 +1131,7 @@ mod tests {
         let theta = result[2];
         assert!(
             theta < 0.01,
-            "phase-folded LaflerKinman = {theta}, expected < 0.01 for smooth curve"
+            "phase-folded LaflerKinmanStringLength = {theta}, expected < 0.01 for smooth curve"
         );
     }
 }

--- a/src/multicolor/features/multi_color_periodogram.rs
+++ b/src/multicolor/features/multi_color_periodogram.rs
@@ -951,6 +951,132 @@ mod tests {
         );
     }
 
+    // Case 1: !t_required && !sorting_required — raw band_ts evaluated, no phase folding.
+    // Amplitude only needs magnitudes; phase_fold_or_compute returns None and the extractor
+    // is called directly on the original (unfolded) band time series.
+    #[test]
+    fn phase_feature_case1_no_t_no_sort_amplitude() {
+        use crate::PeriodogramPowerDirect;
+        use crate::data::TimeSeries;
+        use crate::features::Amplitude;
+
+        let period = 0.3_f64;
+        let n = 50usize;
+        let t: Vec<f64> = (0..n).map(|i| i as f64 * 0.05).collect();
+        let m: Vec<f64> = t
+            .iter()
+            .map(|&ti| (2.0 * std::f64::consts::PI * ti / period).sin())
+            .collect();
+
+        let mut map = std::collections::BTreeMap::new();
+        map.insert(
+            StringPassband::from("g"),
+            TimeSeries::new_without_weight(t.as_slice(), m.as_slice()),
+        );
+        let mut mcts = MultiColorTimeSeries::from_map(map);
+
+        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count);
+        eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
+        eval.set_phase_bands(vec![StringPassband::from("g")]);
+        eval.add_phase_feature(Amplitude::default().into());
+
+        let result = eval.eval_multicolor(&mut mcts).unwrap();
+        assert_eq!(result.len(), eval.size_hint());
+        // Amplitude = (max - min) / 2; must equal the full-band value since no folding
+        let expected_amp = (m.iter().cloned().fold(f64::NEG_INFINITY, f64::max)
+            - m.iter().cloned().fold(f64::INFINITY, f64::min))
+            / 2.0;
+        assert!(
+            (result[2] - expected_amp).abs() < 1e-12,
+            "amplitude {}, expected {}",
+            result[2],
+            expected_amp,
+        );
+    }
+
+    // Case 2: t_required && !sorting_required — phase_compute_ts path (phases as time, no sort).
+    // TimeMean returns the mean of its "time" array; when phases are used as time the result
+    // must lie in (0, 1) and differ from the mean of the original timestamps.
+    #[test]
+    fn phase_feature_case2_t_required_no_sort_time_mean() {
+        use crate::PeriodogramPowerDirect;
+        use crate::data::TimeSeries;
+        use crate::features::TimeMean;
+
+        let period = 0.3_f64;
+        let n = 50usize;
+        let t: Vec<f64> = (0..n).map(|i| i as f64 * 0.05).collect();
+        let m: Vec<f64> = t
+            .iter()
+            .map(|&ti| (2.0 * std::f64::consts::PI * ti / period).sin())
+            .collect();
+
+        let mut map = std::collections::BTreeMap::new();
+        map.insert(
+            StringPassband::from("g"),
+            TimeSeries::new_without_weight(t.as_slice(), m.as_slice()),
+        );
+        let mut mcts = MultiColorTimeSeries::from_map(map);
+
+        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count);
+        eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
+        eval.set_phase_bands(vec![StringPassband::from("g")]);
+        eval.add_phase_feature(TimeMean::default().into());
+
+        let result = eval.eval_multicolor(&mut mcts).unwrap();
+        assert_eq!(result.len(), eval.size_hint());
+        // Mean of phases must lie in (0, 1)
+        let phase_mean = result[2];
+        assert!(
+            phase_mean > 0.0 && phase_mean < 1.0,
+            "mean phase {phase_mean} not in (0, 1)",
+        );
+        // Must differ from mean of the original timestamps
+        let mean_t = t.iter().sum::<f64>() / t.len() as f64;
+        assert!(
+            (phase_mean - mean_t).abs() > 1e-6,
+            "mean phase {phase_mean} suspiciously equal to mean t {mean_t}",
+        );
+    }
+
+    // Case 4: sorting_required && t_required, near-duplicate phases → Bins(1e-6) applied.
+    // t=[0,1,2,3,4] with period=1 → all phases collapse to 0.0; binning merges them into
+    // one point.  MaximumSlope requires ≥2 points, so eval_or_fill returns the fill value.
+    #[test]
+    fn phase_feature_case4_near_duplicate_phases_fill_not_panic() {
+        use crate::PeriodogramPowerDirect;
+        use crate::data::TimeSeries;
+        use crate::features::MaximumSlope;
+
+        let t = vec![0.0_f64, 1.0, 2.0, 3.0, 4.0];
+        let m = vec![1.0_f64, 1.5, 0.5, 1.2, 0.8];
+
+        let mut map = std::collections::BTreeMap::new();
+        map.insert(
+            StringPassband::from("g"),
+            TimeSeries::new_without_weight(t.as_slice(), m.as_slice()),
+        );
+        let mut mcts = MultiColorTimeSeries::from_map(map);
+
+        let mut eval = McPeriodogram::new(1, MultiColorPeriodogramNormalisation::Count);
+        eval.set_periodogram_algorithm(PeriodogramPowerDirect.into());
+        // Fixed grid: single frequency whose period equals 1.0 → all phases collapse to 0.0
+        eval.set_freq_grid(crate::periodogram::FreqGrid::linear(
+            std::f64::consts::TAU,
+            0.1,
+            1,
+        ));
+        eval.set_phase_bands(vec![StringPassband::from("g")]);
+        eval.add_phase_feature(MaximumSlope::default().into());
+
+        let fill = f64::NAN;
+        let result = eval.eval_or_fill_multicolor(&mut mcts, fill).unwrap();
+        // result = [period_0, snr_0, period_folded_g_maximum_slope]
+        assert_eq!(result.len(), eval.size_hint());
+        // Phase feature must be fill (only 1 bin after merge, too few for MaximumSlope)
+        assert!(result[2].is_nan(), "expected fill NaN, got {}", result[2]);
+    }
+
     #[test]
     fn single_band_phase_feature_sine_recovery() {
         use crate::PeriodogramPowerDirect;

--- a/src/multicolor/features/multi_color_periodogram.rs
+++ b/src/multicolor/features/multi_color_periodogram.rs
@@ -955,8 +955,8 @@ mod tests {
         );
         let theta = result[2];
         assert!(
-            theta < 0.05,
-            "phase-folded LaflerKinman = {theta}, expected < 0.05 for smooth curve"
+            theta < 0.01,
+            "phase-folded LaflerKinman = {theta}, expected < 0.01 for smooth curve"
         );
     }
 }

--- a/src/multicolor/features/multi_color_periodogram.rs
+++ b/src/multicolor/features/multi_color_periodogram.rs
@@ -955,8 +955,8 @@ mod tests {
         );
         let theta = result[2];
         assert!(
-            theta < 0.5,
-            "phase-folded LaflerKinman = {theta}, expected < 0.5 for smooth curve"
+            theta < 0.05,
+            "phase-folded LaflerKinman = {theta}, expected < 0.05 for smooth curve"
         );
     }
 }

--- a/src/multicolor/features/multi_color_periodogram.rs
+++ b/src/multicolor/features/multi_color_periodogram.rs
@@ -5,8 +5,9 @@ use crate::evaluator::{
     FeatureNamesDescriptionsTrait, OwnedArrays, TmArrays,
 };
 use crate::extractor::FeatureExtractor;
-use crate::features::phase_fold_ts;
+use crate::features::phase_fold_or_compute;
 use crate::features::{Periodogram, PeriodogramPeaks};
+use crate::features::{eval_phase_ts, eval_phase_ts_or_fill};
 use crate::float_trait::Float;
 use crate::multicolor::multicolor_evaluator::*;
 use crate::multicolor::{PassbandSet, PassbandTrait};
@@ -623,14 +624,33 @@ where
                         actual: actual_passbands.clone(),
                         desired: desired_passbands.clone(),
                     })?;
-                let phase_arrays = phase_fold_ts(band_ts, best_period);
-                let mut phase_ts = phase_arrays.ts();
-                result.extend(self.phase_extractor.eval(&mut phase_ts).map_err(|e| {
-                    MultiColorEvaluatorError::MonochromeEvaluatorError {
-                        error: e,
-                        passband: band.name().to_string(),
+                let phase_arrays = phase_fold_or_compute(
+                    band_ts,
+                    best_period,
+                    self.phase_extractor.is_t_required(),
+                    self.phase_extractor.is_sorting_required(),
+                );
+                match phase_arrays {
+                    Some(arrays) => {
+                        let mut phase_ts = arrays.ts();
+                        result.extend(
+                            eval_phase_ts(&self.phase_extractor, &mut phase_ts).map_err(|e| {
+                                MultiColorEvaluatorError::MonochromeEvaluatorError {
+                                    error: e,
+                                    passband: band.name().to_string(),
+                                }
+                            })?,
+                        );
                     }
-                })?);
+                    None => {
+                        result.extend(self.phase_extractor.eval(band_ts).map_err(|e| {
+                            MultiColorEvaluatorError::MonochromeEvaluatorError {
+                                error: e,
+                                passband: band.name().to_string(),
+                            }
+                        })?);
+                    }
+                }
             }
         }
         Ok(result)
@@ -669,9 +689,24 @@ where
                     .iter_matched_passbands_mut(self.phase_bands.iter())
                 {
                     if let Some(band_ts) = maybe_ts {
-                        let phase_arrays = phase_fold_ts(band_ts, best_period);
-                        let mut phase_ts = phase_arrays.ts();
-                        result.extend(self.phase_extractor.eval_or_fill(&mut phase_ts, fill_value));
+                        let phase_arrays = phase_fold_or_compute(
+                            band_ts,
+                            best_period,
+                            self.phase_extractor.is_t_required(),
+                            self.phase_extractor.is_sorting_required(),
+                        );
+                        match phase_arrays {
+                            Some(arrays) => {
+                                let mut phase_ts = arrays.ts();
+                                result.extend(eval_phase_ts_or_fill(
+                                    &self.phase_extractor,
+                                    &mut phase_ts,
+                                    fill_value,
+                                ));
+                            }
+                            None => result
+                                .extend(self.phase_extractor.eval_or_fill(band_ts, fill_value)),
+                        }
                     } else {
                         result.extend(vec![fill_value; phase_feature_size]);
                     }

--- a/src/multicolor/multicolor_feature.rs
+++ b/src/multicolor/multicolor_feature.rs
@@ -32,7 +32,7 @@ where
     ColorOfMedian(ColorOfMedian<P>),
     ColorOfMinimum(ColorOfMinimum<P>),
     ColorSpread(ColorSpread),
-    MultiColorPeriodogram(MultiColorPeriodogram<T, Feature<T>>),
+    MultiColorPeriodogram(MultiColorPeriodogram<P, T, Feature<T>>),
 }
 
 impl<P, T> MultiColorFeature<P, T>


### PR DESCRIPTION


Periodogram now supports two kinds of sub-features:
- spectrum_features: applied to the periodogram itself (existing behaviour, names unchanged)
- phase_features: applied to the phase-folded light curve at the best period (phase ∈ [0,1), phase 0 at minimum magnitude, sorted by phase); names are prefixed with `period_folded_`

MultiColorPeriodogram gains the same split, with phase features evaluated per-band. A FixedSet of passbands must be registered via set_phase_bands() before adding phase features; per-band names are prefixed `period_folded_{band}_`.