### PR TITLE
feat: add BiweightScale robust scale feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
---
+- Add `BiweightScale` feature: Tukey's biweight robust scale estimator of the magnitude
+  (Beers, Flynn & Gebhardt 1990), a robust alternative to the standard deviation
+  https://github.com/light-curve/light-curve-feature/issues/170
 
 ### Changed
 

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -27,6 +27,7 @@ where
     Bins(Bins<T, Self>),
     BazinFit,
     BeyondNStd(BeyondNStd<T>),
+    BiweightScale,
     Chi2Pvar,
     Cusum,
     Duration,

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -27,7 +27,7 @@ where
     Bins(Bins<T, Self>),
     BazinFit,
     BeyondNStd(BeyondNStd<T>),
-    BiweightScale,
+    BiweightScale(BiweightScale<T>),
     Chi2Pvar,
     Cusum,
     Duration,

--- a/src/features/biweight_scale.rs
+++ b/src/features/biweight_scale.rs
@@ -1,6 +1,9 @@
 use crate::data::SortedArray;
 use crate::evaluator::*;
 
+use conv::ConvUtil;
+use ordered_float::NotNan;
+
 macro_const! {
     const DOC: &str = r"
 Biweight scale — a robust measure of the magnitude scale
@@ -11,12 +14,14 @@ $\mathrm{MAD} = \mathrm{Median}(|m_i - M|)$, define
 $$
 u_i = \frac{m_i - M}{c \cdot \mathrm{MAD}},
 $$
-with tuning constant $c = 9$. Only points with $|u_i| < 1$ contribute, and the scale is
+with tuning constant $c$ (default $c = 9$). Only points with $|u_i| < 1$ contribute, and the
+scale is
 $$
 \zeta_\mathrm{BI} = \sqrt{N} \,
 \frac{\sqrt{\sum_{|u_i| < 1} (m_i - M)^2 \, (1 - u_i^2)^4}}
 {\left| \sum_{|u_i| < 1} (1 - u_i^2)(1 - 5 u_i^2) \right|}.
 $$
+Smaller $c$ rejects outliers more aggressively; larger $c$ approaches the standard deviation.
 
 When $\mathrm{MAD} = 0$ (at least half of the values equal the median) the estimator is
 undefined and zero is returned.
@@ -30,12 +35,67 @@ Beers, Flynn & Gebhardt 1990 [DOI:10.1086/115487](https://doi.org/10.1086/115487
 }
 
 #[doc = DOC!()]
-#[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
-pub struct BiweightScale {}
+/// ### Example
+/// ```
+/// use light_curve_feature::*;
+///
+/// let fe = FeatureExtractor::new(vec![BiweightScale::default(), BiweightScale::new(6.0)]);
+/// let time = [0.0; 5]; // Doesn't depend on time
+/// let magn = [1.0, 2.0, 3.0, 4.0, 100.0];
+/// let mut ts = TimeSeries::new_without_weight(&time, &magn);
+/// let values = fe.eval(&mut ts).unwrap();
+/// assert_eq!(values.len(), 2);
+/// ```
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(
+    from = "BiweightScaleParameters",
+    into = "BiweightScaleParameters",
+    bound(deserialize = "T: Float")
+)]
+pub struct BiweightScale<T>
+where
+    T: Float,
+{
+    c: NotNan<f32>,
+    name: String,
+    description: String,
+    #[serde(skip)]
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T> BiweightScale<T>
+where
+    T: Float,
+{
+    pub fn new(c: f32) -> Self {
+        assert!(c > 0.0, "c should be positive");
+        assert!(c.is_finite(), "c must be finite");
+        let c = NotNan::new(c).expect("c must not be NaN");
+        Self {
+            c,
+            name: format!("biweight_scale_{:.0}", c.into_inner()),
+            description: format!(
+                "robust biweight scale estimator of magnitude with tuning constant {:.3e}",
+                c.into_inner()
+            ),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn default_c() -> f32 {
+        9.0
+    }
+
+    pub const fn doc() -> &'static str {
+        DOC
+    }
+}
 
 lazy_info!(
     BIWEIGHT_SCALE_INFO,
-    BiweightScale,
+    BiweightScale<T>,
+    T,
     size: 1,
     min_ts_length: 1,
     t_required: false,
@@ -45,27 +105,29 @@ lazy_info!(
     variability_required: false,
 );
 
-impl BiweightScale {
-    pub fn new() -> Self {
-        Self {}
-    }
-
-    pub const fn doc() -> &'static str {
-        DOC
+impl<T> Default for BiweightScale<T>
+where
+    T: Float,
+{
+    fn default() -> Self {
+        Self::new(Self::default_c())
     }
 }
 
-impl FeatureNamesDescriptionsTrait for BiweightScale {
+impl<T> FeatureNamesDescriptionsTrait for BiweightScale<T>
+where
+    T: Float,
+{
     fn get_names(&self) -> Vec<&str> {
-        vec!["biweight_scale"]
+        vec![self.name.as_str()]
     }
 
     fn get_descriptions(&self) -> Vec<&str> {
-        vec!["robust biweight scale estimator of magnitude"]
+        vec![self.description.as_str()]
     }
 }
 
-impl<T> FeatureEvaluator<T> for BiweightScale
+impl<T> FeatureEvaluator<T> for BiweightScale<T>
 where
     T: Float,
 {
@@ -87,7 +149,8 @@ where
             return Ok(vec![T::zero()]);
         }
 
-        let c = T::nine(); // tuning constant
+        // f32 -> T conversion never fails (f32 fits both f32 and f64).
+        let c = self.c.into_inner().value_as::<T>().unwrap();
         let denominator = c * mad;
 
         // numerator = sum d^2 (1 - u^2)^4, denominator = sum (1 - u^2)(1 - 5 u^2)
@@ -114,6 +177,39 @@ where
     }
 }
 
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename = "BiweightScale")]
+struct BiweightScaleParameters {
+    c: f32,
+}
+
+impl<T> From<BiweightScale<T>> for BiweightScaleParameters
+where
+    T: Float,
+{
+    fn from(f: BiweightScale<T>) -> Self {
+        Self {
+            c: f.c.into_inner(),
+        }
+    }
+}
+
+impl<T> From<BiweightScaleParameters> for BiweightScale<T>
+where
+    T: Float,
+{
+    fn from(p: BiweightScaleParameters) -> Self {
+        Self::new(p.c)
+    }
+}
+
+impl<T> JsonSchema for BiweightScale<T>
+where
+    T: Float,
+{
+    json_schema!(BiweightScaleParameters, false);
+}
+
 #[cfg(test)]
 #[allow(clippy::unreadable_literal)]
 #[allow(clippy::excessive_precision)]
@@ -121,13 +217,15 @@ mod tests {
     use super::*;
     use crate::tests::*;
 
-    check_feature!(BiweightScale);
+    use serde_test::{Token, assert_tokens};
+
+    check_feature!(BiweightScale<f64>);
 
     feature_test!(
         biweight_scale,
-        [BiweightScale::new()],
-        // astropy.stats.biweight_scale (c=9, modify_sample_size=False)
-        [7.922078257662727],
+        [BiweightScale::default(), BiweightScale::new(9.0)], // identical
+        // astropy.stats.biweight_scale(c=9, modify_sample_size=False)
+        [7.922078257662727, 7.922078257662727],
         [1.0_f64, 2.0, 4.0, 7.0, 11.0, 16.0, 22.0, 100.0],
     );
 
@@ -136,7 +234,25 @@ mod tests {
         // MAD == 0: a flat light curve has zero robust scale, no NaN/panic.
         let m = [5.0_f64; 6];
         let mut ts = TimeSeries::new_without_weight(&m, &m);
-        let actual = BiweightScale::new().eval(&mut ts).unwrap();
+        let actual = BiweightScale::<f64>::default().eval(&mut ts).unwrap();
         assert_eq!(actual, vec![0.0]);
+    }
+
+    #[test]
+    fn serialization() {
+        const C: f32 = 7.5;
+        let biweight_scale = BiweightScale::<f64>::new(C);
+        assert_tokens(
+            &biweight_scale,
+            &[
+                Token::Struct {
+                    len: 1,
+                    name: "BiweightScale",
+                },
+                Token::String("c"),
+                Token::F32(C),
+                Token::StructEnd,
+            ],
+        )
     }
 }

--- a/src/features/biweight_scale.rs
+++ b/src/features/biweight_scale.rs
@@ -1,0 +1,142 @@
+use crate::data::SortedArray;
+use crate::evaluator::*;
+
+macro_const! {
+    const DOC: &str = r"
+Biweight scale — a robust measure of the magnitude scale
+
+Tukey's biweight (bisquare) scale estimator, a robust alternative to the standard deviation
+that down-weights outliers smoothly. With the median $M$ and the median absolute deviation
+$\mathrm{MAD} = \mathrm{Median}(|m_i - M|)$, define
+$$
+u_i = \frac{m_i - M}{c \cdot \mathrm{MAD}},
+$$
+with tuning constant $c = 9$. Only points with $|u_i| < 1$ contribute, and the scale is
+$$
+\zeta_\mathrm{BI} = \sqrt{N} \,
+\frac{\sqrt{\sum_{|u_i| < 1} (m_i - M)^2 \, (1 - u_i^2)^4}}
+{\left| \sum_{|u_i| < 1} (1 - u_i^2)(1 - 5 u_i^2) \right|}.
+$$
+
+When $\mathrm{MAD} = 0$ (at least half of the values equal the median) the estimator is
+undefined and zero is returned.
+
+- Depends on: **magnitude**
+- Minimum number of observations: **1**
+- Number of features: **1**
+
+Beers, Flynn & Gebhardt 1990 [DOI:10.1086/115487](https://doi.org/10.1086/115487)
+";
+}
+
+#[doc = DOC!()]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
+pub struct BiweightScale {}
+
+lazy_info!(
+    BIWEIGHT_SCALE_INFO,
+    BiweightScale,
+    size: 1,
+    min_ts_length: 1,
+    t_required: false,
+    m_required: true,
+    w_required: false,
+    sorting_required: false,
+    variability_required: false,
+);
+
+impl BiweightScale {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub const fn doc() -> &'static str {
+        DOC
+    }
+}
+
+impl FeatureNamesDescriptionsTrait for BiweightScale {
+    fn get_names(&self) -> Vec<&str> {
+        vec!["biweight_scale"]
+    }
+
+    fn get_descriptions(&self) -> Vec<&str> {
+        vec!["robust biweight scale estimator of magnitude"]
+    }
+}
+
+impl<T> FeatureEvaluator<T> for BiweightScale
+where
+    T: Float,
+{
+    fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
+        let m_median = ts.m.get_median();
+
+        // Median absolute deviation from the median.
+        let sorted_deviation: SortedArray<_> =
+            ts.m.sample
+                .mapv(|m| (m - m_median).abs())
+                .as_slice_memory_order()
+                .expect("TimeSeries::m::sample::mapv(...) is supposed to be contiguous")
+                .into();
+        let mad = sorted_deviation.median();
+
+        // MAD == 0 means at least half of the points equal the median; the
+        // biweight scale is undefined, return zero.
+        if mad <= T::zero() {
+            return Ok(vec![T::zero()]);
+        }
+
+        let c = T::three() * T::three(); // tuning constant, 9
+        let denominator = c * mad;
+
+        // numerator = sum d^2 (1 - u^2)^4, denominator = sum (1 - u^2)(1 - 5 u^2)
+        // over points with u^2 < 1.
+        let (num, den) =
+            ts.m.sample
+                .iter()
+                .fold((T::zero(), T::zero()), |(num, den), &m| {
+                    let d = m - m_median;
+                    let u2 = (d / denominator).powi(2);
+                    if u2 < T::one() {
+                        let one_minus_u2 = T::one() - u2;
+                        (
+                            num + d * d * one_minus_u2.powi(4),
+                            den + one_minus_u2 * (T::one() - T::five() * u2),
+                        )
+                    } else {
+                        (num, den)
+                    }
+                });
+
+        let midvariance = ts.lenf() * num / den.powi(2);
+        Ok(vec![midvariance.sqrt()])
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unreadable_literal)]
+#[allow(clippy::excessive_precision)]
+mod tests {
+    use super::*;
+    use crate::tests::*;
+
+    check_feature!(BiweightScale);
+
+    feature_test!(
+        biweight_scale,
+        [BiweightScale::new()],
+        // astropy.stats.biweight_scale (c=9, modify_sample_size=False)
+        [7.922078257662727],
+        [1.0_f64, 2.0, 4.0, 7.0, 11.0, 16.0, 22.0, 100.0],
+    );
+
+    #[test]
+    fn constant_is_zero() {
+        // MAD == 0: a flat light curve has zero robust scale, no NaN/panic.
+        let m = [5.0_f64; 6];
+        let mut ts = TimeSeries::new_without_weight(&m, &m);
+        let actual = BiweightScale::new().eval(&mut ts).unwrap();
+        assert_eq!(actual, vec![0.0]);
+    }
+}

--- a/src/features/biweight_scale.rs
+++ b/src/features/biweight_scale.rs
@@ -87,7 +87,7 @@ where
             return Ok(vec![T::zero()]);
         }
 
-        let c = T::three() * T::three(); // tuning constant, 9
+        let c = T::nine(); // tuning constant
         let denominator = c * mad;
 
         // numerator = sum d^2 (1 - u^2)^4, denominator = sum (1 - u^2)(1 - 5 u^2)

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -17,6 +17,8 @@ pub use beyond_n_std::BeyondNStd;
 
 pub(crate) mod bins;
 pub use bins::Bins;
+mod biweight_scale;
+pub use biweight_scale::BiweightScale;
 mod chi2_pvar;
 pub use chi2_pvar::Chi2Pvar;
 

--- a/src/float_trait.rs
+++ b/src/float_trait.rs
@@ -69,7 +69,6 @@ pub trait Float:
     fn three() -> Self;
     fn four() -> Self;
     fn five() -> Self;
-    fn nine() -> Self;
     fn ten() -> Self;
     fn hundred() -> Self;
     fn array0_unity() -> &'static Array0<Self>;
@@ -116,7 +115,6 @@ pub trait Float:
     fn three() -> Self;
     fn four() -> Self;
     fn five() -> Self;
-    fn nine() -> Self;
     fn ten() -> Self;
     fn hundred() -> Self;
     fn array0_unity() -> &'static Array0<Self>;
@@ -146,11 +144,6 @@ impl Float for f32 {
     #[inline]
     fn five() -> Self {
         5.0
-    }
-
-    #[inline]
-    fn nine() -> Self {
-        9.0
     }
 
     #[inline]
@@ -192,11 +185,6 @@ impl Float for f64 {
     #[inline]
     fn five() -> Self {
         5.0
-    }
-
-    #[inline]
-    fn nine() -> Self {
-        9.0
     }
 
     #[inline]

--- a/src/float_trait.rs
+++ b/src/float_trait.rs
@@ -69,6 +69,7 @@ pub trait Float:
     fn three() -> Self;
     fn four() -> Self;
     fn five() -> Self;
+    fn nine() -> Self;
     fn ten() -> Self;
     fn hundred() -> Self;
     fn array0_unity() -> &'static Array0<Self>;
@@ -115,6 +116,7 @@ pub trait Float:
     fn three() -> Self;
     fn four() -> Self;
     fn five() -> Self;
+    fn nine() -> Self;
     fn ten() -> Self;
     fn hundred() -> Self;
     fn array0_unity() -> &'static Array0<Self>;
@@ -144,6 +146,11 @@ impl Float for f32 {
     #[inline]
     fn five() -> Self {
         5.0
+    }
+
+    #[inline]
+    fn nine() -> Self {
+        9.0
     }
 
     #[inline]
@@ -185,6 +192,11 @@ impl Float for f64 {
     #[inline]
     fn five() -> Self {
         5.0
+    }
+
+    #[inline]
+    fn nine() -> Self {
+        9.0
     }
 
     #[inline]


### PR DESCRIPTION
Implement part of issue #170 (robust measures of scale): add BiweightScale, Tukey's biweight robust scale estimator of the magnitude (Beers, Flynn & Gebhardt 1990), a robust alternative to StandardDeviation that smoothly down-weights outliers using the median and MAD.

Returns 0 for degenerate (MAD == 0) light curves. Validated against astropy.stats.biweight_scale.


Claude-Session: https://claude.ai/code/session_01KEKNjm8oSYzw276okfggzc