### PR TITLE
Allow user-defined passband order in PerBandFeature; fix Color* eval order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
---
+- **Breaking** `PerBandFeature::new` and `MultiColorFeature::from_per_band_feature` now accept `Vec<P>` instead of `BTreeSet<P>`, giving the user control over passband output order
 
 ### Deprecated
 
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
---
+- `ColorOfMedian`, `ColorOfMinimum`, `ColorOfMaximum` evaluation now correctly respects the user-specified `[P; 2]` passband order; previously results were silently wrong when passbands were provided in non-sorted order
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Breaking** `PerBandFeature::new` and `MultiColorFeature::from_per_band_feature` now accept `Vec<P>` instead of `BTreeSet<P>`, giving the user control over passband output order
+- **Breaking** `PerBandFeature::new` and `MultiColorFeature::from_per_band_feature` now accept `Vec<P>` instead of `BTreeSet<P>`, giving the user control over passband output order https://github.com/light-curve/light-curve-feature/pull/294
 
 ### Deprecated
 
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `ColorOfMedian`, `ColorOfMinimum`, `ColorOfMaximum` evaluation now correctly respects the user-specified `[P; 2]` passband order; previously results were silently wrong when passbands were provided in non-sorted order
+- `ColorOfMedian`, `ColorOfMinimum`, `ColorOfMaximum` evaluation now correctly respects the user-specified `[P; 2]` passband order; previously results were silently wrong when passbands were provided in non-sorted order https://github.com/light-curve/light-curve-feature/pull/294
 
 ### Security
 

--- a/src/multicolor/features/color_of_maximum.rs
+++ b/src/multicolor/features/color_of_maximum.rs
@@ -107,12 +107,10 @@ where
     {
         let mut maxima = [T::zero(); 2];
         mcts.with_mapping_mut(|mapping| {
-            for ((_passband, band_ts), maximum) in mapping
-                .iter_matched_passbands_mut(self.passbands.iter())
-                .zip(maxima.iter_mut())
-            {
-                let band_ts =
-                    band_ts.expect("MultiColorTimeSeries must have all required passbands");
+            for (passband, maximum) in self.passbands.iter().zip(maxima.iter_mut()) {
+                let band_ts = mapping
+                    .get_mut(passband)
+                    .expect("MultiColorTimeSeries must have all required passbands");
                 *maximum = band_ts.m.get_max();
             }
         });

--- a/src/multicolor/features/color_of_maximum.rs
+++ b/src/multicolor/features/color_of_maximum.rs
@@ -140,6 +140,23 @@ mod tests {
     }
 
     #[test]
+    fn color_of_maximum_reversed_passband_order() {
+        // u before g: result must be u-g, not g-u
+        let eval = ColorOfMaximum::new([StringPassband::from("u"), StringPassband::from("g")]);
+        let t = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0];
+        let m = vec![4.0_f64, 5.0, 6.0, 1.0, 3.0, 2.0];
+        let w = vec![1.0_f64; 6];
+        let bands: Vec<StringPassband> = vec!["g", "g", "g", "u", "u", "u"]
+            .into_iter()
+            .map(StringPassband::from)
+            .collect();
+        let mut mcts = MultiColorTimeSeries::from_flat(t, m, w, bands);
+        let result = eval.eval_multicolor(&mut mcts).unwrap();
+        // g max = 6.0, u max = 3.0; order is [u, g] so result = u - g = 3.0 - 6.0
+        assert!((result[0] - (3.0 - 6.0)).abs() < 1e-10);
+    }
+
+    #[test]
     fn color_of_maximum_names() {
         let eval = ColorOfMaximum::new([StringPassband::from("g"), StringPassband::from("r")]);
         assert_eq!(eval.get_names(), vec!["color_max_g_r"]);

--- a/src/multicolor/features/color_of_median.rs
+++ b/src/multicolor/features/color_of_median.rs
@@ -148,6 +148,23 @@ mod tests {
     }
 
     #[test]
+    fn color_of_median_reversed_passband_order() {
+        // u before g: result must be u-g, not g-u
+        let eval = ColorOfMedian::new([StringPassband::from("u"), StringPassband::from("g")]);
+        let t = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0];
+        let m = vec![4.0_f64, 6.0, 5.0, 1.0, 3.0, 2.0];
+        let w = vec![1.0_f64; 6];
+        let bands: Vec<StringPassband> = vec!["g", "g", "g", "u", "u", "u"]
+            .into_iter()
+            .map(StringPassband::from)
+            .collect();
+        let mut mcts = MultiColorTimeSeries::from_flat(t, m, w, bands);
+        let result = eval.eval_multicolor(&mut mcts).unwrap();
+        // g median = 5.0, u median = 2.0; order is [u, g] so result = u - g = 2.0 - 5.0
+        assert!((result[0] - (2.0 - 5.0)).abs() < 1e-10);
+    }
+
+    #[test]
     fn color_of_median_names() {
         let eval = ColorOfMedian::new([StringPassband::from("g"), StringPassband::from("r")]);
         assert_eq!(eval.get_names(), vec!["color_median_g_r"]);

--- a/src/multicolor/features/color_of_median.rs
+++ b/src/multicolor/features/color_of_median.rs
@@ -109,12 +109,10 @@ where
     {
         let mut medians = [T::zero(); 2];
         mcts.with_mapping_mut(|mapping| -> Result<(), MultiColorEvaluatorError> {
-            for ((passband, band_ts), median) in mapping
-                .iter_matched_passbands_mut(self.passbands.iter())
-                .zip(medians.iter_mut())
-            {
-                let band_ts =
-                    band_ts.expect("MultiColorTimeSeries must have all required passbands");
+            for (passband, median) in self.passbands.iter().zip(medians.iter_mut()) {
+                let band_ts = mapping
+                    .get_mut(passband)
+                    .expect("MultiColorTimeSeries must have all required passbands");
                 *median = self.median.eval(band_ts).map_err(|error| {
                     MultiColorEvaluatorError::MonochromeEvaluatorError {
                         passband: passband.name().into(),

--- a/src/multicolor/features/color_of_minimum.rs
+++ b/src/multicolor/features/color_of_minimum.rs
@@ -140,6 +140,23 @@ mod tests {
     }
 
     #[test]
+    fn color_of_minimum_reversed_passband_order() {
+        // u before g: result must be u-g, not g-u
+        let eval = ColorOfMinimum::new([StringPassband::from("u"), StringPassband::from("g")]);
+        let t = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0];
+        let m = vec![6.0_f64, 4.0, 5.0, 3.0, 1.0, 2.0];
+        let w = vec![1.0_f64; 6];
+        let bands: Vec<StringPassband> = vec!["g", "g", "g", "u", "u", "u"]
+            .into_iter()
+            .map(StringPassband::from)
+            .collect();
+        let mut mcts = MultiColorTimeSeries::from_flat(t, m, w, bands);
+        let result = eval.eval_multicolor(&mut mcts).unwrap();
+        // g min = 4.0, u min = 1.0; order is [u, g] so result = u - g = 1.0 - 4.0
+        assert!((result[0] - (1.0 - 4.0)).abs() < 1e-10);
+    }
+
+    #[test]
     fn color_of_minimum_names() {
         let eval = ColorOfMinimum::new([StringPassband::from("g"), StringPassband::from("r")]);
         assert_eq!(eval.get_names(), vec!["color_min_g_r"]);

--- a/src/multicolor/features/color_of_minimum.rs
+++ b/src/multicolor/features/color_of_minimum.rs
@@ -107,12 +107,10 @@ where
     {
         let mut minima = [T::zero(); 2];
         mcts.with_mapping_mut(|mapping| {
-            for ((_passband, band_ts), minimum) in mapping
-                .iter_matched_passbands_mut(self.passbands.iter())
-                .zip(minima.iter_mut())
-            {
-                let band_ts =
-                    band_ts.expect("MultiColorTimeSeries must have all required passbands");
+            for (passband, minimum) in self.passbands.iter().zip(minima.iter_mut()) {
+                let band_ts = mapping
+                    .get_mut(passband)
+                    .expect("MultiColorTimeSeries must have all required passbands");
                 *minimum = band_ts.m.get_min();
             }
         });

--- a/src/multicolor/multicolor_feature.rs
+++ b/src/multicolor/multicolor_feature.rs
@@ -11,7 +11,6 @@ use crate::multicolor::{MultiColorBins, MultiColorExtractor, PerBandFeature};
 use enum_dispatch::enum_dispatch;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
 use std::fmt::Debug;
 
 #[enum_dispatch(MultiColorEvaluator<P, T>, FeatureNamesDescriptionsTrait, EvaluatorInfoTrait, MultiColorPassbandSetTrait<P>)]
@@ -41,10 +40,10 @@ where
     P: PassbandTrait,
     T: Float,
 {
-    pub fn from_per_band_feature<F>(feature: F, passband_set: BTreeSet<P>) -> Self
+    pub fn from_per_band_feature<F>(feature: F, passbands: Vec<P>) -> Self
     where
         F: Into<Feature<T>>,
     {
-        PerBandFeature::new(feature.into(), passband_set).into()
+        PerBandFeature::new(feature.into(), passbands).into()
     }
 }

--- a/src/multicolor/per_band_feature.rs
+++ b/src/multicolor/per_band_feature.rs
@@ -19,18 +19,12 @@ where
     P: PassbandTrait,
 {
     feature: F,
-    /// User-specified passband order: determines feature name order and output value order.
     passband_order: Vec<P>,
-    /// Sorted BTreeSet for `check_mcts` validation only; derived from `passband_order`.
     passband_set: PassbandSet<P>,
     properties: Box<EvaluatorProperties>,
     phantom: PhantomData<T>,
 }
 
-/// Serialization helper — holds the serializable fields of [PerBandFeature].
-///
-/// `passband_set` is the JSON key (kept for backward compatibility); the value is
-/// the user-ordered `Vec<P>`, not a `BTreeSet`.
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(
     rename = "PerBandFeature",
@@ -46,7 +40,6 @@ where
     F: FeatureEvaluator<T>,
 {
     feature: F,
-    #[serde(rename = "passband_set")]
     passband_order: Vec<P>,
     properties: Box<EvaluatorProperties>,
     phantom: PhantomData<T>,

--- a/src/multicolor/per_band_feature.rs
+++ b/src/multicolor/per_band_feature.rs
@@ -9,23 +9,109 @@ use crate::multicolor::multicolor_evaluator::*;
 use itertools::Itertools;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
 /// Multi-color feature which evaluates a monochrome feature independently for each passband.
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(bound(
-    deserialize = "P: PassbandTrait + Deserialize<'de>, T: Float, F: FeatureEvaluator<T>"
-))]
+#[derive(Clone, Debug)]
 pub struct PerBandFeature<P, T, F>
 where
-    P: Ord,
+    P: PassbandTrait,
 {
     feature: F,
+    /// User-specified passband order: determines feature name order and output value order.
+    passband_order: Vec<P>,
+    /// Sorted BTreeSet for `check_mcts` validation only; derived from `passband_order`.
     passband_set: PassbandSet<P>,
     properties: Box<EvaluatorProperties>,
     phantom: PhantomData<T>,
+}
+
+/// Serialization helper — holds the serializable fields of [PerBandFeature].
+///
+/// `passband_set` is the JSON key (kept for backward compatibility); the value is
+/// the user-ordered `Vec<P>`, not a `BTreeSet`.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(
+    rename = "PerBandFeature",
+    bound(
+        serialize = "P: PassbandTrait + Serialize, T: Float, F: FeatureEvaluator<T> + Serialize",
+        deserialize = "P: PassbandTrait + Deserialize<'de>, T: Float, F: FeatureEvaluator<T>",
+    )
+)]
+struct PerBandFeatureData<P, T, F>
+where
+    P: PassbandTrait,
+    T: Float,
+    F: FeatureEvaluator<T>,
+{
+    feature: F,
+    #[serde(rename = "passband_set")]
+    passband_order: Vec<P>,
+    properties: Box<EvaluatorProperties>,
+    phantom: PhantomData<T>,
+}
+
+impl<P, T, F> Serialize for PerBandFeature<P, T, F>
+where
+    P: PassbandTrait + Serialize,
+    T: Float,
+    F: FeatureEvaluator<T> + Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        PerBandFeatureData {
+            feature: self.feature.clone(),
+            passband_order: self.passband_order.clone(),
+            properties: self.properties.clone(),
+            phantom: PhantomData,
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de, P, T, F> Deserialize<'de> for PerBandFeature<P, T, F>
+where
+    P: PassbandTrait + Deserialize<'de>,
+    T: Float,
+    F: FeatureEvaluator<T>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        PerBandFeatureData::<P, T, F>::deserialize(deserializer).map(|d| {
+            let passband_set = PassbandSet(d.passband_order.iter().cloned().collect());
+            Self {
+                feature: d.feature,
+                passband_order: d.passband_order,
+                passband_set,
+                properties: d.properties,
+                phantom: d.phantom,
+            }
+        })
+    }
+}
+
+impl<P, T, F> JsonSchema for PerBandFeature<P, T, F>
+where
+    P: PassbandTrait + JsonSchema,
+    T: Float,
+    F: FeatureEvaluator<T> + JsonSchema,
+{
+    fn is_referenceable() -> bool {
+        false
+    }
+
+    fn schema_name() -> String {
+        PerBandFeatureData::<P, T, F>::schema_name()
+    }
+
+    fn json_schema(g: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        PerBandFeatureData::<P, T, F>::json_schema(g)
+    }
 }
 
 impl<P, T, F> PerBandFeature<P, T, F>
@@ -38,23 +124,24 @@ where
     ///
     /// # Arguments
     /// - `feature` - non-multi-color feature to evaluate for each passband.
-    /// - `passband_set` - set of passbands to evaluate the feature for.
-    pub fn new(feature: F, passband_set: BTreeSet<P>) -> Self {
-        let names = passband_set
+    /// - `passbands` - passbands to evaluate the feature for, in the desired output order.
+    pub fn new(feature: F, passbands: Vec<P>) -> Self {
+        let names = passbands
             .iter()
             .cartesian_product(feature.get_names())
             .map(|(passband, name)| format!("{}_{}", name, passband.name()))
             .collect();
-        let descriptions = passband_set
+        let descriptions = passbands
             .iter()
             .cartesian_product(feature.get_descriptions())
             .map(|(passband, description)| format!("{}, passband {}", description, passband.name()))
             .collect();
         let info = {
             let mut info = feature.get_info().clone();
-            info.size *= passband_set.len();
+            info.size *= passbands.len();
             info
         };
+        let passband_set = PassbandSet(passbands.iter().cloned().collect());
         Self {
             properties: EvaluatorProperties {
                 info,
@@ -63,7 +150,8 @@ where
             }
             .into(),
             feature,
-            passband_set: passband_set.into(),
+            passband_order: passbands,
+            passband_set,
             phantom: PhantomData,
         }
     }
@@ -71,7 +159,7 @@ where
 
 impl<P, T, F> FeatureNamesDescriptionsTrait for PerBandFeature<P, T, F>
 where
-    P: Ord,
+    P: PassbandTrait,
 {
     fn get_names(&self) -> Vec<&str> {
         self.properties.names.iter().map(String::as_str).collect()
@@ -88,7 +176,7 @@ where
 
 impl<P, T, F> EvaluatorInfoTrait for PerBandFeature<P, T, F>
 where
-    P: Ord,
+    P: PassbandTrait,
 {
     fn get_info(&self) -> &EvaluatorInfo {
         &self.properties.info
@@ -118,13 +206,12 @@ where
         'slf: 'a,
         'a: 'mcts,
     {
-        let PassbandSet(set) = &self.passband_set;
         mcts.with_mapping_mut(|mapping| {
-            mapping
-                .iter_matched_passbands_mut(set.iter())
-                .map(|(passband, ts)| {
+            self.passband_order
+                .iter()
+                .map(|passband| {
                     self.feature
-                        .eval_no_ts_check(ts.expect(
+                        .eval_no_ts_check(mapping.get_mut(passband).expect(
                             "we checked all needed passbands are in mcts, but we still cannot find one",
                         ))
                         .map_err(|error| MultiColorEvaluatorError::MonochromeEvaluatorError {
@@ -153,12 +240,10 @@ mod tests {
     fn test_per_band_feature() {
         let feature: PerBandFeature<MonochromePassband<_>, f64, Feature<_>> = PerBandFeature::new(
             Mean::default().into(),
-            [
+            vec![
                 MonochromePassband::new(4700e-8, "g"),
                 MonochromePassband::new(6200e-8, "r"),
-            ]
-            .into_iter()
-            .collect(),
+            ],
         );
         assert_eq!(feature.get_names(), vec!["mean_g", "mean_r"]);
         assert_eq!(
@@ -182,9 +267,7 @@ mod tests {
 
         let feature: PerBandFeature<MonochromePassband<_>, f64, Feature<_>> = PerBandFeature::new(
             Mean::default().into(),
-            [passband_g.clone(), passband_r.clone()]
-                .into_iter()
-                .collect(),
+            vec![passband_g.clone(), passband_r.clone()],
         );
 
         let mut mcts = {
@@ -195,8 +278,39 @@ mod tests {
         };
 
         let result = feature.eval_multicolor(&mut mcts).unwrap();
-        // Passbands are ordered by wavelength (g before r), so mean_g=2.0 comes first
+        // Passbands in user order [g, r], so mean_g=2.0 comes first
         assert_eq!(result, vec![2.0_f64, 5.0_f64]);
+    }
+
+    #[test]
+    fn test_per_band_feature_reversed_order() {
+        use crate::data::TimeSeries;
+        use std::collections::BTreeMap;
+
+        let passband_g = MonochromePassband::new(4700e-8, "g");
+        let passband_r = MonochromePassband::new(6200e-8, "r");
+
+        let t = vec![0.0_f64, 1.0, 2.0];
+        let m_g = vec![1.0_f64, 2.0, 3.0]; // mean = 2.0
+        let m_r = vec![4.0_f64, 5.0, 6.0]; // mean = 5.0
+
+        // r before g: output order must follow user-specified order
+        let feature: PerBandFeature<MonochromePassband<_>, f64, Feature<_>> = PerBandFeature::new(
+            Mean::default().into(),
+            vec![passband_r.clone(), passband_g.clone()],
+        );
+        assert_eq!(feature.get_names(), vec!["mean_r", "mean_g"]);
+
+        let mut mcts = {
+            let mut map = BTreeMap::new();
+            map.insert(passband_g.clone(), TimeSeries::new_without_weight(&t, &m_g));
+            map.insert(passband_r.clone(), TimeSeries::new_without_weight(&t, &m_r));
+            MultiColorTimeSeries::from_map(map)
+        };
+
+        let result = feature.eval_multicolor(&mut mcts).unwrap();
+        // r is first in passband_order, so mean_r=5.0 comes first
+        assert_eq!(result, vec![5.0_f64, 2.0_f64]);
     }
 
     #[test]
@@ -212,10 +326,7 @@ mod tests {
 
         let feature: PerBandFeature<StringPassband, f64, Feature<f64>> = PerBandFeature::new(
             Mean::default().into(),
-            ["g", "r"]
-                .iter()
-                .map(|&s| StringPassband::from(s))
-                .collect(),
+            vec![StringPassband::from("g"), StringPassband::from("r")],
         );
         let mut mcts = MultiColorTimeSeries::from_flat(t, m, w, bands);
 
@@ -230,10 +341,7 @@ mod tests {
     fn test_per_band_feature_serde() {
         let feature: PerBandFeature<StringPassband, f64, Feature<f64>> = PerBandFeature::new(
             Mean::default().into(),
-            ["g", "r"]
-                .iter()
-                .map(|&s| StringPassband::from(s))
-                .collect(),
+            vec![StringPassband::from("g"), StringPassband::from("r")],
         );
         let json = serde_json::to_string(&feature).unwrap();
         let feature2: PerBandFeature<StringPassband, f64, Feature<f64>> =


### PR DESCRIPTION
## Summary

- **Breaking**: `PerBandFeature::new` and `MultiColorFeature::from_per_band_feature` now accept `Vec<P>` instead of `BTreeSet<P>`. Output feature names and values follow the user-specified passband order; a sorted `BTreeSet` is still maintained internally for `check_mcts` validation.
- Fix `ColorOfMedian`, `ColorOfMinimum`, `ColorOfMaximum` evaluation to use direct per-passband `get_mut` lookup instead of `iter_matched_passbands_mut`, which required sorted input and silently produced wrong results when passbands were provided in non-sorted order (e.g. `[r, g]`).
- `ColorSpread` and `MultiColorPeriodogram` are unchanged — their outputs are order-independent or already use direct lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)