### PR TITLE
v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Breaking** `MappedMultiColorTimeSeries` is now a named struct with `map` and
-  `uniq_passbands` fields instead of a newtype tuple; `Deref`/`DerefMut` still target
-  `BTreeMap<&P, TimeSeries<T>>` https://github.com/light-curve/light-curve-feature/pull/298
-- Significant speedup for `from_flat`, `from_flat_borrowed`, and all `MultiColor` feature
-  evaluations, especially for interleaved passband orderings
-  https://github.com/light-curve/light-curve-feature/issues/296
-  https://github.com/light-curve/light-curve-feature/issues/297
-  https://github.com/light-curve/light-curve-feature/pull/298
+--
 
 ### Deprecated
 
@@ -37,6 +30,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 --
+
+# [0.18.0] 2026 June 11
+
+### Changed
+
+- **Breaking** `MappedMultiColorTimeSeries` is now a named struct with `map` and
+  `uniq_passbands` fields instead of a newtype tuple; `Deref`/`DerefMut` still target
+  `BTreeMap<&P, TimeSeries<T>>` https://github.com/light-curve/light-curve-feature/pull/298
+- Significant speedup for `from_flat`, `from_flat_borrowed`, and all `MultiColor` feature
+  evaluations, especially for interleaved passband orderings
+  https://github.com/light-curve/light-curve-feature/issues/296
+  https://github.com/light-curve/light-curve-feature/issues/297
+  https://github.com/light-curve/light-curve-feature/pull/298
 
 # [0.17.0] 2026 May 29
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-curve-feature"
-version = "0.17.0"
+version = "0.18.0"
 description = "Feature extractor from noisy time series"
 categories = ["science"]
 keywords = ["astronomy", "time-series"]


### PR DESCRIPTION
## Summary

- Bump version to 0.18.0
- Update CHANGELOG: promote [Unreleased] entries to [0.18.0] 2026 June 11

## Changes in this release

### Changed

- **Breaking** `MappedMultiColorTimeSeries` is now a named struct with `map` and `uniq_passbands` fields instead of a newtype tuple; `Deref`/`DerefMut` still target `BTreeMap<&P, TimeSeries<T>>` #298
- Significant speedup for `from_flat`, `from_flat_borrowed`, and all `MultiColor` feature evaluations, especially for interleaved passband orderings #296 #297 #298

## Test plan

- [ ] CI passes (all jobs green)
- [ ] `cargo publish`
- [ ] Tag `v0.18.0` and push
- [ ] Merge PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)