### PR TITLE
Add MultiColorBins meta-feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `MultiColorBins<P, T, F>` — a multi-color meta-feature that bins each passband's time series independently (same weighted-mean binning as `Bins`) and then evaluates an inner `F: MultiColorEvaluator<P, T>` on the collection of binned per-band series
-- `impl MultiColorEvaluator<P, T> for Box<F>` (and analogous `EvaluatorInfoTrait`, `FeatureNamesDescriptionsTrait`, `MultiColorPassbandSetTrait` impls) to support boxed multicolor evaluators, required for the recursive `MultiColorFeature::MultiColorBins` variant
+- `MultiColorBins<P, T>` — multi-color meta-feature that bins each passband's time series independently (same weighted-mean binning as `Bins`) then evaluates inner multi-color features on the collection of binned per-band series; mirrors the `Bins` API with `new(window, offset)` + `add_feature(MultiColorFeature<P, T>)`
+- `MultiColorExtractor::add_feature` and `MultiColorExtractor::get_features` for incremental extractor construction
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
---
+- `MultiColorBins<P, T, F>` — a multi-color meta-feature that bins each passband's time series independently (same weighted-mean binning as `Bins`) and then evaluates an inner `F: MultiColorEvaluator<P, T>` on the collection of binned per-band series
+- `impl MultiColorEvaluator<P, T> for Box<F>` (and analogous `EvaluatorInfoTrait`, `FeatureNamesDescriptionsTrait`, `MultiColorPassbandSetTrait` impls) to support boxed multicolor evaluators, required for the recursive `MultiColorFeature::MultiColorBins` variant
 
 ### Changed
 

--- a/src/features/bins.rs
+++ b/src/features/bins.rs
@@ -161,35 +161,43 @@ where
         &self,
         ts: &mut TimeSeries<T>,
     ) -> Result<TmwArrays<T>, EvaluatorError> {
-        // These conversions should never fail because we validated the range in new() and set methods
         let window = self.window.into_inner().approx_as::<T>().unwrap();
         let offset = self.offset.into_inner().approx_as::<T>().unwrap();
-        let (t, m, w): (Vec<_>, Vec<_>, Vec<_>) =
-            ts.t.as_slice()
-                .iter()
-                .copied()
-                .zip(ts.m.as_slice().iter().copied())
-                .zip(ts.w.as_slice().iter().copied())
-                .map(|((t, m), w)| (t, m, w))
-                .chunk_by(|(t, _, _)| ((*t - offset) / window).floor())
-                .into_iter()
-                .map(|(x, chunk)| {
-                    let bin_t = (x + T::half()) * window;
-                    let (n, bin_m, norm) = chunk
-                        .fold((T::zero(), T::zero(), T::zero()), |acc, (_, m, w)| {
-                            (acc.0 + T::one(), acc.1 + m * w, acc.2 + w)
-                        });
-                    let bin_m = bin_m / norm;
-                    let bin_w = norm / n;
-                    (bin_t, bin_m, bin_w)
-                })
-                .unzip3();
-        Ok(TmwArrays {
-            t: t.into(),
-            m: m.into(),
-            w: w.into(),
-        })
+        bin_time_series(ts, window, offset)
     }
+}
+
+/// Bins a single-band time series into weighted means.
+pub(crate) fn bin_time_series<T: Float>(
+    ts: &mut TimeSeries<T>,
+    window: T,
+    offset: T,
+) -> Result<TmwArrays<T>, EvaluatorError> {
+    let (t, m, w): (Vec<_>, Vec<_>, Vec<_>) =
+        ts.t.as_slice()
+            .iter()
+            .copied()
+            .zip(ts.m.as_slice().iter().copied())
+            .zip(ts.w.as_slice().iter().copied())
+            .map(|((t, m), w)| (t, m, w))
+            .chunk_by(|(t, _, _)| ((*t - offset) / window).floor())
+            .into_iter()
+            .map(|(x, chunk)| {
+                let bin_t = (x + T::half()) * window;
+                let (n, bin_m, norm) = chunk
+                    .fold((T::zero(), T::zero(), T::zero()), |acc, (_, m, w)| {
+                        (acc.0 + T::one(), acc.1 + m * w, acc.2 + w)
+                    });
+                let bin_m = bin_m / norm;
+                let bin_w = norm / n;
+                (bin_t, bin_m, bin_w)
+            })
+            .unzip3();
+    Ok(TmwArrays {
+        t: t.into(),
+        m: m.into(),
+        w: w.into(),
+    })
 }
 
 impl<T, F> Default for Bins<T, F>

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -15,7 +15,7 @@ pub use bazin_fit::{BazinFit, BazinInitsBounds, BazinLnPrior};
 mod beyond_n_std;
 pub use beyond_n_std::BeyondNStd;
 
-mod bins;
+pub(crate) mod bins;
 pub use bins::Bins;
 mod chi2_pvar;
 pub use chi2_pvar::Chi2Pvar;

--- a/src/multicolor/mod.rs
+++ b/src/multicolor/mod.rs
@@ -1,5 +1,8 @@
 pub mod features;
 
+mod multicolor_bins;
+pub use multicolor_bins::MultiColorBins;
+
 mod per_band_feature;
 pub use per_band_feature::PerBandFeature;
 

--- a/src/multicolor/multicolor_bins.rs
+++ b/src/multicolor/multicolor_bins.rs
@@ -1,0 +1,327 @@
+use crate::data::{MultiColorTimeSeries, TimeSeries};
+use crate::error::MultiColorEvaluatorError;
+use crate::evaluator::{
+    EvaluatorInfo, EvaluatorInfoTrait, EvaluatorProperties, FeatureNamesDescriptionsTrait,
+    TmwArrays,
+};
+use crate::features::bins::bin_time_series;
+use crate::float_trait::Float;
+use crate::multicolor::multicolor_evaluator::*;
+use crate::multicolor::{MultiColorExtractor, PassbandSet, PassbandTrait};
+
+use conv::ConvUtil;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+
+use super::MultiColorFeature;
+
+/// Multi-color meta-feature that bins each passband's time series independently,
+/// then evaluates inner multi-color features on the collection of binned per-band series.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(
+    into = "MultiColorBinsParameters<P, T>",
+    from = "MultiColorBinsParameters<P, T>",
+    bound(
+        serialize = "P: PassbandTrait + Serialize, T: Float",
+        deserialize = "P: PassbandTrait + Deserialize<'de>, T: Float"
+    )
+)]
+pub struct MultiColorBins<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    window: f64,
+    offset: f64,
+    feature_extractor: MultiColorExtractor<P, T>,
+    properties: Box<EvaluatorProperties>,
+}
+
+impl<P, T> MultiColorBins<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    pub fn new(window: f64, offset: f64) -> Self {
+        assert!(window > 0.0, "window must be positive");
+        assert!(
+            window.is_finite() && window.abs() <= f32::MAX as f64,
+            "window value {} is out of range for f32",
+            window
+        );
+        assert!(
+            offset.is_finite() && offset.abs() <= f32::MAX as f64,
+            "offset value {} is out of range for f32",
+            offset
+        );
+        Self {
+            window,
+            offset,
+            feature_extractor: MultiColorExtractor::new(vec![]),
+            properties: EvaluatorProperties {
+                info: EvaluatorInfo {
+                    size: 0,
+                    min_ts_length: 1,
+                    t_required: true,
+                    m_required: true,
+                    w_required: true,
+                    sorting_required: true,
+                    variability_required: false,
+                },
+                names: vec![],
+                descriptions: vec![],
+            }
+            .into(),
+        }
+    }
+
+    pub fn add_feature(&mut self, feature: MultiColorFeature<P, T>) -> &mut Self {
+        let window = self.window;
+        let offset = self.offset;
+        self.properties.info.size += feature.size_hint();
+        self.properties.info.min_ts_length = self
+            .properties
+            .info
+            .min_ts_length
+            .max(feature.min_ts_length());
+        self.properties.info.variability_required |= feature.is_variability_required();
+        self.properties.names.extend(
+            feature
+                .get_names()
+                .iter()
+                .map(|name| format!("bins_window{window:.1}_offset{offset:.1}_{name}")),
+        );
+        self.properties
+            .descriptions
+            .extend(feature.get_descriptions().iter().map(|desc| {
+                format!("{desc} for binned time-series with window {window} and offset {offset}")
+            }));
+        self.feature_extractor.add_feature(feature);
+        self
+    }
+
+    pub fn default_window() -> f64 {
+        1.0
+    }
+
+    pub fn default_offset() -> f64 {
+        0.0
+    }
+}
+
+impl<P, T> EvaluatorInfoTrait for MultiColorBins<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn get_info(&self) -> &EvaluatorInfo {
+        &self.properties.info
+    }
+}
+
+impl<P, T> FeatureNamesDescriptionsTrait for MultiColorBins<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn get_names(&self) -> Vec<&str> {
+        self.properties.names.iter().map(String::as_str).collect()
+    }
+
+    fn get_descriptions(&self) -> Vec<&str> {
+        self.properties
+            .descriptions
+            .iter()
+            .map(String::as_str)
+            .collect()
+    }
+}
+
+impl<P, T> MultiColorPassbandSetTrait<P> for MultiColorBins<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn get_passband_set(&self) -> &PassbandSet<P> {
+        self.feature_extractor.get_passband_set()
+    }
+}
+
+impl<P, T> MultiColorEvaluator<P, T> for MultiColorBins<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn eval_multicolor_no_mcts_check<'slf, 'a, 'mcts>(
+        &'slf self,
+        mcts: &'mcts mut MultiColorTimeSeries<'a, P, T>,
+    ) -> Result<Vec<T>, MultiColorEvaluatorError>
+    where
+        'slf: 'a,
+        'a: 'mcts,
+    {
+        let window: T = self.window.approx_as::<T>().unwrap();
+        let offset: T = self.offset.approx_as::<T>().unwrap();
+
+        let PassbandSet(set) = self.feature_extractor.get_passband_set();
+
+        let binned_arrays: BTreeMap<P, TmwArrays<T>> = mcts
+            .mapping_mut()
+            .iter_matched_passbands_mut(set.iter())
+            .map(|(passband, maybe_ts)| {
+                let ts = maybe_ts.expect("passband checked before eval_multicolor_no_mcts_check");
+                let tmw = bin_time_series(ts, window, offset).map_err(|error| {
+                    MultiColorEvaluatorError::MonochromeEvaluatorError {
+                        passband: passband.name().into(),
+                        error,
+                    }
+                })?;
+                Ok((passband.clone(), tmw))
+            })
+            .collect::<Result<_, MultiColorEvaluatorError>>()?;
+
+        let binned_map: BTreeMap<P, TimeSeries<'_, T>> = binned_arrays
+            .iter()
+            .map(|(p, tmw)| {
+                (
+                    p.clone(),
+                    TimeSeries::new(tmw.t.view(), tmw.m.view(), tmw.w.view()),
+                )
+            })
+            .collect();
+
+        let mut binned_mcts = MultiColorTimeSeries::from_map(binned_map);
+        self.feature_extractor
+            .eval_multicolor_no_mcts_check(&mut binned_mcts)
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(
+    rename = "MultiColorBins",
+    bound(
+        serialize = "P: PassbandTrait + Serialize, T: Float",
+        deserialize = "P: PassbandTrait + Deserialize<'de>, T: Float"
+    )
+)]
+struct MultiColorBinsParameters<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    window: f64,
+    offset: f64,
+    feature_extractor: MultiColorExtractor<P, T>,
+}
+
+impl<P, T> From<MultiColorBins<P, T>> for MultiColorBinsParameters<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn from(b: MultiColorBins<P, T>) -> Self {
+        Self {
+            window: b.window,
+            offset: b.offset,
+            feature_extractor: b.feature_extractor,
+        }
+    }
+}
+
+impl<P, T> From<MultiColorBinsParameters<P, T>> for MultiColorBins<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn from(p: MultiColorBinsParameters<P, T>) -> Self {
+        let mut bins = Self::new(p.window, p.offset);
+        p.feature_extractor
+            .get_features()
+            .iter()
+            .cloned()
+            .for_each(|f| {
+                bins.add_feature(f);
+            });
+        bins
+    }
+}
+
+impl<P, T> JsonSchema for MultiColorBins<P, T>
+where
+    P: PassbandTrait + JsonSchema,
+    T: Float,
+{
+    json_schema!(MultiColorBinsParameters<P, T>, false);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::data::TimeSeries;
+    use crate::multicolor::features::ColorOfMaximum;
+    use crate::{MultiColorTimeSeries, StringPassband};
+
+    use std::collections::BTreeMap;
+
+    fn make_mcts<'a>(
+        t: &'a [f64],
+        m_g: &'a [f64],
+        m_r: &'a [f64],
+        w: &'a [f64],
+    ) -> MultiColorTimeSeries<'a, StringPassband, f64> {
+        let mut map = BTreeMap::new();
+        map.insert(StringPassband::from("g"), TimeSeries::new(t, m_g, w));
+        map.insert(StringPassband::from("r"), TimeSeries::new(t, m_r, w));
+        MultiColorTimeSeries::from_map(map)
+    }
+
+    // g-band: t=[0.0, 0.1, 1.0, 1.1, 2.0], m=[1,3,5,7,9], w=1
+    // r-band: same t, m=[2,4,6,8,10], w=1
+    // binned (window=1, offset=0):
+    //   bin [0,1): g->mean(1,3)=2; r->mean(2,4)=3
+    //   bin [1,2): g->mean(5,7)=6; r->mean(6,8)=7
+    //   bin [2,3): g->9;           r->10
+    // ColorOfMaximum(g,r): max_g=9, max_r=10 → 9-10=-1
+    #[test]
+    fn multicolor_bins_values() {
+        let t = [0.0_f64, 0.1, 1.0, 1.1, 2.0];
+        let m_g = [1.0_f64, 3.0, 5.0, 7.0, 9.0];
+        let m_r = [2.0_f64, 4.0, 6.0, 8.0, 10.0];
+        let w = [1.0_f64; 5];
+
+        let mut eval = MultiColorBins::new(1.0, 0.0);
+        eval.add_feature(
+            ColorOfMaximum::new([StringPassband::from("g"), StringPassband::from("r")]).into(),
+        );
+        let mut mcts = make_mcts(&t, &m_g, &m_r, &w);
+        let result = eval.eval_multicolor(&mut mcts).unwrap();
+        assert_eq!(result.len(), 1);
+        assert!((result[0] - (-1.0_f64)).abs() < 1e-10, "got {}", result[0]);
+    }
+
+    #[test]
+    fn multicolor_bins_names() {
+        let mut eval = MultiColorBins::<StringPassband, f64>::new(1.0, 0.0);
+        eval.add_feature(
+            ColorOfMaximum::new([StringPassband::from("g"), StringPassband::from("r")]).into(),
+        );
+        assert_eq!(
+            eval.get_names(),
+            vec!["bins_window1.0_offset0.0_color_max_g_r"]
+        );
+    }
+
+    #[test]
+    fn multicolor_bins_serde() {
+        let mut eval = MultiColorBins::<StringPassband, f64>::new(1.0, 0.0);
+        eval.add_feature(
+            ColorOfMaximum::new([StringPassband::from("g"), StringPassband::from("r")]).into(),
+        );
+        let json = serde_json::to_string(&eval).unwrap();
+        let eval2: MultiColorBins<StringPassband, f64> = serde_json::from_str(&json).unwrap();
+        assert_eq!(eval.get_names(), eval2.get_names());
+    }
+}

--- a/src/multicolor/multicolor_extractor.rs
+++ b/src/multicolor/multicolor_extractor.rs
@@ -77,6 +77,23 @@ where
             info,
         }
     }
+
+    pub fn add_feature(&mut self, feature: MultiColorFeature<P, T>) {
+        let PassbandSet(new_pbs) = feature.get_passband_set();
+        self.passband_set.0.extend(new_pbs.iter().cloned());
+        self.info.size += feature.size_hint();
+        self.info.min_ts_length = self.info.min_ts_length.max(feature.min_ts_length());
+        self.info.t_required |= feature.is_t_required();
+        self.info.m_required |= feature.is_m_required();
+        self.info.w_required |= feature.is_w_required();
+        self.info.sorting_required |= feature.is_sorting_required();
+        self.info.variability_required |= feature.is_variability_required();
+        self.features.push(feature);
+    }
+
+    pub fn get_features(&self) -> &[MultiColorFeature<P, T>] {
+        &self.features
+    }
 }
 
 impl<P, T> FeatureNamesDescriptionsTrait for MultiColorExtractor<P, T>

--- a/src/multicolor/multicolor_feature.rs
+++ b/src/multicolor/multicolor_feature.rs
@@ -6,7 +6,7 @@ use crate::multicolor::features::{
     ColorOfMaximum, ColorOfMedian, ColorOfMinimum, ColorSpread, MultiColorPeriodogram,
 };
 use crate::multicolor::multicolor_evaluator::*;
-use crate::multicolor::{MultiColorExtractor, PerBandFeature};
+use crate::multicolor::{MultiColorBins, MultiColorExtractor, PerBandFeature};
 
 use enum_dispatch::enum_dispatch;
 use schemars::JsonSchema;
@@ -33,6 +33,7 @@ where
     ColorOfMinimum(ColorOfMinimum<P>),
     ColorSpread(ColorSpread<P>),
     MultiColorPeriodogram(MultiColorPeriodogram<P, T, Feature<T>>),
+    MultiColorBins(MultiColorBins<P, T>),
 }
 
 impl<P, T> MultiColorFeature<P, T>


### PR DESCRIPTION
## Summary

- Adds `MultiColorBins<P, T>` — a multi-color meta-feature that bins each passband's time series independently (same weighted-mean binning as `Bins`) then evaluates inner multi-color features on the collection of binned per-band series
- Mirrors the `Bins` API exactly: `new(window, offset)` + `add_feature(MultiColorFeature<P, T>)`; holds `MultiColorExtractor<P, T>` internally so the recursive type cycle is broken via `Vec` the same way `Feature::Bins` relies on `FeatureExtractor`
- Extracts a `pub(crate) fn bin_time_series` helper from `Bins::transform_ts` to share the binning logic
- Adds `add_feature` and `get_features` to `MultiColorExtractor` for incremental building
- No breaking changes: `MultiColorFeature` is `#[non_exhaustive]`, all other additions are purely additive

## Test plan

- [ ] `cargo test` passes (all existing tests + 3 new tests in `multicolor_bins`)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cargo fmt --check` clean
- [ ] Serde round-trip test included
- [ ] Value correctness test: binned `ColorOfMaximum` matches manually computed result

🤖 Generated with [Claude Code](https://claude.com/claude-code)