### PR TITLE
v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `Periodogram::add_phase_feature` not propagating `w_required` and `variability_required`
-  from phase features to the top-level `EvaluatorInfo`
-- Fix `MultiColorPeriodogram` reporting `is_w_required() = false` for `Chi2` normalization and
-  not propagating `w_required` / `variability_required` from phase features
+--
 
 ### Security
 
 --
+
+# [0.18.1] 2026 June 11
+
+### Fixed
+
+- Fix `Periodogram::add_phase_feature` not propagating `w_required` and `variability_required`
+  from phase features to the top-level `EvaluatorInfo`
+  https://github.com/light-curve/light-curve-feature/pull/300
+- Fix `MultiColorPeriodogram` reporting `is_w_required() = false` for `Chi2` normalization and
+  not propagating `w_required` / `variability_required` from phase features
+  https://github.com/light-curve/light-curve-feature/pull/300
 
 # [0.18.0] 2026 June 11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-curve-feature"
-version = "0.18.0"
+version = "0.18.1"
 description = "Feature extractor from noisy time series"
 categories = ["science"]
 keywords = ["astronomy", "time-series"]


### PR DESCRIPTION
Patch release bumping version to 0.18.1 and finalizing changelog.

Fixes shipped in #300:
- Fix `Periodogram::add_phase_feature` not propagating `w_required` and `variability_required` from phase features
- Fix `MultiColorPeriodogram` reporting `is_w_required() = false` for `Chi2` normalization