### PR TITLE
Fix is_w_required/variability_required not propagated from phase features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
---
+- Fix `Periodogram::add_phase_feature` not propagating `w_required` and `variability_required`
+  from phase features to the top-level `EvaluatorInfo`
+- Fix `MultiColorPeriodogram` reporting `is_w_required() = false` for `Chi2` normalization and
+  not propagating `w_required` / `variability_required` from phase features
 
 ### Security
 

--- a/src/features/periodogram.rs
+++ b/src/features/periodogram.rs
@@ -337,6 +337,8 @@ where
             .info
             .min_ts_length
             .max(feature.min_ts_length());
+        self.properties.info.w_required |= feature.is_w_required();
+        self.properties.info.variability_required |= feature.is_variability_required();
         self.properties.names.extend(
             feature
                 .get_names()
@@ -1038,6 +1040,43 @@ mod tests {
             result[2] < 0.01,
             "lafler_kinman_string_length = {}",
             result[2]
+        );
+    }
+
+    // ── Info propagation tests ────────────────────────────────────────────────
+
+    #[test]
+    fn phase_feature_w_required_propagated() {
+        use crate::features::WeightedMean;
+        let mut periodogram: Periodogram<f64, Feature<f64>> = Periodogram::default();
+        assert!(!periodogram.is_w_required());
+        periodogram.add_phase_feature(WeightedMean::default().into());
+        assert!(
+            periodogram.is_w_required(),
+            "w_required must be true after adding a weight-requiring phase feature"
+        );
+    }
+
+    #[test]
+    fn phase_feature_variability_required_propagated() {
+        use crate::features::OtsuSplit;
+        let mut periodogram: Periodogram<f64, Feature<f64>> = Periodogram::default();
+        assert!(!periodogram.is_variability_required());
+        periodogram.add_phase_feature(OtsuSplit::default().into());
+        assert!(
+            periodogram.is_variability_required(),
+            "variability_required must be true after adding a variability-requiring phase feature"
+        );
+    }
+
+    #[test]
+    fn spectrum_feature_does_not_set_w_required() {
+        use crate::features::WeightedMean;
+        let mut periodogram: Periodogram<f64, Feature<f64>> = Periodogram::default();
+        periodogram.add_spectrum_feature(WeightedMean::default().into());
+        assert!(
+            !periodogram.is_w_required(),
+            "spectrum features operate on the periodogram output, not original weights"
         );
     }
 

--- a/src/multicolor/features/multi_color_periodogram.rs
+++ b/src/multicolor/features/multi_color_periodogram.rs
@@ -235,8 +235,10 @@ where
         normalization: MultiColorPeriodogramNormalisation,
         passband_set: PassbandSet<P>,
     ) -> Self {
+        let mut info = monochrome.get_info().clone();
+        info.w_required |= matches!(normalization, MultiColorPeriodogramNormalisation::Chi2);
         let properties = EvaluatorProperties {
-            info: monochrome.get_info().clone(),
+            info,
             names: monochrome
                 .get_names()
                 .iter()
@@ -420,6 +422,11 @@ where
             info: EvaluatorInfo {
                 size: monochrome_info.size + phase_size,
                 min_ts_length: monochrome_info.min_ts_length.max(phase_min_ts),
+                w_required: monochrome_info.w_required
+                    || matches!(self.normalization, MultiColorPeriodogramNormalisation::Chi2)
+                    || self.phase_extractor.is_w_required(),
+                variability_required: monochrome_info.variability_required
+                    || self.phase_extractor.is_variability_required(),
                 ..*monochrome_info
             },
             names,
@@ -1044,6 +1051,62 @@ mod tests {
         assert!(
             eval_chi2_flat.eval_multicolor(&mut mcts_flat).is_err(),
             "Chi2 with all-flat bands should return an error"
+        );
+    }
+
+    #[test]
+    fn chi2_norm_is_w_required() {
+        let eval_count = McPeriodogram::new(
+            1,
+            MultiColorPeriodogramNormalisation::Count,
+            make_gr_passbands(),
+        );
+        let eval_chi2 = McPeriodogram::new(
+            1,
+            MultiColorPeriodogramNormalisation::Chi2,
+            make_gr_passbands(),
+        );
+        assert!(
+            !eval_count.is_w_required(),
+            "Count normalization must not require weights"
+        );
+        assert!(
+            eval_chi2.is_w_required(),
+            "Chi2 normalization must require weights"
+        );
+    }
+
+    #[test]
+    fn phase_feature_w_required_propagated() {
+        use crate::features::WeightedMean;
+        let mut eval = McPeriodogram::new(
+            1,
+            MultiColorPeriodogramNormalisation::Count,
+            make_gr_passbands(),
+        );
+        assert!(!eval.is_w_required());
+        eval.set_phase_bands(vec![StringPassband::from("g")]);
+        eval.add_phase_feature(WeightedMean::default().into());
+        assert!(
+            eval.is_w_required(),
+            "w_required must be true after adding a weight-requiring phase feature"
+        );
+    }
+
+    #[test]
+    fn phase_feature_variability_required_propagated() {
+        use crate::features::OtsuSplit;
+        let mut eval = McPeriodogram::new(
+            1,
+            MultiColorPeriodogramNormalisation::Count,
+            make_gr_passbands(),
+        );
+        assert!(!eval.is_variability_required());
+        eval.set_phase_bands(vec![StringPassband::from("g")]);
+        eval.add_phase_feature(OtsuSplit::default().into());
+        assert!(
+            eval.is_variability_required(),
+            "variability_required must be true after adding a variability-requiring phase feature"
         );
     }
 


### PR DESCRIPTION
## Summary

- `Periodogram::add_phase_feature` was not ORing `w_required` or `variability_required` from the added feature into the top-level `EvaluatorInfo`, so callers querying `is_w_required()` / `is_variability_required()` on a periodogram with weight- or variability-requiring phase features would get wrong answers.
- `MultiColorPeriodogram` had the same gap for phase features, plus a separate bug: `is_w_required()` returned `false` even when `Chi2` normalization was selected (which uses observation weights to compute per-band $\chi^2$ weights).
- Spectrum features intentionally do **not** propagate these flags — they operate on the periodogram output (freq/power), not the original observation weights.

## Test plan

- [ ] `cargo test --lib features::periodogram` — 35 tests including 3 new info-propagation tests
- [ ] `cargo test --lib multicolor::features::multi_color_periodogram` — 17 tests including 3 new info-propagation tests
- [ ] CI green on full feature matrix