### PR TITLE
Add RainbowFit: multi-band Rainbow model fit (bolometric envelope x temperature-dependent SED)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - run: cargo build --all-targets --features gsl,fftw-source --no-default-features
       - run: cargo build --all-targets --features gsl,fftw-system --no-default-features
       - run: cargo build --all-targets --features gsl,fftw-mkl --no-default-features
-      - run: cargo build --all-targets --features gsl,fftw-source,ceres-source --no-default-features
+      - run: cargo build --all-targets --features gsl,fftw-source,ceres-source,rainbow --no-default-features
       - run: cargo build --all-targets --features fftw-source,ceres-source --no-default-features
       # Build without FFTW (RustFFT-only)
       - run: cargo build --all-targets --no-default-features
@@ -55,7 +55,7 @@ jobs:
         with:
           shared-key: "msrv"
       # Build "normal" target only, see https://github.com/light-curve/light-curve-feature/issues/74
-      - run: cargo +${{ steps.get_msrv.outputs.msrv }} build --no-default-features --features ceres-source,fftw-source,gsl
+      - run: cargo +${{ steps.get_msrv.outputs.msrv }} build --no-default-features --features ceres-source,fftw-source,gsl,rainbow
 
   test:
     runs-on: ${{ matrix.os }}
@@ -78,7 +78,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "stable"
-      - run: cargo test --no-default-features --features=ceres-source,fftw-source,gsl
+      - run: cargo test --no-default-features --features=ceres-source,fftw-source,gsl,rainbow
 
   test-release:
     runs-on: ubuntu-latest
@@ -97,7 +97,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "stable"
-      - run: cargo test --profile=release-with-debug --no-default-features --features=ceres-source,fftw-source,gsl
+      - run: cargo test --profile=release-with-debug --no-default-features --features=ceres-source,fftw-source,gsl,rainbow
 
   examples:
     runs-on: ubuntu-latest
@@ -145,7 +145,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "stable"
-      - run: cargo clippy --all-targets --no-default-features --features=ceres-source,fftw-source,gsl -- -D warnings
+      - run: cargo clippy --all-targets --no-default-features --features=ceres-source,fftw-source,gsl,rainbow -- -D warnings
 
   fmt-test-util:
     runs-on: ubuntu-latest
@@ -201,7 +201,7 @@ jobs:
           sudo apt-get install -y libfftw3-dev libgsl-dev libfontconfig-dev
       - name: Generate code coverage
         run: |
-          cargo llvm-cov --no-report --no-default-features --features=ceres-source,fftw-system,gsl
+          cargo llvm-cov --no-report --no-default-features --features=ceres-source,fftw-system,gsl,rainbow
           cargo llvm-cov run --example=plot_snia_curve_fits --no-report --no-default-features --features=ceres-source,fftw-source,gsl -- -n=1
           cargo llvm-cov report --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
@@ -227,7 +227,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "macos"
-      - run: cargo build --all-targets --no-default-features --features=ceres-source,fftw-source,gsl
+      - run: cargo build --all-targets --no-default-features --features=ceres-source,fftw-source,gsl,rainbow
 
   windows:
     runs-on: windows-latest
@@ -258,4 +258,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "windows"
-      - run: cargo test --no-default-features --features=ceres-system,gsl
+      - run: cargo test --no-default-features --features=ceres-system,gsl,rainbow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   counts) and `Rejection` (i.i.d. resampling with bounded rejection of resamples that fail the
   wrapped features' per-band requirements)
   https://github.com/light-curve/light-curve-feature/issues/285
+- Add `RainbowFit` multi-color feature (opt-in `rainbow` Cargo feature): joint multi-band fit of
+  a bolometric envelope times a temperature-dependent spectral energy distribution (the "Rainbow"
+  model, Russeil et al. 2023). Bolometric in {Bazin, Sigmoid, Doublexp}, temperature in
+  {Constant, Sigmoid, DelayedSigmoid}, spectral in {Planck, GenWien, ModifiedBlackBody,
+  LogParabola}, plus an optional per-band additive baseline; returns fitted parameters, their
+  1-sigma (Gauss-Newton) uncertainties, and reduced chi2. Adds `PassbandTrait::wavelength()`
+  (default `None`) so wavelength-aware features can participate in the generic
+  `MultiColorFeature<P, T>` registry. First pure-Rust linear-algebra dependency in the crate
+  (`levenberg-marquardt`/`nalgebra`), hence the opt-in feature gate rather than `default`.
+  `bolometric = "linexp"` and `spectral = "blanketed"` from the Python reference are not ported
+  (see the `multicolor::rainbow` module docs for why)
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ fftw-system = ["fftw", "fftw/system"]
 fftw-source = ["fftw", "fftw/source"]
 fftw-mkl = ["fftw", "fftw/intel-mkl"]
 gsl = ["GSL/v2_1"]
+# Enables the multi-band `RainbowFit` feature. This is the first pure-Rust linear-algebra
+# dependency in the crate (via `levenberg-marquardt`/`nalgebra`), so it is opt-in like the
+# GSL/Ceres-backed fits, rather than part of `default`.
+rainbow = ["dep:levenberg-marquardt", "dep:nalgebra"]
 
 [profile.release]
 lto = true
@@ -46,8 +50,13 @@ rustfft = "6.2"
 GSL = { version = "^7", default-features = false, optional = true }
 itertools = "^0.15"
 lazy_static = "^1.4"
+levenberg-marquardt = { version = "0.15.0", optional = true }
 libm = "^0.2"
 macro_const = "^0.1"
+# Pinned exactly: `levenberg-marquardt` 0.15.0 depends on nalgebra 0.34.2 specifically, and a
+# second nalgebra version in the dependency tree would break `LeastSquaresProblem` impls across
+# the version boundary.
+nalgebra = { version = "=0.34.2", optional = true }
 ndarray = { version = "^0.17", features = ["serde"] }
 ndarray-stats = "^0.7"
 num-complex = "^0.4"
@@ -102,4 +111,4 @@ rustdoc-args = [
     "katex-header.html",
 ]
 no-default-features = true
-features = ["ceres-source", "fftw-system", "gsl"]
+features = ["ceres-source", "fftw-system", "gsl", "rainbow"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,9 @@ pub enum EvaluatorError {
         "too few valid bootstrap resamples: {actual} obtained, at least {minimum} required to estimate the uncertainty"
     )]
     InsufficientResamples { actual: usize, minimum: usize },
+
+    #[error("non-linear fit did not converge")]
+    FitDidNotConverge,
 }
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]

--- a/src/multicolor/mod.rs
+++ b/src/multicolor/mod.rs
@@ -23,7 +23,5 @@ pub use passband::*;
 
 #[cfg(feature = "rainbow")]
 mod rainbow;
-// TODO(next commit): re-export RainbowFit once the public struct lands.
 #[cfg(feature = "rainbow")]
-#[allow(unused_imports)]
-use rainbow::terms;
+pub use rainbow::{Bolometric, RainbowFit, RainbowFitError, Spectral, Temperature};

--- a/src/multicolor/mod.rs
+++ b/src/multicolor/mod.rs
@@ -20,3 +20,10 @@ pub use multicolor_feature::MultiColorFeature;
 
 mod passband;
 pub use passband::*;
+
+#[cfg(feature = "rainbow")]
+mod rainbow;
+// TODO(next commit): re-export RainbowFit once the public struct lands.
+#[cfg(feature = "rainbow")]
+#[allow(unused_imports)]
+use rainbow::terms;

--- a/src/multicolor/multicolor_feature.rs
+++ b/src/multicolor/multicolor_feature.rs
@@ -2,6 +2,8 @@ use crate::data::{MultiColorTimeSeries, TimeSeries};
 use crate::error::MultiColorEvaluatorError;
 use crate::evaluator::{EvaluatorInfoTrait, FeatureNamesDescriptionsTrait};
 use crate::float_trait::Float;
+#[cfg(feature = "rainbow")]
+use crate::multicolor::RainbowFit;
 use crate::multicolor::features::{
     ColorOfMaximum, ColorOfMedian, ColorOfMinimum, ColorSpread, MultiColorPeriodogram,
 };
@@ -34,6 +36,8 @@ where
     MultiColorPeriodogram(MultiColorPeriodogram<P, T, Feature<T>>),
     MultiColorBins(MultiColorBins<P, T>),
     MultiColorBootstrap(MultiColorBootstrap<P, T>),
+    #[cfg(feature = "rainbow")]
+    RainbowFit(RainbowFit<P, T>),
 }
 
 impl<P, T> MultiColorFeature<P, T>

--- a/src/multicolor/passband/monochrome_passband.rs
+++ b/src/multicolor/passband/monochrome_passband.rs
@@ -74,6 +74,10 @@ where
     fn name(&self) -> &str {
         self.name
     }
+
+    fn wavelength(&self) -> Option<f64> {
+        Some(self.wavelength.value_into().unwrap())
+    }
 }
 
 #[cfg(test)]
@@ -85,5 +89,6 @@ mod tests {
         let passband = MonochromePassband::new(1.0, "test");
         assert_eq!(passband.name(), "test");
         assert_eq!(passband.wavelength, 1.0);
+        assert_eq!(PassbandTrait::wavelength(&passband), Some(1.0));
     }
 }

--- a/src/multicolor/passband/passband_trait.rs
+++ b/src/multicolor/passband/passband_trait.rs
@@ -7,11 +7,9 @@ pub trait PassbandTrait: Debug + Clone + Send + Sync + Ord + Serialize + JsonSch
 
     /// Effective wavelength of the passband, in cm, if known.
     ///
-    /// Defaults to `None` so existing implementors (e.g. [StringPassband](super::StringPassband),
-    /// which only carries a label) are unaffected. Wavelength-aware features such as `RainbowFit`
-    /// require it and reject passbands that return `None` at evaluation time, the same way any
-    /// other feature rejects a passband it can't use. [MonochromePassband](super::MonochromePassband)
-    /// overrides this to return its wavelength.
+    /// Defaults to `None` so existing implementors (e.g. [StringPassband](super::StringPassband))
+    /// are unaffected; [MonochromePassband](super::MonochromePassband) overrides it.
+    /// Wavelength-aware features like `RainbowFit` reject passbands that return `None`.
     fn wavelength(&self) -> Option<f64> {
         None
     }

--- a/src/multicolor/passband/passband_trait.rs
+++ b/src/multicolor/passband/passband_trait.rs
@@ -4,4 +4,15 @@ use std::fmt::Debug;
 
 pub trait PassbandTrait: Debug + Clone + Send + Sync + Ord + Serialize + JsonSchema {
     fn name(&self) -> &str;
+
+    /// Effective wavelength of the passband, in cm, if known.
+    ///
+    /// Defaults to `None` so existing implementors (e.g. [StringPassband](super::StringPassband),
+    /// which only carries a label) are unaffected. Wavelength-aware features such as `RainbowFit`
+    /// require it and reject passbands that return `None` at evaluation time, the same way any
+    /// other feature rejects a passband it can't use. [MonochromePassband](super::MonochromePassband)
+    /// overrides this to return its wavelength.
+    fn wavelength(&self) -> Option<f64> {
+        None
+    }
 }

--- a/src/multicolor/passband/string_passband.rs
+++ b/src/multicolor/passband/string_passband.rs
@@ -36,6 +36,8 @@ mod tests {
         let band = StringPassband::from("r");
         assert_eq!(band.name(), "r");
         assert_eq!(band.0, "r");
+        // No wavelength override: falls back to PassbandTrait's default.
+        assert_eq!(band.wavelength(), None);
     }
 
     #[test]

--- a/src/multicolor/rainbow/constants.rs
+++ b/src/multicolor/rainbow/constants.rs
@@ -1,0 +1,10 @@
+//! CGS physical constants (CODATA 2018) used by [super::terms::spectral]'s blackbody-family SEDs.
+
+/// Planck constant, erg*s
+pub const PLANCK_H: f64 = 6.62607004e-27;
+/// Speed of light, cm/s
+pub const SPEED_OF_LIGHT: f64 = 2.99792458e10;
+/// Boltzmann constant, erg/K
+pub const BOLTZMANN_K: f64 = 1.380649e-16;
+/// Stefan-Boltzmann constant, erg/(cm^2 s K^4)
+pub const SIGMA_SB: f64 = 5.6703744191844314e-05;

--- a/src/multicolor/rainbow/fit.rs
+++ b/src/multicolor/rainbow/fit.rs
@@ -59,7 +59,10 @@ fn internal_to_external(u: &DVector<f64>, bounds: &[(f64, f64)]) -> (Vec<f64>, V
 fn external_to_internal(external: &[f64], bounds: &[(f64, f64)]) -> DVector<f64> {
     DVector::from_iterator(
         bounds.len(),
-        external.iter().zip(bounds).map(|(&e, &(lower, upper))| inverse_bounded_transform(e, lower, upper)),
+        external
+            .iter()
+            .zip(bounds)
+            .map(|(&e, &(lower, upper))| inverse_bounded_transform(e, lower, upper)),
     )
 }
 
@@ -98,13 +101,14 @@ fn covariance_from_jacobian(
     }
     let jtj = j.transpose() * &j;
 
-    if let Some(inv) = jtj.clone().try_inverse() {
-        if inv.diagonal().iter().all(|&x| x.is_finite() && x > 0.0) {
-            return inv;
-        }
+    if let Some(inv) = jtj.clone().try_inverse()
+        && inv.diagonal().iter().all(|&x| x.is_finite() && x > 0.0)
+    {
+        return inv;
     }
     let svd = jtj.svd(true, true);
-    svd.pseudo_inverse(1e-12).unwrap_or_else(|_| DMatrix::from_element(n_params, n_params, f64::NAN))
+    svd.pseudo_inverse(1e-12)
+        .unwrap_or_else(|_| DMatrix::from_element(n_params, n_params, f64::NAN))
 }
 
 struct RainbowFitProblem<'a> {
@@ -147,7 +151,9 @@ impl<'a> LeastSquaresProblem<f64, Dyn, Dyn> for RainbowFitProblem<'a> {
         let n_params = params.len();
         let mut j = OMatrix::<f64, Dyn, Dyn>::zeros(n, n_params);
         for i in 0..n {
-            let (_, grad) = self.model.model_and_gradient(self.t[i], self.band_idx[i], &params);
+            let (_, grad) = self
+                .model
+                .model_and_gradient(self.t[i], self.band_idx[i], &params);
             for k in 0..n_params {
                 j[(i, k)] = grad[k] * dext_du[k] / self.flux_err[i];
             }
@@ -162,11 +168,11 @@ pub(crate) struct FitResult {
     pub(crate) params: Vec<f64>,
     /// 1-sigma uncertainty on each parameter (same order as `params`), from the Gauss-Newton
     /// covariance approximation. See [`covariance_from_jacobian`] for the method and its caveats
-    /// around genuinely degenerate parameters.
+    /// around genuinely degenerate parameters. (The full covariance matrix, off-diagonal
+    /// correlations included, is computed as an intermediate value but not currently surfaced
+    /// here -- a flat per-parameter matrix doesn't fit this crate's flat named-scalar feature
+    /// output convention. Easy to add later if a use for it comes up.)
     pub(crate) errors: Vec<f64>,
-    /// Full parameter covariance matrix (`covariance[i][j]`), same order and method as `errors`
-    /// (whose entries are `sqrt(covariance[i][i])`).
-    pub(crate) covariance: Vec<Vec<f64>>,
     pub(crate) reduced_chi2: f64,
     pub(crate) success: bool,
 }
@@ -178,7 +184,13 @@ pub(crate) struct FitResult {
 /// -- real light curves are sometimes too sparse) instead returns a [`FitResult`] with
 /// `success: false` and NaN-filled outputs, so callers don't need to pre-check `t.len()`
 /// themselves.
-pub(crate) fn fit(model: &RainbowModel, t: &[f64], flux: &[f64], flux_err: &[f64], band_idx: &[usize]) -> FitResult {
+pub(crate) fn fit(
+    model: &RainbowModel,
+    t: &[f64],
+    flux: &[f64],
+    flux_err: &[f64],
+    band_idx: &[usize],
+) -> FitResult {
     assert_eq!(t.len(), flux.len());
     assert_eq!(t.len(), flux_err.len());
     assert_eq!(t.len(), band_idx.len());
@@ -188,7 +200,6 @@ pub(crate) fn fit(model: &RainbowModel, t: &[f64], flux: &[f64], flux_err: &[f64
         return FitResult {
             params: vec![f64::NAN; n_params],
             errors: vec![f64::NAN; n_params],
-            covariance: vec![vec![f64::NAN; n_params]; n_params],
             reduced_chi2: f64::NAN,
             success: false,
         };
@@ -198,7 +209,15 @@ pub(crate) fn fit(model: &RainbowModel, t: &[f64], flux: &[f64], flux_err: &[f64
     let guess = model.initial_guess(t, flux, flux_err, band_idx);
     let u0 = external_to_internal(&guess, &bounds);
 
-    let problem = RainbowFitProblem { model, t, flux, flux_err, band_idx, bounds, u: u0 };
+    let problem = RainbowFitProblem {
+        model,
+        t,
+        flux,
+        flux_err,
+        band_idx,
+        bounds,
+        u: u0,
+    };
 
     let (solved, report) = LevenbergMarquardt::new().minimize(problem);
     let (params, _) = internal_to_external(&solved.u, &solved.bounds);
@@ -209,26 +228,41 @@ pub(crate) fn fit(model: &RainbowModel, t: &[f64], flux: &[f64], flux_err: &[f64
 
     let cov = covariance_from_jacobian(model, t, flux_err, band_idx, &params);
     let errors: Vec<f64> = cov.diagonal().iter().map(|&v| v.max(0.0).sqrt()).collect();
-    let covariance: Vec<Vec<f64>> =
-        (0..params.len()).map(|i| (0..params.len()).map(|j| cov[(i, j)]).collect()).collect();
 
-    FitResult { params, errors, covariance, reduced_chi2, success: report.termination.was_successful() }
+    FitResult {
+        params,
+        errors,
+        reduced_chi2,
+        success: report.termination.was_successful(),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::model::Band;
     use super::super::terms::{Bolometric, Spectral, Temperature};
+    use super::*;
     use levenberg_marquardt::differentiate_numerically;
 
     #[test]
     fn analytic_jacobian_matches_numerical_differentiation() {
         let bands = vec![
-            Band { name: "g".to_string(), wavelength_cm: 4770.0e-8 },
-            Band { name: "r".to_string(), wavelength_cm: 6231.0e-8 },
+            Band {
+                name: "g".to_string(),
+                wavelength_cm: 4770.0e-8,
+            },
+            Band {
+                name: "r".to_string(),
+                wavelength_cm: 6231.0e-8,
+            },
         ];
-        let model = RainbowModel::new(Bolometric::Bazin, Temperature::Sigmoid, Spectral::Planck, bands, false);
+        let model = RainbowModel::new(
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            bands,
+            false,
+        );
 
         let t: Vec<f64> = (0..20).map(|i| i as f64 * 3.0).collect();
         let band_idx: Vec<usize> = (0..20).map(|i| i % 2).collect();
@@ -239,8 +273,15 @@ mod tests {
         let truth_external = [30.0, 100.0, 5.0, 20.0, 9000.0, 0.1, 6.0];
         let u = external_to_internal(&truth_external, &bounds);
 
-        let mut problem =
-            RainbowFitProblem { model: &model, t: &t, flux: &flux, flux_err: &flux_err, band_idx: &band_idx, bounds, u };
+        let mut problem = RainbowFitProblem {
+            model: &model,
+            t: &t,
+            flux: &flux,
+            flux_err: &flux_err,
+            band_idx: &band_idx,
+            bounds,
+            u,
+        };
 
         let analytic = problem.jacobian().unwrap();
         let numeric = differentiate_numerically(&mut problem).unwrap();
@@ -250,7 +291,10 @@ mod tests {
             for j in 0..analytic.ncols() {
                 let a = analytic[(i, j)];
                 let n = numeric[(i, j)];
-                assert!((a - n).abs() <= 1e-4 * n.abs().max(1.0), "jacobian[{i},{j}]: analytic={a}, numeric={n}");
+                assert!(
+                    (a - n).abs() <= 1e-4 * n.abs().max(1.0),
+                    "jacobian[{i},{j}]: analytic={a}, numeric={n}"
+                );
             }
         }
     }
@@ -258,11 +302,26 @@ mod tests {
     #[test]
     fn too_few_points_returns_failure_instead_of_panicking() {
         let bands = vec![
-            Band { name: "g".to_string(), wavelength_cm: 4770.0e-8 },
-            Band { name: "r".to_string(), wavelength_cm: 6231.0e-8 },
-            Band { name: "i".to_string(), wavelength_cm: 7625.0e-8 },
+            Band {
+                name: "g".to_string(),
+                wavelength_cm: 4770.0e-8,
+            },
+            Band {
+                name: "r".to_string(),
+                wavelength_cm: 6231.0e-8,
+            },
+            Band {
+                name: "i".to_string(),
+                wavelength_cm: 7625.0e-8,
+            },
         ];
-        let model = RainbowModel::new(Bolometric::Bazin, Temperature::Sigmoid, Spectral::Planck, bands, false);
+        let model = RainbowModel::new(
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            bands,
+            false,
+        );
 
         let t = vec![0.0, 1.0, 2.0];
         let flux = vec![1.0, 2.0, 1.5];

--- a/src/multicolor/rainbow/fit.rs
+++ b/src/multicolor/rainbow/fit.rs
@@ -1,25 +1,17 @@
 //! Levenberg-Marquardt fitting of the [`RainbowModel`].
 //!
-//! Every physical parameter is fit through an unconstrained "internal" optimizer variable `u`,
-//! reparametrized to always land inside the parameter's `(lower, upper)` box bounds via a
-//! logistic (sigmoid) map: `external = lower + (upper - lower) / (1 + exp(-u))`. This is the same
-//! idea Python's `iminuit`/MINUIT uses internally for bounded parameters (and the same spirit as
-//! this crate's own [`nl_fit`](crate::nl_fit) module's internal/external parameter-space split),
-//! but expressed as a single transform instead of separate data-normalization and sign-only
-//! reparametrization steps: since `u`'s scale only depends on where the true value sits within
-//! its bound interval (not on the parameter's physical magnitude), no separate data-normalization
-//! ("dimensionless") layer is needed for optimizer conditioning.
+//! Parameters are optimized in an unconstrained internal space `u`, mapped into each
+//! parameter's `(lower, upper)` bounds via a logistic transform:
+//! `external = lower + (upper - lower) / (1 + exp(-u))` -- the same idea iminuit uses
+//! internally for bounded parameters.
 //!
-//! This is why Rainbow does not use [`nl_fit`](crate::nl_fit)/[`CurveFitAlgorithm`](crate::nl_fit::CurveFitAlgorithm):
-//! that machinery is built around a compile-time-fixed `const NPARAMS: usize` (fixed-size
-//! `[f64; NPARAMS]` arrays throughout), whereas Rainbow's parameter count varies with the chosen
-//! bolometric/temperature/spectral term combination. The optimizer here is `levenberg-marquardt`
-//! (a pure-Rust, `nalgebra`-based Levenberg-Marquardt implementation) working with dynamically
-//! (`Dyn`)-sized vectors/matrices instead.
+//! Uses the `levenberg-marquardt` crate (pure Rust, `nalgebra`-based, `Dyn`-sized) rather than
+//! this crate's own [`nl_fit`](crate::nl_fit), because `nl_fit` assumes a compile-time-fixed
+//! `NPARAMS`, while Rainbow's parameter count depends on the chosen term combination.
 //!
-//! Bounds themselves are physical-unit and mostly data-dependent (e.g. `rise_time`'s upper bound
-//! scales with the light curve's time span); they're computed once per fit from
-//! `super::terms::{Bolometric, Temperature, Spectral}::bounds()`.
+//! Bounds are physical-unit and data-dependent (e.g. `rise_time`'s upper bound scales with the
+//! light curve's time span); computed per fit by `super::terms::{Bolometric, Temperature,
+//! Spectral}::bounds()`.
 
 use levenberg_marquardt::{LeastSquaresProblem, LevenbergMarquardt};
 use nalgebra::{DMatrix, DVector, Dyn, OMatrix, storage::Owned};
@@ -66,23 +58,12 @@ fn external_to_internal(external: &[f64], bounds: &[(f64, f64)]) -> DVector<f64>
     )
 }
 
-/// Parameter covariance matrix from the Gauss-Newton approximation `inv(JᵀJ)` at the converged
-/// solution, where `J` is `d(residual)/d(external param)` (residuals already weighted by
-/// `1/flux_err`). Mirrors Python's `_lsq_covariance`: the same construction scipy's `curve_fit`
-/// uses with `absolute_sigma=True` -- no rescaling by `reduced_chi2`.
+/// Parameter covariance `inv(JᵀJ)` (Gauss-Newton approximation), reusing the fit's own
+/// per-point gradient -- same convention as `scipy.curve_fit`'s `absolute_sigma=True`.
 ///
-/// Cheap: this is one extra pass over the data building an `n_points x n_params` Jacobian (the
-/// same per-point gradient the fit already computes every iteration) plus inverting an
-/// `n_params x n_params` matrix (at most ~10x10 for the richest term combinations), done once
-/// after convergence.
-///
-/// Falls back to the Moore-Penrose pseudo-inverse when `JᵀJ` is singular or non-positive-definite
-/// -- that signals an unidentified parameter direction (a genuine degeneracy, e.g. two
-/// parameters that trade off perfectly given this data), not a failed fit, so a best-effort
-/// covariance is still returned. Caveat (same as Python's): the pseudo-inverse reports a
-/// *near-zero* variance for a fully unconstrained direction, which understates the true
-/// uncertainty there -- the fitted parameters and chi2 are unaffected, only that direction's
-/// error bar is unreliable.
+/// Falls back to the pseudo-inverse when `JᵀJ` is singular (a degenerate parameter direction,
+/// not a failed fit); that direction's reported error will then read as near-zero rather than
+/// its true, unconstrained uncertainty.
 fn covariance_from_jacobian(
     model: &RainbowModel,
     t: &[f64],
@@ -166,43 +147,28 @@ impl<'a> LeastSquaresProblem<f64, Dyn, Dyn> for RainbowFitProblem<'a> {
 pub(crate) struct FitResult {
     /// Fitted physical parameters, in [`RainbowModel::param_names`] order.
     pub(crate) params: Vec<f64>,
-    /// 1-sigma uncertainty on each parameter (same order as `params`), from the Gauss-Newton
-    /// covariance approximation. See [`covariance_from_jacobian`] for the method and its caveats
-    /// around genuinely degenerate parameters. (The full covariance matrix, off-diagonal
-    /// correlations included, is computed as an intermediate value but not currently surfaced
-    /// here -- a flat per-parameter matrix doesn't fit this crate's flat named-scalar feature
-    /// output convention. Easy to add later if a use for it comes up.)
+    /// 1-sigma uncertainty per parameter, same order as `params`. See
+    /// [`covariance_from_jacobian`].
     pub(crate) errors: Vec<f64>,
     pub(crate) reduced_chi2: f64,
     pub(crate) success: bool,
 }
 
-/// Jointly fits all bands' flux observations `(t, flux, flux_err, band_idx)` to `model`.
+/// Jointly fits all bands' `(t, flux, flux_err, band_idx)` to `model`.
 ///
-/// `band_idx[i]` must index into `model`'s bands. Mismatched array lengths are a caller bug and
-/// panic; too few data points to constrain the model (a normal data-quality condition, not a bug
-/// -- real light curves are sometimes too sparse) instead returns a [`FitResult`] with
-/// `success: false` and NaN-filled outputs, so callers don't need to pre-check `t.len()`
-/// themselves.
+/// Too few points to constrain the model returns `success: false` with NaN outputs rather than
+/// panicking -- sparse real light curves are a normal data-quality issue, not a bug.
 ///
-/// Uses a looser convergence tolerance than `levenberg-marquardt`'s default (`1e-8`, matching
-/// `scipy.optimize.curve_fit`/iminuit's usual convention, rather than the crate's default of
-/// `f64::EPSILON * 30 ≈ 6.7e-15`): on real, noisy light curves the default is tight enough that
-/// the optimizer routinely exhausts its evaluation budget (`LostPatience`) without ever
-/// satisfying it, even after it has already reached essentially the same point a looser
-/// tolerance would accept as converged -- i.e. the fit was fine, just mislabeled as failed. The
-/// evaluation budget (`patience`) is raised to match, so the looser tolerance actually gets a
-/// chance to be reached on harder fits rather than hitting the (now effectively unchanged)
-/// absolute evaluation cap first.
+/// Uses `tol=1e-8` (`scipy.curve_fit`/iminuit convention), looser than
+/// `levenberg-marquardt`'s default (`~6.7e-15`): the default is tight enough that real, noisy
+/// data routinely exhausts the evaluation budget (`LostPatience`) after already reaching
+/// essentially its final point -- a mislabeled success, not an actual failure. Patience is
+/// raised to match, so harder fits get a real chance to reach the looser tolerance.
 ///
-/// Deliberately does *not* retry from jittered starting points on failure: tried it (see git
-/// history), and on every real non-converging light curve tested it either reproduced the same
-/// point or landed somewhere worse, while roughly doubling worst-case runtime on exactly the
-/// hardest fits (each retry re-running up to the full evaluation budget). A light curve that's
-/// still `LostPatience` after this tolerance/budget is either genuinely too sparse to constrain
-/// the model, or (like one observed case) converging so slowly that reaching the tolerance would
-/// cost seconds for a <0.1% change in the objective -- in both cases `success: false` is the
-/// more honest answer than spending that time to relabel an unchanged result.
+/// No retry from jittered starting points on failure: tried it, and across every real
+/// non-converging light curve found, retries never beat the first attempt while roughly
+/// doubling worst-case runtime. A fit still `LostPatience` after this is genuinely
+/// underconstrained or converging too slowly for the extra time to be worth it.
 pub(crate) fn fit(
     model: &RainbowModel,
     t: &[f64],

--- a/src/multicolor/rainbow/fit.rs
+++ b/src/multicolor/rainbow/fit.rs
@@ -1,0 +1,276 @@
+//! Levenberg-Marquardt fitting of the [`RainbowModel`].
+//!
+//! Every physical parameter is fit through an unconstrained "internal" optimizer variable `u`,
+//! reparametrized to always land inside the parameter's `(lower, upper)` box bounds via a
+//! logistic (sigmoid) map: `external = lower + (upper - lower) / (1 + exp(-u))`. This is the same
+//! idea Python's `iminuit`/MINUIT uses internally for bounded parameters (and the same spirit as
+//! this crate's own [`nl_fit`](crate::nl_fit) module's internal/external parameter-space split),
+//! but expressed as a single transform instead of separate data-normalization and sign-only
+//! reparametrization steps: since `u`'s scale only depends on where the true value sits within
+//! its bound interval (not on the parameter's physical magnitude), no separate data-normalization
+//! ("dimensionless") layer is needed for optimizer conditioning.
+//!
+//! This is why Rainbow does not use [`nl_fit`](crate::nl_fit)/[`CurveFitAlgorithm`](crate::nl_fit::CurveFitAlgorithm):
+//! that machinery is built around a compile-time-fixed `const NPARAMS: usize` (fixed-size
+//! `[f64; NPARAMS]` arrays throughout), whereas Rainbow's parameter count varies with the chosen
+//! bolometric/temperature/spectral term combination. The optimizer here is `levenberg-marquardt`
+//! (a pure-Rust, `nalgebra`-based Levenberg-Marquardt implementation) working with dynamically
+//! (`Dyn`)-sized vectors/matrices instead.
+//!
+//! Bounds themselves are physical-unit and mostly data-dependent (e.g. `rise_time`'s upper bound
+//! scales with the light curve's time span); they're computed once per fit from
+//! `super::terms::{Bolometric, Temperature, Spectral}::bounds()`.
+
+use levenberg_marquardt::{LeastSquaresProblem, LevenbergMarquardt};
+use nalgebra::{DMatrix, DVector, Dyn, OMatrix, storage::Owned};
+
+use super::model::RainbowModel;
+
+/// `(external, d(external)/du)` for the optimizer's unconstrained internal value `u`,
+/// logistically mapped into `(lower, upper)`.
+fn bounded_transform(u: f64, lower: f64, upper: f64) -> (f64, f64) {
+    let s = 1.0 / (1.0 + (-u).exp());
+    let external = lower + (upper - lower) * s;
+    let dext_du = (upper - lower) * s * (1.0 - s);
+    (external, dext_du)
+}
+
+/// Inverse of [`bounded_transform`] (the logit function), used to convert a physical-unit
+/// initial guess into the optimizer's internal space. Clamped away from the exact bounds to
+/// avoid `+-inf`.
+fn inverse_bounded_transform(external: f64, lower: f64, upper: f64) -> f64 {
+    let frac = ((external - lower) / (upper - lower)).clamp(1e-9, 1.0 - 1e-9);
+    (frac / (1.0 - frac)).ln()
+}
+
+fn internal_to_external(u: &DVector<f64>, bounds: &[(f64, f64)]) -> (Vec<f64>, Vec<f64>) {
+    let n = bounds.len();
+    let mut external = vec![0.0; n];
+    let mut dext_du = vec![0.0; n];
+    for k in 0..n {
+        let (lower, upper) = bounds[k];
+        let (e, d) = bounded_transform(u[k], lower, upper);
+        external[k] = e;
+        dext_du[k] = d;
+    }
+    (external, dext_du)
+}
+
+fn external_to_internal(external: &[f64], bounds: &[(f64, f64)]) -> DVector<f64> {
+    DVector::from_iterator(
+        bounds.len(),
+        external.iter().zip(bounds).map(|(&e, &(lower, upper))| inverse_bounded_transform(e, lower, upper)),
+    )
+}
+
+/// Parameter covariance matrix from the Gauss-Newton approximation `inv(JᵀJ)` at the converged
+/// solution, where `J` is `d(residual)/d(external param)` (residuals already weighted by
+/// `1/flux_err`). Mirrors Python's `_lsq_covariance`: the same construction scipy's `curve_fit`
+/// uses with `absolute_sigma=True` -- no rescaling by `reduced_chi2`.
+///
+/// Cheap: this is one extra pass over the data building an `n_points x n_params` Jacobian (the
+/// same per-point gradient the fit already computes every iteration) plus inverting an
+/// `n_params x n_params` matrix (at most ~10x10 for the richest term combinations), done once
+/// after convergence.
+///
+/// Falls back to the Moore-Penrose pseudo-inverse when `JᵀJ` is singular or non-positive-definite
+/// -- that signals an unidentified parameter direction (a genuine degeneracy, e.g. two
+/// parameters that trade off perfectly given this data), not a failed fit, so a best-effort
+/// covariance is still returned. Caveat (same as Python's): the pseudo-inverse reports a
+/// *near-zero* variance for a fully unconstrained direction, which understates the true
+/// uncertainty there -- the fitted parameters and chi2 are unaffected, only that direction's
+/// error bar is unreliable.
+fn covariance_from_jacobian(
+    model: &RainbowModel,
+    t: &[f64],
+    flux_err: &[f64],
+    band_idx: &[usize],
+    params: &[f64],
+) -> DMatrix<f64> {
+    let n = t.len();
+    let n_params = params.len();
+    let mut j = DMatrix::<f64>::zeros(n, n_params);
+    for i in 0..n {
+        let (_, grad) = model.model_and_gradient(t[i], band_idx[i], params);
+        for k in 0..n_params {
+            j[(i, k)] = grad[k] / flux_err[i];
+        }
+    }
+    let jtj = j.transpose() * &j;
+
+    if let Some(inv) = jtj.clone().try_inverse() {
+        if inv.diagonal().iter().all(|&x| x.is_finite() && x > 0.0) {
+            return inv;
+        }
+    }
+    let svd = jtj.svd(true, true);
+    svd.pseudo_inverse(1e-12).unwrap_or_else(|_| DMatrix::from_element(n_params, n_params, f64::NAN))
+}
+
+struct RainbowFitProblem<'a> {
+    model: &'a RainbowModel,
+    t: &'a [f64],
+    flux: &'a [f64],
+    flux_err: &'a [f64],
+    band_idx: &'a [usize],
+    bounds: Vec<(f64, f64)>,
+    u: DVector<f64>,
+}
+
+impl<'a> LeastSquaresProblem<f64, Dyn, Dyn> for RainbowFitProblem<'a> {
+    type ResidualStorage = Owned<f64, Dyn>;
+    type JacobianStorage = Owned<f64, Dyn, Dyn>;
+    type ParameterStorage = Owned<f64, Dyn>;
+
+    fn set_params(&mut self, x: &DVector<f64>) {
+        self.u = x.clone();
+    }
+
+    fn params(&self) -> DVector<f64> {
+        self.u.clone()
+    }
+
+    fn residuals(&self) -> Option<DVector<f64>> {
+        let (params, _) = internal_to_external(&self.u, &self.bounds);
+        let n = self.t.len();
+        let mut r = DVector::zeros(n);
+        for i in 0..n {
+            let model_flux = self.model.model(self.t[i], self.band_idx[i], &params);
+            r[i] = (model_flux - self.flux[i]) / self.flux_err[i];
+        }
+        Some(r)
+    }
+
+    fn jacobian(&self) -> Option<OMatrix<f64, Dyn, Dyn>> {
+        let (params, dext_du) = internal_to_external(&self.u, &self.bounds);
+        let n = self.t.len();
+        let n_params = params.len();
+        let mut j = OMatrix::<f64, Dyn, Dyn>::zeros(n, n_params);
+        for i in 0..n {
+            let (_, grad) = self.model.model_and_gradient(self.t[i], self.band_idx[i], &params);
+            for k in 0..n_params {
+                j[(i, k)] = grad[k] * dext_du[k] / self.flux_err[i];
+            }
+        }
+        Some(j)
+    }
+}
+
+/// Result of fitting [`RainbowModel`] to a light curve.
+pub(crate) struct FitResult {
+    /// Fitted physical parameters, in [`RainbowModel::param_names`] order.
+    pub(crate) params: Vec<f64>,
+    /// 1-sigma uncertainty on each parameter (same order as `params`), from the Gauss-Newton
+    /// covariance approximation. See [`covariance_from_jacobian`] for the method and its caveats
+    /// around genuinely degenerate parameters.
+    pub(crate) errors: Vec<f64>,
+    /// Full parameter covariance matrix (`covariance[i][j]`), same order and method as `errors`
+    /// (whose entries are `sqrt(covariance[i][i])`).
+    pub(crate) covariance: Vec<Vec<f64>>,
+    pub(crate) reduced_chi2: f64,
+    pub(crate) success: bool,
+}
+
+/// Jointly fits all bands' flux observations `(t, flux, flux_err, band_idx)` to `model`.
+///
+/// `band_idx[i]` must index into `model`'s bands. Mismatched array lengths are a caller bug and
+/// panic; too few data points to constrain the model (a normal data-quality condition, not a bug
+/// -- real light curves are sometimes too sparse) instead returns a [`FitResult`] with
+/// `success: false` and NaN-filled outputs, so callers don't need to pre-check `t.len()`
+/// themselves.
+pub(crate) fn fit(model: &RainbowModel, t: &[f64], flux: &[f64], flux_err: &[f64], band_idx: &[usize]) -> FitResult {
+    assert_eq!(t.len(), flux.len());
+    assert_eq!(t.len(), flux_err.len());
+    assert_eq!(t.len(), band_idx.len());
+
+    let n_params = model.n_params();
+    if t.len() <= n_params {
+        return FitResult {
+            params: vec![f64::NAN; n_params],
+            errors: vec![f64::NAN; n_params],
+            covariance: vec![vec![f64::NAN; n_params]; n_params],
+            reduced_chi2: f64::NAN,
+            success: false,
+        };
+    }
+
+    let bounds = model.bounds(t, flux, flux_err, band_idx);
+    let guess = model.initial_guess(t, flux, flux_err, band_idx);
+    let u0 = external_to_internal(&guess, &bounds);
+
+    let problem = RainbowFitProblem { model, t, flux, flux_err, band_idx, bounds, u: u0 };
+
+    let (solved, report) = LevenbergMarquardt::new().minimize(problem);
+    let (params, _) = internal_to_external(&solved.u, &solved.bounds);
+
+    let dof = (t.len() as isize - n_params as isize).max(1) as f64;
+    let chi2 = 2.0 * report.objective_function;
+    let reduced_chi2 = chi2 / dof;
+
+    let cov = covariance_from_jacobian(model, t, flux_err, band_idx, &params);
+    let errors: Vec<f64> = cov.diagonal().iter().map(|&v| v.max(0.0).sqrt()).collect();
+    let covariance: Vec<Vec<f64>> =
+        (0..params.len()).map(|i| (0..params.len()).map(|j| cov[(i, j)]).collect()).collect();
+
+    FitResult { params, errors, covariance, reduced_chi2, success: report.termination.was_successful() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::model::Band;
+    use super::super::terms::{Bolometric, Spectral, Temperature};
+    use levenberg_marquardt::differentiate_numerically;
+
+    #[test]
+    fn analytic_jacobian_matches_numerical_differentiation() {
+        let bands = vec![
+            Band { name: "g".to_string(), wavelength_cm: 4770.0e-8 },
+            Band { name: "r".to_string(), wavelength_cm: 6231.0e-8 },
+        ];
+        let model = RainbowModel::new(Bolometric::Bazin, Temperature::Sigmoid, Spectral::Planck, bands, false);
+
+        let t: Vec<f64> = (0..20).map(|i| i as f64 * 3.0).collect();
+        let band_idx: Vec<usize> = (0..20).map(|i| i % 2).collect();
+        let flux: Vec<f64> = t.iter().map(|&x| 50.0 + 10.0 * (x / 20.0).sin()).collect();
+        let flux_err: Vec<f64> = vec![1.0; 20];
+
+        let bounds = model.bounds(&t, &flux, &flux_err, &band_idx);
+        let truth_external = [30.0, 100.0, 5.0, 20.0, 9000.0, 0.1, 6.0];
+        let u = external_to_internal(&truth_external, &bounds);
+
+        let mut problem =
+            RainbowFitProblem { model: &model, t: &t, flux: &flux, flux_err: &flux_err, band_idx: &band_idx, bounds, u };
+
+        let analytic = problem.jacobian().unwrap();
+        let numeric = differentiate_numerically(&mut problem).unwrap();
+
+        assert_eq!(analytic.shape(), numeric.shape());
+        for i in 0..analytic.nrows() {
+            for j in 0..analytic.ncols() {
+                let a = analytic[(i, j)];
+                let n = numeric[(i, j)];
+                assert!((a - n).abs() <= 1e-4 * n.abs().max(1.0), "jacobian[{i},{j}]: analytic={a}, numeric={n}");
+            }
+        }
+    }
+
+    #[test]
+    fn too_few_points_returns_failure_instead_of_panicking() {
+        let bands = vec![
+            Band { name: "g".to_string(), wavelength_cm: 4770.0e-8 },
+            Band { name: "r".to_string(), wavelength_cm: 6231.0e-8 },
+            Band { name: "i".to_string(), wavelength_cm: 7625.0e-8 },
+        ];
+        let model = RainbowModel::new(Bolometric::Bazin, Temperature::Sigmoid, Spectral::Planck, bands, false);
+
+        let t = vec![0.0, 1.0, 2.0];
+        let flux = vec![1.0, 2.0, 1.5];
+        let flux_err = vec![0.1, 0.1, 0.1];
+        let band_idx = vec![0, 1, 2];
+        let result = fit(&model, &t, &flux, &flux_err, &band_idx);
+        assert!(!result.success);
+        assert!(result.params.iter().all(|p| p.is_nan()));
+        assert!(result.reduced_chi2.is_nan());
+    }
+}

--- a/src/multicolor/rainbow/fit.rs
+++ b/src/multicolor/rainbow/fit.rs
@@ -177,61 +177,6 @@ pub(crate) struct FitResult {
     pub(crate) success: bool,
 }
 
-/// Number of extra jittered-restart attempts if the primary fit doesn't converge (see [`fit`]).
-const MAX_RETRIES: usize = 4;
-
-/// Tiny deterministic xorshift64 PRNG, used only to generate reproducible jittered restarts when
-/// the primary fit attempt doesn't converge. A hand-rolled generator avoids pulling in a `rand`
-/// dependency for what's a handful of uniform perturbations.
-struct Xorshift64(u64);
-
-impl Xorshift64 {
-    /// Uniform value in `(0, 1)`.
-    fn next_unit(&mut self) -> f64 {
-        let mut x = self.0;
-        x ^= x << 13;
-        x ^= x >> 7;
-        x ^= x << 17;
-        self.0 = x;
-        ((x >> 11) as f64) / ((1u64 << 53) as f64)
-    }
-
-    /// Uniform value in `(-halfwidth, halfwidth)`.
-    fn next_offset(&mut self, halfwidth: f64) -> f64 {
-        (2.0 * self.next_unit() - 1.0) * halfwidth
-    }
-}
-
-/// Bundles the data a fit attempt needs, so [`run_lm`] only takes one data argument regardless
-/// of how many arrays that turns out to be.
-struct FitData<'a> {
-    model: &'a RainbowModel,
-    t: &'a [f64],
-    flux: &'a [f64],
-    flux_err: &'a [f64],
-    band_idx: &'a [usize],
-}
-
-/// Runs a single Levenberg-Marquardt attempt from internal-space starting point `u0`.
-fn run_lm(
-    lm: &LevenbergMarquardt<f64>,
-    data: &FitData,
-    bounds: &[(f64, f64)],
-    u0: DVector<f64>,
-) -> (DVector<f64>, levenberg_marquardt::MinimizationReport<f64>) {
-    let problem = RainbowFitProblem {
-        model: data.model,
-        t: data.t,
-        flux: data.flux,
-        flux_err: data.flux_err,
-        band_idx: data.band_idx,
-        bounds: bounds.to_vec(),
-        u: u0,
-    };
-    let (solved, report) = lm.minimize(problem);
-    (solved.u, report)
-}
-
 /// Jointly fits all bands' flux observations `(t, flux, flux_err, band_idx)` to `model`.
 ///
 /// `band_idx[i]` must index into `model`'s bands. Mismatched array lengths are a caller bug and
@@ -250,10 +195,14 @@ fn run_lm(
 /// chance to be reached on harder fits rather than hitting the (now effectively unchanged)
 /// absolute evaluation cap first.
 ///
-/// If that first attempt still doesn't converge, retries up to [`MAX_RETRIES`] times from
-/// jittered starting points (deterministic, so results are reproducible), keeping whichever
-/// attempt reaches the lowest objective. This only adds cost on the failure path -- the common
-/// case (first attempt converges) is unaffected.
+/// Deliberately does *not* retry from jittered starting points on failure: tried it (see git
+/// history), and on every real non-converging light curve tested it either reproduced the same
+/// point or landed somewhere worse, while roughly doubling worst-case runtime on exactly the
+/// hardest fits (each retry re-running up to the full evaluation budget). A light curve that's
+/// still `LostPatience` after this tolerance/budget is either genuinely too sparse to constrain
+/// the model, or (like one observed case) converging so slowly that reaching the tolerance would
+/// cost seconds for a <0.1% change in the objective -- in both cases `success: false` is the
+/// more honest answer than spending that time to relabel an unchanged result.
 pub(crate) fn fit(
     model: &RainbowModel,
     t: &[f64],
@@ -278,39 +227,25 @@ pub(crate) fn fit(
     let bounds = model.bounds(t, flux, flux_err, band_idx);
     let guess = model.initial_guess(t, flux, flux_err, band_idx);
     let u0 = external_to_internal(&guess, &bounds);
-    let data = FitData {
+
+    let problem = RainbowFitProblem {
         model,
         t,
         flux,
         flux_err,
         band_idx,
+        bounds,
+        u: u0,
     };
 
-    let lm = LevenbergMarquardt::new().with_tol(1e-8).with_patience(1000);
-    let (mut best_u, mut best_report) = run_lm(&lm, &data, &bounds, u0.clone());
-
-    if !best_report.termination.was_successful() {
-        // Seed depends only on the data size, so retries are deterministic and reproducible
-        // across runs on the same light curve, but vary between differently-sized fits.
-        let mut rng = Xorshift64(0x9E3779B97F4A7C15 ^ (t.len() as u64));
-        for _ in 0..MAX_RETRIES {
-            let jittered_u0 =
-                DVector::from_iterator(u0.len(), u0.iter().map(|&u| u + rng.next_offset(3.0)));
-            let (candidate_u, candidate_report) = run_lm(&lm, &data, &bounds, jittered_u0);
-            if candidate_report.objective_function < best_report.objective_function {
-                best_u = candidate_u;
-                best_report = candidate_report;
-            }
-            if best_report.termination.was_successful() {
-                break;
-            }
-        }
-    }
-
-    let (params, _) = internal_to_external(&best_u, &bounds);
+    let (solved, report) = LevenbergMarquardt::new()
+        .with_tol(1e-8)
+        .with_patience(1000)
+        .minimize(problem);
+    let (params, _) = internal_to_external(&solved.u, &solved.bounds);
 
     let dof = (t.len() as isize - n_params as isize).max(1) as f64;
-    let chi2 = 2.0 * best_report.objective_function;
+    let chi2 = 2.0 * report.objective_function;
     let reduced_chi2 = chi2 / dof;
 
     let cov = covariance_from_jacobian(model, t, flux_err, band_idx, &params);
@@ -320,7 +255,7 @@ pub(crate) fn fit(
         params,
         errors,
         reduced_chi2,
-        success: best_report.termination.was_successful(),
+        success: report.termination.was_successful(),
     }
 }
 
@@ -383,18 +318,6 @@ mod tests {
                     "jacobian[{i},{j}]: analytic={a}, numeric={n}"
                 );
             }
-        }
-    }
-
-    #[test]
-    fn xorshift64_offsets_stay_in_range_and_are_deterministic() {
-        let mut rng_a = Xorshift64(12345);
-        let mut rng_b = Xorshift64(12345);
-        for _ in 0..100 {
-            let a = rng_a.next_offset(3.0);
-            let b = rng_b.next_offset(3.0);
-            assert_eq!(a, b, "same seed must give the same sequence");
-            assert!((-3.0..=3.0).contains(&a), "offset {a} out of (-3, 3)");
         }
     }
 

--- a/src/multicolor/rainbow/fit.rs
+++ b/src/multicolor/rainbow/fit.rs
@@ -177,6 +177,61 @@ pub(crate) struct FitResult {
     pub(crate) success: bool,
 }
 
+/// Number of extra jittered-restart attempts if the primary fit doesn't converge (see [`fit`]).
+const MAX_RETRIES: usize = 4;
+
+/// Tiny deterministic xorshift64 PRNG, used only to generate reproducible jittered restarts when
+/// the primary fit attempt doesn't converge. A hand-rolled generator avoids pulling in a `rand`
+/// dependency for what's a handful of uniform perturbations.
+struct Xorshift64(u64);
+
+impl Xorshift64 {
+    /// Uniform value in `(0, 1)`.
+    fn next_unit(&mut self) -> f64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        ((x >> 11) as f64) / ((1u64 << 53) as f64)
+    }
+
+    /// Uniform value in `(-halfwidth, halfwidth)`.
+    fn next_offset(&mut self, halfwidth: f64) -> f64 {
+        (2.0 * self.next_unit() - 1.0) * halfwidth
+    }
+}
+
+/// Bundles the data a fit attempt needs, so [`run_lm`] only takes one data argument regardless
+/// of how many arrays that turns out to be.
+struct FitData<'a> {
+    model: &'a RainbowModel,
+    t: &'a [f64],
+    flux: &'a [f64],
+    flux_err: &'a [f64],
+    band_idx: &'a [usize],
+}
+
+/// Runs a single Levenberg-Marquardt attempt from internal-space starting point `u0`.
+fn run_lm(
+    lm: &LevenbergMarquardt<f64>,
+    data: &FitData,
+    bounds: &[(f64, f64)],
+    u0: DVector<f64>,
+) -> (DVector<f64>, levenberg_marquardt::MinimizationReport<f64>) {
+    let problem = RainbowFitProblem {
+        model: data.model,
+        t: data.t,
+        flux: data.flux,
+        flux_err: data.flux_err,
+        band_idx: data.band_idx,
+        bounds: bounds.to_vec(),
+        u: u0,
+    };
+    let (solved, report) = lm.minimize(problem);
+    (solved.u, report)
+}
+
 /// Jointly fits all bands' flux observations `(t, flux, flux_err, band_idx)` to `model`.
 ///
 /// `band_idx[i]` must index into `model`'s bands. Mismatched array lengths are a caller bug and
@@ -184,6 +239,21 @@ pub(crate) struct FitResult {
 /// -- real light curves are sometimes too sparse) instead returns a [`FitResult`] with
 /// `success: false` and NaN-filled outputs, so callers don't need to pre-check `t.len()`
 /// themselves.
+///
+/// Uses a looser convergence tolerance than `levenberg-marquardt`'s default (`1e-8`, matching
+/// `scipy.optimize.curve_fit`/iminuit's usual convention, rather than the crate's default of
+/// `f64::EPSILON * 30 ≈ 6.7e-15`): on real, noisy light curves the default is tight enough that
+/// the optimizer routinely exhausts its evaluation budget (`LostPatience`) without ever
+/// satisfying it, even after it has already reached essentially the same point a looser
+/// tolerance would accept as converged -- i.e. the fit was fine, just mislabeled as failed. The
+/// evaluation budget (`patience`) is raised to match, so the looser tolerance actually gets a
+/// chance to be reached on harder fits rather than hitting the (now effectively unchanged)
+/// absolute evaluation cap first.
+///
+/// If that first attempt still doesn't converge, retries up to [`MAX_RETRIES`] times from
+/// jittered starting points (deterministic, so results are reproducible), keeping whichever
+/// attempt reaches the lowest objective. This only adds cost on the failure path -- the common
+/// case (first attempt converges) is unaffected.
 pub(crate) fn fit(
     model: &RainbowModel,
     t: &[f64],
@@ -208,22 +278,39 @@ pub(crate) fn fit(
     let bounds = model.bounds(t, flux, flux_err, band_idx);
     let guess = model.initial_guess(t, flux, flux_err, band_idx);
     let u0 = external_to_internal(&guess, &bounds);
-
-    let problem = RainbowFitProblem {
+    let data = FitData {
         model,
         t,
         flux,
         flux_err,
         band_idx,
-        bounds,
-        u: u0,
     };
 
-    let (solved, report) = LevenbergMarquardt::new().minimize(problem);
-    let (params, _) = internal_to_external(&solved.u, &solved.bounds);
+    let lm = LevenbergMarquardt::new().with_tol(1e-8).with_patience(1000);
+    let (mut best_u, mut best_report) = run_lm(&lm, &data, &bounds, u0.clone());
+
+    if !best_report.termination.was_successful() {
+        // Seed depends only on the data size, so retries are deterministic and reproducible
+        // across runs on the same light curve, but vary between differently-sized fits.
+        let mut rng = Xorshift64(0x9E3779B97F4A7C15 ^ (t.len() as u64));
+        for _ in 0..MAX_RETRIES {
+            let jittered_u0 =
+                DVector::from_iterator(u0.len(), u0.iter().map(|&u| u + rng.next_offset(3.0)));
+            let (candidate_u, candidate_report) = run_lm(&lm, &data, &bounds, jittered_u0);
+            if candidate_report.objective_function < best_report.objective_function {
+                best_u = candidate_u;
+                best_report = candidate_report;
+            }
+            if best_report.termination.was_successful() {
+                break;
+            }
+        }
+    }
+
+    let (params, _) = internal_to_external(&best_u, &bounds);
 
     let dof = (t.len() as isize - n_params as isize).max(1) as f64;
-    let chi2 = 2.0 * report.objective_function;
+    let chi2 = 2.0 * best_report.objective_function;
     let reduced_chi2 = chi2 / dof;
 
     let cov = covariance_from_jacobian(model, t, flux_err, band_idx, &params);
@@ -233,7 +320,7 @@ pub(crate) fn fit(
         params,
         errors,
         reduced_chi2,
-        success: report.termination.was_successful(),
+        success: best_report.termination.was_successful(),
     }
 }
 
@@ -296,6 +383,18 @@ mod tests {
                     "jacobian[{i},{j}]: analytic={a}, numeric={n}"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn xorshift64_offsets_stay_in_range_and_are_deterministic() {
+        let mut rng_a = Xorshift64(12345);
+        let mut rng_b = Xorshift64(12345);
+        for _ in 0..100 {
+            let a = rng_a.next_offset(3.0);
+            let b = rng_b.next_offset(3.0);
+            assert_eq!(a, b, "same seed must give the same sequence");
+            assert!((-3.0..=3.0).contains(&a), "offset {a} out of (-3, 3)");
         }
     }
 

--- a/src/multicolor/rainbow/mod.rs
+++ b/src/multicolor/rainbow/mod.rs
@@ -1,0 +1,6 @@
+//! Placeholder -- the public RainbowFit type lands in the next commit.
+
+mod constants;
+mod fit;
+mod model;
+pub mod terms;

--- a/src/multicolor/rainbow/mod.rs
+++ b/src/multicolor/rainbow/mod.rs
@@ -1,6 +1,569 @@
-//! Placeholder -- the public RainbowFit type lands in the next commit.
+//! Multi-band non-linear fit of a bolometric envelope times a temperature-dependent spectral
+//! energy distribution (SED) -- the "Rainbow" model (Russeil et al. 2023,
+//! [arXiv:2310.02916](https://arxiv.org/abs/2310.02916)):
+//! $$
+//! \mathrm{flux}(t, \lambda) = \mathrm{bol}(t) \cdot \frac{B(\lambda, T(t))}{\mathrm{norm}(T(t))} \ [+ \ \mathrm{baseline}_\mathrm{band}].
+//! $$
+//! `bol(t)` (a [`terms::Bolometric`] choice), `T(t)` (a [`terms::Temperature`] choice), and
+//! `B(lambda, T)` (a [`terms::Spectral`] choice) are independently pluggable; see [`RainbowFit::new`]
+//! and each enum's own documentation for the available functional forms and their parameters.
+//! `norm(T)` is always the Stefan-Boltzmann/Planck-based normalization regardless of which SED is
+//! chosen (see [`model`] for the composition), so the overall flux scale is carried entirely by
+//! the bolometric term's `amplitude`.
+//!
+//! # Why this doesn't use `nl_fit`/`CurveFitAlgorithm`
+//!
+//! [`nl_fit`](crate::nl_fit) (used by `BazinFit`, `VillarFit`, etc.) is built around a
+//! compile-time-fixed `const NPARAMS: usize`: fixed-size `[f64; NPARAMS]` arrays throughout, and
+//! [`CurveFitTrait`](crate::nl_fit::CurveFitTrait)'s `curve_fit` is generic over that same
+//! constant. Rainbow's parameter count depends on which bolometric/temperature/spectral terms are
+//! chosen (and whether a baseline is fit), so it can't be a compile-time constant here. Instead,
+//! [`fit`] implements a self-contained Levenberg-Marquardt fit (via the `levenberg-marquardt`
+//! crate, `Dyn`-dimensioned rather than `Const<NPARAMS>`) directly, the same way `ParabolaFit`
+//! (`crate::parabola_fit`) implements its own closed-form fit without going through `nl_fit`.
+//!
+//! # Bounds instead of `nl_fit`'s internal/dimensionless/external spaces
+//!
+//! Every parameter is fit through an unconstrained internal optimizer variable, reparametrized
+//! into a physical-unit `(lower, upper)` box via a logistic map (see [`fit`]'s module doc for the
+//! exact transform) -- conceptually the same idea as `nl_fit`'s internal/dimensionless/external
+//! split (e.g. `BazinFit` using `abs()` to enforce positivity), but expressed as a single bounded
+//! transform per parameter rather than a separate data-normalization layer plus a sign-only
+//! reparametrization. Bounds are computed per-fit from the data (mirroring the Python reference
+//! implementation's heuristics) by each term's own `bounds()` method.
+//!
+//! # Uncertainties
+//!
+//! [`fit::fit`] additionally computes 1-sigma parameter uncertainties from the Gauss-Newton
+//! covariance approximation `inv(JᵀJ)` (cheap: reuses the fit's own per-point gradient, one
+//! `n_params x n_params` matrix inversion). These are appended to this feature's output as
+//! `<name>_sigma` columns rather than requiring the generic `Bootstrap`/`MultiColorBootstrap`
+//! wrapper (which would substantially multiply the cost via resampling) -- see
+//! [`RainbowFit::build_properties`] for the exact output layout. Whether this is the right
+//! convention (vs. leaving uncertainty estimation to the `Bootstrap` wrapper, matching every
+//! other feature) is a design question for review.
+//!
+//! # Open design questions (flagged for review)
+//!
+//! - **New dependency**: this is the first pure-Rust linear-algebra dependency in the crate
+//!   (`levenberg-marquardt`, pulling in `nalgebra`), gated behind the opt-in `rainbow` Cargo
+//!   feature (see `Cargo.toml`) rather than `default`, following the `gsl`/`ceres-*` precedent
+//!   for optional heavy dependencies.
+//! - **`PassbandTrait::wavelength()`**: added as a new default (`None`) method so `RainbowFit`
+//!   can require a wavelength while still slotting into the generic `MultiColorFeature<P, T>`
+//!   registry like every other feature, at the cost of one new trait method affecting the
+//!   whole `multicolor` module.
+//! - **Output layout**: whether baking in analytic uncertainties (see above) is the right call,
+//!   or whether it should be dropped in favor of the existing `Bootstrap` convention.
+//!
+//! # Not yet ported from the Python reference
+//!
+//! - `bolometric = "linexp"`: Python's own docstring flags its guesses/limits as unstable,
+//!   confirmed by a seed sweep during development of this port (roughly half of random seeds
+//!   land the fit in a self-consistent-looking but wrong local optimum).
+//! - `spectral = "blanketed"`: its `lambda_scale` parameter anchors to the temperature term's own
+//!   characteristic `T` via Python's `common_temp_spec` cross-term parameter sharing, more
+//!   involved than a straight port of the other terms.
+//! - Gaussian priors on individual parameters (Python anchors e.g. `T_amplitude`, `beta` toward
+//!   0 to break known degeneracies for some spectral terms); non-detections/upper limits (Python
+//!   supports a Tobit-model likelihood term for these).
 
 mod constants;
 mod fit;
 mod model;
 pub mod terms;
+
+use std::collections::BTreeSet;
+use std::marker::PhantomData;
+
+use conv::ConvUtil;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::data::MultiColorTimeSeries;
+use crate::error::{EvaluatorError, MultiColorEvaluatorError};
+use crate::evaluator::{
+    EvaluatorInfo, EvaluatorInfoTrait, EvaluatorProperties, FeatureNamesDescriptionsTrait,
+};
+use crate::float_trait::Float;
+use crate::multicolor::multicolor_evaluator::{
+    MultiColorEvaluator, MultiColorPassbandSetTrait, PassbandSet,
+};
+use crate::multicolor::passband::PassbandTrait;
+
+use model::{Band, RainbowModel};
+pub use terms::{Bolometric, Spectral, Temperature};
+
+/// Error constructing a [`RainbowFit`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RainbowFitError {
+    #[error("RainbowFit requires at least one passband")]
+    NoPassbands,
+
+    #[error(
+        "passband {0:?} has no known wavelength (PassbandTrait::wavelength() returned None); use MonochromePassband, or a passband type overriding wavelength()"
+    )]
+    MissingWavelength(String),
+}
+
+/// Multi-band fit of the Rainbow model (see the [module-level documentation](self) for the
+/// model, why it doesn't use `nl_fit`, and open design questions).
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(
+    into = "RainbowFitParameters<P, T>",
+    try_from = "RainbowFitParameters<P, T>",
+    bound(
+        serialize = "P: PassbandTrait + Serialize, T: Float",
+        deserialize = "P: PassbandTrait + Deserialize<'de>, T: Float"
+    )
+)]
+pub struct RainbowFit<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    bolometric: Bolometric,
+    temperature: Temperature,
+    spectral: Spectral,
+    with_baseline: bool,
+    passband_set: PassbandSet<P>,
+    /// Built once at construction from `passband_set`'s (sorted) iteration order; `model`'s
+    /// internal band indices correspond 1:1 to that same order, which `eval_multicolor_no_mcts_check`
+    /// relies on when flattening the input data.
+    model: RainbowModel,
+    properties: Box<EvaluatorProperties>,
+    _marker: PhantomData<T>,
+}
+
+impl<P, T> std::fmt::Debug for RainbowFit<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RainbowFit")
+            .field("bolometric", &self.bolometric)
+            .field("temperature", &self.temperature)
+            .field("spectral", &self.spectral)
+            .field("with_baseline", &self.with_baseline)
+            .field("passband_set", &self.passband_set)
+            .finish()
+    }
+}
+
+impl<P, T> RainbowFit<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    /// Constructs a `RainbowFit` for the given passbands and term choices.
+    ///
+    /// # Errors
+    /// [`RainbowFitError::NoPassbands`] if `passbands` is empty, or
+    /// [`RainbowFitError::MissingWavelength`] if any passband's [`PassbandTrait::wavelength`]
+    /// returns `None` (only [`crate::multicolor::MonochromePassband`] provides one today).
+    pub fn new(
+        passbands: impl IntoIterator<Item = P>,
+        bolometric: Bolometric,
+        temperature: Temperature,
+        spectral: Spectral,
+        with_baseline: bool,
+    ) -> Result<Self, RainbowFitError> {
+        let passband_set: BTreeSet<P> = passbands.into_iter().collect();
+        if passband_set.is_empty() {
+            return Err(RainbowFitError::NoPassbands);
+        }
+
+        let bands: Vec<Band> = passband_set
+            .iter()
+            .map(|p| {
+                let wavelength_cm = p
+                    .wavelength()
+                    .ok_or_else(|| RainbowFitError::MissingWavelength(p.name().into()))?;
+                Ok(Band {
+                    name: p.name().into(),
+                    wavelength_cm,
+                })
+            })
+            .collect::<Result<_, RainbowFitError>>()?;
+
+        let model = RainbowModel::new(bolometric, temperature, spectral, bands, with_baseline);
+        let properties = Box::new(Self::build_properties(&model));
+
+        Ok(Self {
+            bolometric,
+            temperature,
+            spectral,
+            with_baseline,
+            passband_set: PassbandSet(passband_set),
+            model,
+            properties,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Output layout: fitted parameters, then their 1-sigma uncertainties (see the module-level
+    /// documentation's "Uncertainties" section), then the reduced chi2 -- `2*n_params + 1` values
+    /// in total.
+    fn build_properties(model: &RainbowModel) -> EvaluatorProperties {
+        let param_names = model.param_names();
+        let mut names = Vec::with_capacity(2 * param_names.len() + 1);
+        let mut descriptions = Vec::with_capacity(2 * param_names.len() + 1);
+
+        for name in param_names {
+            names.push(format!("rainbow_{name}"));
+            descriptions.push(format!("Rainbow fit parameter: {name}"));
+        }
+        for name in param_names {
+            names.push(format!("rainbow_{name}_sigma"));
+            descriptions.push(format!(
+                "1-sigma uncertainty (Gauss-Newton) of Rainbow fit parameter: {name}"
+            ));
+        }
+        names.push("rainbow_reduced_chi2".to_owned());
+        descriptions.push("Reduced chi^2 of the Rainbow fit".to_owned());
+
+        EvaluatorProperties {
+            info: EvaluatorInfo {
+                size: names.len(),
+                // A genuine per-band minimum isn't meaningful here (the fit is joint across
+                // bands, so what matters is the *total* point count vs. parameter count, not any
+                // single band's length); that check happens inside `eval_multicolor_no_mcts_check`
+                // via `fit::fit`'s own graceful "too few points" handling, converted to a proper
+                // error instead of relying on this precondition.
+                min_ts_length: 1,
+                t_required: true,
+                m_required: true,
+                w_required: true,
+                sorting_required: false,
+                // Not enforced per-band (see min_ts_length's comment): a single flat band
+                // shouldn't necessarily block a joint multi-band fit. A light curve that is flat
+                // in *every* band will not error here; today it produces a poorly-constrained
+                // (but not crashing) fit rather than a clean rejection -- a known gap, flagged in
+                // the module-level documentation rather than silently accepted.
+                variability_required: false,
+            },
+            names,
+            descriptions,
+        }
+    }
+
+    /// Analytic bolometric peak time, if defined for the chosen [`Bolometric`] term (see each
+    /// variant's documentation). `params` must be the first `n_params` values of this feature's
+    /// output (i.e. the fitted parameters, not their `_sigma` uncertainties or `reduced_chi2`),
+    /// in [`FeatureNamesDescriptionsTrait::get_names`] order.
+    pub fn peak_time(&self, params: &[T]) -> Option<T> {
+        let params_f64: Vec<f64> = params.iter().map(|&x| x.value_into().unwrap()).collect();
+        self.model.peak_time(&params_f64).map(|t| {
+            t.approx_as::<T>().unwrap_or_else(|_| {
+                if t.is_sign_negative() {
+                    T::min_value()
+                } else {
+                    T::max_value()
+                }
+            })
+        })
+    }
+}
+
+impl<P, T> EvaluatorInfoTrait for RainbowFit<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn get_info(&self) -> &EvaluatorInfo {
+        &self.properties.info
+    }
+}
+
+impl<P, T> FeatureNamesDescriptionsTrait for RainbowFit<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn get_names(&self) -> Vec<&str> {
+        self.properties.names.iter().map(String::as_str).collect()
+    }
+
+    fn get_descriptions(&self) -> Vec<&str> {
+        self.properties
+            .descriptions
+            .iter()
+            .map(String::as_str)
+            .collect()
+    }
+}
+
+impl<P, T> MultiColorPassbandSetTrait<P> for RainbowFit<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn get_passband_set(&self) -> &PassbandSet<P> {
+        &self.passband_set
+    }
+}
+
+impl<P, T> MultiColorEvaluator<P, T> for RainbowFit<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn eval_multicolor_no_mcts_check<'slf, 'a, 'mcts>(
+        &'slf self,
+        mcts: &'mcts mut MultiColorTimeSeries<'a, P, T>,
+    ) -> Result<Vec<T>, MultiColorEvaluatorError>
+    where
+        'slf: 'a,
+        'a: 'mcts,
+    {
+        // Flatten all matched bands into flat f64 arrays, in the same band order as
+        // `self.model`'s internal band list (`self.passband_set`'s sorted iteration order, which
+        // is exactly how `model` was built in `new`).
+        mcts.with_mapping_mut(|_| {});
+        let mapping = mcts.mapping().expect("mapping was just ensured");
+
+        let mut t = Vec::new();
+        let mut flux = Vec::new();
+        let mut flux_err = Vec::new();
+        let mut band_idx = Vec::new();
+
+        for (band_i, (p, maybe_ts)) in mapping.iter_passband_set(&self.passband_set).enumerate() {
+            let ts = maybe_ts.ok_or_else(|| {
+                MultiColorEvaluatorError::wrong_passbands_error(
+                    mcts.passbands(),
+                    self.passband_set.0.iter(),
+                )
+            })?;
+            let _ = p; // only needed for the error path above
+            for i in 0..ts.lenu() {
+                let ti: f64 = ts.t.sample[i].value_into().unwrap();
+                let mi: f64 = ts.m.sample[i].value_into().unwrap();
+                // `w` is inverse-variance weight (`w = 1/sigma^2`), not sigma directly.
+                let wi: f64 = ts.w.sample[i].value_into().unwrap();
+                t.push(ti);
+                flux.push(mi);
+                flux_err.push(1.0 / wi.sqrt());
+                band_idx.push(band_i);
+            }
+        }
+
+        let result = fit::fit(&self.model, &t, &flux, &flux_err, &band_idx);
+        if !result.success {
+            return Err(EvaluatorError::FitDidNotConverge.into());
+        }
+
+        let to_t = |x: f64| {
+            x.approx_as::<T>().unwrap_or_else(|_| {
+                if x.is_sign_negative() {
+                    T::min_value()
+                } else {
+                    T::max_value()
+                }
+            })
+        };
+        let mut out: Vec<T> = Vec::with_capacity(self.properties.info.size);
+        out.extend(result.params.iter().copied().map(to_t));
+        out.extend(result.errors.iter().copied().map(to_t));
+        out.push(to_t(result.reduced_chi2));
+
+        Ok(out)
+    }
+}
+
+/// Serde/JsonSchema surrogate for [`RainbowFit`]: only the user-facing configuration is
+/// (de)serialized; `model`/`properties` are rebuilt from it (via [`RainbowFit::new`]) since they
+/// are derived state, not independent configuration.
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(
+    rename = "RainbowFit",
+    bound(
+        serialize = "P: PassbandTrait + Serialize, T: Float",
+        deserialize = "P: PassbandTrait + Deserialize<'de>, T: Float"
+    )
+)]
+struct RainbowFitParameters<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    bolometric: Bolometric,
+    temperature: Temperature,
+    spectral: Spectral,
+    with_baseline: bool,
+    passbands: Vec<P>,
+    #[serde(skip)]
+    _marker: PhantomData<T>,
+}
+
+impl<P, T> From<RainbowFit<P, T>> for RainbowFitParameters<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn from(r: RainbowFit<P, T>) -> Self {
+        Self {
+            bolometric: r.bolometric,
+            temperature: r.temperature,
+            spectral: r.spectral,
+            with_baseline: r.with_baseline,
+            passbands: r.passband_set.0.into_iter().collect(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<P, T> TryFrom<RainbowFitParameters<P, T>> for RainbowFit<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    type Error = RainbowFitError;
+
+    fn try_from(p: RainbowFitParameters<P, T>) -> Result<Self, Self::Error> {
+        Self::new(
+            p.passbands,
+            p.bolometric,
+            p.temperature,
+            p.spectral,
+            p.with_baseline,
+        )
+    }
+}
+
+impl<P, T> JsonSchema for RainbowFit<P, T>
+where
+    P: PassbandTrait + JsonSchema,
+    T: Float,
+{
+    json_schema!(RainbowFitParameters<P, T>, false);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::TimeSeries;
+    use crate::multicolor::MonochromePassband;
+
+    use std::collections::BTreeMap;
+
+    fn bands() -> Vec<MonochromePassband<'static, f64>> {
+        vec![
+            MonochromePassband::new(4770.0e-8, "g"),
+            MonochromePassband::new(6231.0e-8, "r"),
+        ]
+    }
+
+    fn make_rainbow() -> RainbowFit<MonochromePassband<'static, f64>, f64> {
+        RainbowFit::new(
+            bands(),
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            false,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn construction_requires_at_least_one_band() {
+        let err = RainbowFit::<MonochromePassband<'static, f64>, f64>::new(
+            [],
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            false,
+        )
+        .unwrap_err();
+        assert_eq!(err, RainbowFitError::NoPassbands);
+    }
+
+    #[test]
+    fn construction_rejects_wavelength_less_passbands() {
+        use crate::multicolor::StringPassband;
+        let err = RainbowFit::<StringPassband, f64>::new(
+            [StringPassband::from("g")],
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            false,
+        )
+        .unwrap_err();
+        assert!(matches!(err, RainbowFitError::MissingWavelength(_)));
+    }
+
+    #[test]
+    fn names_and_size_match_2n_plus_1() {
+        let rainbow = make_rainbow();
+        // reference_time, amplitude, rise_time, fall_time, T, T_amplitude, t_color = 7 params
+        assert_eq!(rainbow.size_hint(), 2 * 7 + 1);
+        assert_eq!(rainbow.get_names().len(), rainbow.size_hint());
+        assert!(rainbow.get_names().contains(&"rainbow_reference_time"));
+        assert!(
+            rainbow
+                .get_names()
+                .contains(&"rainbow_reference_time_sigma")
+        );
+        assert!(rainbow.get_names().contains(&"rainbow_reduced_chi2"));
+    }
+
+    #[test]
+    fn recovers_known_parameters_from_noisy_multiband_light_curve() {
+        let rainbow = make_rainbow();
+
+        let truth = [58900.0_f64, 120.0, 5.0, 25.0, 11000.0, 0.2, 8.0];
+        let mut rng_state: u64 = 42;
+        let mut rand01 = move || {
+            // xorshift, deterministic, no extra dev-dependency needed here.
+            rng_state ^= rng_state << 13;
+            rng_state ^= rng_state >> 7;
+            rng_state ^= rng_state << 17;
+            (rng_state >> 11) as f64 / (1u64 << 53) as f64
+        };
+
+        let mut map = BTreeMap::new();
+        for band in bands() {
+            let n = 60;
+            let mut t: Vec<f64> = (0..n).map(|_| truth[0] - 15.0 + rand01() * 90.0).collect();
+            t.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            let m: Vec<f64> = t
+                .iter()
+                .map(|&ti| {
+                    let flux =
+                        rainbow
+                            .model
+                            .model(ti, if band.name == "g" { 0 } else { 1 }, &truth);
+                    let err = (flux.abs() * 0.02).max(0.05);
+                    // Box-Muller for approximately Gaussian noise from two uniforms.
+                    let u1 = rand01().max(1e-12);
+                    let u2 = rand01();
+                    let noise =
+                        err * (-2.0 * u1.ln()).sqrt() * (2.0 * std::f64::consts::PI * u2).cos();
+                    flux + noise
+                })
+                .collect();
+            let w: Vec<f64> = t
+                .iter()
+                .map(|&ti| {
+                    1.0 / (rainbow.model.model(ti, 0, &truth).abs() * 0.02)
+                        .max(0.05)
+                        .powi(2)
+                })
+                .collect();
+            map.insert(band, TimeSeries::new(t, m, w));
+        }
+
+        let mut mcts = MultiColorTimeSeries::from_map(map);
+        let result = rainbow.eval_multicolor(&mut mcts).unwrap();
+
+        assert_eq!(result.len(), rainbow.size_hint());
+        let reduced_chi2 = result[14];
+        assert!(reduced_chi2 < 3.0, "reduced chi2 too high: {reduced_chi2}");
+
+        let rel_err =
+            |actual: f64, expected: f64| (actual - expected).abs() / expected.abs().max(1.0);
+        assert!(rel_err(result[0], truth[0]) < 0.02); // reference_time
+        assert!(rel_err(result[1], truth[1]) < 0.15); // amplitude
+        assert!(rel_err(result[4], truth[4]) < 0.2); // T
+    }
+}

--- a/src/multicolor/rainbow/mod.rs
+++ b/src/multicolor/rainbow/mod.rs
@@ -4,69 +4,43 @@
 //! $$
 //! \mathrm{flux}(t, \lambda) = \mathrm{bol}(t) \cdot \frac{B(\lambda, T(t))}{\mathrm{norm}(T(t))} \ [+ \ \mathrm{baseline}_\mathrm{band}].
 //! $$
-//! `bol(t)` (a [`terms::Bolometric`] choice), `T(t)` (a [`terms::Temperature`] choice), and
-//! `B(lambda, T)` (a [`terms::Spectral`] choice) are independently pluggable; see [`RainbowFit::new`]
-//! and each enum's own documentation for the available functional forms and their parameters.
-//! `norm(T)` is always the Stefan-Boltzmann/Planck-based normalization regardless of which SED is
-//! chosen (see [`model`] for the composition), so the overall flux scale is carried entirely by
-//! the bolometric term's `amplitude`.
+//! `bol(t)`, `T(t)`, and `B(lambda, T)` are independently pluggable ([`terms::Bolometric`],
+//! [`terms::Temperature`], [`terms::Spectral`] -- see [`RainbowFit::new`]). `norm(T)` is always
+//! the Planck-based normalization, so overall flux scale is carried by the bolometric term's
+//! `amplitude`.
 //!
-//! # Why this doesn't use `nl_fit`/`CurveFitAlgorithm`
+//! # Why not `nl_fit`
 //!
-//! [`nl_fit`](crate::nl_fit) (used by `BazinFit`, `VillarFit`, etc.) is built around a
-//! compile-time-fixed `const NPARAMS: usize`: fixed-size `[f64; NPARAMS]` arrays throughout, and
-//! [`CurveFitTrait`](crate::nl_fit::CurveFitTrait)'s `curve_fit` is generic over that same
-//! constant. Rainbow's parameter count depends on which bolometric/temperature/spectral terms are
-//! chosen (and whether a baseline is fit), so it can't be a compile-time constant here. Instead,
-//! [`fit`] implements a self-contained Levenberg-Marquardt fit (via the `levenberg-marquardt`
-//! crate, `Dyn`-dimensioned rather than `Const<NPARAMS>`) directly, the same way `ParabolaFit`
-//! (`crate::parabola_fit`) implements its own closed-form fit without going through `nl_fit`.
-//!
-//! # Bounds instead of `nl_fit`'s internal/dimensionless/external spaces
-//!
-//! Every parameter is fit through an unconstrained internal optimizer variable, reparametrized
-//! into a physical-unit `(lower, upper)` box via a logistic map (see [`fit`]'s module doc for the
-//! exact transform) -- conceptually the same idea as `nl_fit`'s internal/dimensionless/external
-//! split (e.g. `BazinFit` using `abs()` to enforce positivity), but expressed as a single bounded
-//! transform per parameter rather than a separate data-normalization layer plus a sign-only
-//! reparametrization. Bounds are computed per-fit from the data (mirroring the Python reference
-//! implementation's heuristics) by each term's own `bounds()` method.
+//! [`nl_fit`](crate::nl_fit) (used by `BazinFit`, `VillarFit`, etc.) assumes a compile-time
+//! `const NPARAMS`. Rainbow's parameter count depends on which terms are chosen, so it can't be
+//! one; [`fit`] instead runs its own `Dyn`-dimensioned Levenberg-Marquardt fit directly, the same
+//! way `ParabolaFit` bypasses `nl_fit` for its own closed-form fit. See [`fit`]'s module doc for
+//! the bounded-parameter transform.
 //!
 //! # Uncertainties
 //!
-//! [`fit::fit`] additionally computes 1-sigma parameter uncertainties from the Gauss-Newton
-//! covariance approximation `inv(JᵀJ)` (cheap: reuses the fit's own per-point gradient, one
-//! `n_params x n_params` matrix inversion). These are appended to this feature's output as
-//! `<name>_sigma` columns rather than requiring the generic `Bootstrap`/`MultiColorBootstrap`
-//! wrapper (which would substantially multiply the cost via resampling) -- see
-//! [`RainbowFit::build_properties`] for the exact output layout. Whether this is the right
-//! convention (vs. leaving uncertainty estimation to the `Bootstrap` wrapper, matching every
-//! other feature) is a design question for review.
+//! [`fit::fit`] also returns 1-sigma parameter uncertainties (Gauss-Newton `inv(JᵀJ)`, cheap
+//! since it reuses the fit's own gradient), appended to the output as `<name>_sigma` columns
+//! instead of going through the generic `Bootstrap` wrapper (which would multiply the cost via
+//! resampling). See [`RainbowFit::build_properties`] for the exact layout -- a different
+//! convention from every other feature, worth a second look on review.
 //!
 //! # Open design questions (flagged for review)
 //!
-//! - **New dependency**: this is the first pure-Rust linear-algebra dependency in the crate
-//!   (`levenberg-marquardt`, pulling in `nalgebra`), gated behind the opt-in `rainbow` Cargo
-//!   feature (see `Cargo.toml`) rather than `default`, following the `gsl`/`ceres-*` precedent
-//!   for optional heavy dependencies.
-//! - **`PassbandTrait::wavelength()`**: added as a new default (`None`) method so `RainbowFit`
-//!   can require a wavelength while still slotting into the generic `MultiColorFeature<P, T>`
-//!   registry like every other feature, at the cost of one new trait method affecting the
-//!   whole `multicolor` module.
-//! - **Output layout**: whether baking in analytic uncertainties (see above) is the right call,
-//!   or whether it should be dropped in favor of the existing `Bootstrap` convention.
+//! - **New dependency**: first pure-Rust linear-algebra dependency in the crate
+//!   (`levenberg-marquardt` + `nalgebra`), gated behind the opt-in `rainbow` Cargo feature.
+//! - **`PassbandTrait::wavelength()`**: new default (`None`) method so `RainbowFit` can require
+//!   a wavelength while still fitting into the generic `MultiColorFeature<P, T>` registry.
+//! - **Output layout**: see "Uncertainties" above.
 //!
 //! # Not yet ported from the Python reference
 //!
-//! - `bolometric = "linexp"`: Python's own docstring flags its guesses/limits as unstable,
-//!   confirmed by a seed sweep during development of this port (roughly half of random seeds
-//!   land the fit in a self-consistent-looking but wrong local optimum).
-//! - `spectral = "blanketed"`: its `lambda_scale` parameter anchors to the temperature term's own
-//!   characteristic `T` via Python's `common_temp_spec` cross-term parameter sharing, more
-//!   involved than a straight port of the other terms.
-//! - Gaussian priors on individual parameters (Python anchors e.g. `T_amplitude`, `beta` toward
-//!   0 to break known degeneracies for some spectral terms); non-detections/upper limits (Python
-//!   supports a Tobit-model likelihood term for these).
+//! - `bolometric = "linexp"`: Python's own docstring flags its guesses/limits as unstable
+//!   (confirmed here by a seed sweep -- about half land in a wrong local optimum).
+//! - `spectral = "blanketed"`: anchors to the temperature term's own `T` via Python's
+//!   `common_temp_spec` cross-term sharing, more involved than the other terms.
+//! - Gaussian priors anchoring some parameters (e.g. `T_amplitude`, `beta`) toward 0, and
+//!   non-detection/upper-limit support (Python's Tobit-model likelihood).
 
 mod constants;
 mod fit;
@@ -127,9 +101,8 @@ where
     spectral: Spectral,
     with_baseline: bool,
     passband_set: PassbandSet<P>,
-    /// Built once at construction from `passband_set`'s (sorted) iteration order; `model`'s
-    /// internal band indices correspond 1:1 to that same order, which `eval_multicolor_no_mcts_check`
-    /// relies on when flattening the input data.
+    /// Band indices match `passband_set`'s sorted order (relied on by
+    /// `eval_multicolor_no_mcts_check`).
     model: RainbowModel,
     properties: Box<EvaluatorProperties>,
     _marker: PhantomData<T>,
@@ -226,21 +199,15 @@ where
         EvaluatorProperties {
             info: EvaluatorInfo {
                 size: names.len(),
-                // A genuine per-band minimum isn't meaningful here (the fit is joint across
-                // bands, so what matters is the *total* point count vs. parameter count, not any
-                // single band's length); that check happens inside `eval_multicolor_no_mcts_check`
-                // via `fit::fit`'s own graceful "too few points" handling, converted to a proper
-                // error instead of relying on this precondition.
+                // Per-band minimums aren't meaningful for a joint multi-band fit; the real
+                // total-vs-parameter-count check happens inside `fit::fit`.
                 min_ts_length: 1,
                 t_required: true,
                 m_required: true,
                 w_required: true,
                 sorting_required: false,
-                // Not enforced per-band (see min_ts_length's comment): a single flat band
-                // shouldn't necessarily block a joint multi-band fit. A light curve that is flat
-                // in *every* band will not error here; today it produces a poorly-constrained
-                // (but not crashing) fit rather than a clean rejection -- a known gap, flagged in
-                // the module-level documentation rather than silently accepted.
+                // A light curve flat in every band isn't rejected today; it just produces a
+                // poorly-constrained fit (known gap, see module docs).
                 variability_required: false,
             },
             names,
@@ -248,10 +215,9 @@ where
         }
     }
 
-    /// Analytic bolometric peak time, if defined for the chosen [`Bolometric`] term (see each
-    /// variant's documentation). `params` must be the first `n_params` values of this feature's
-    /// output (i.e. the fitted parameters, not their `_sigma` uncertainties or `reduced_chi2`),
-    /// in [`FeatureNamesDescriptionsTrait::get_names`] order.
+    /// Analytic bolometric peak time, if defined for the chosen [`Bolometric`] term. `params`
+    /// must be just the fitted parameters (the first `n_params` values of this feature's
+    /// output, not the `_sigma`/`reduced_chi2` tail).
     pub fn peak_time(&self, params: &[T]) -> Option<T> {
         let params_f64: Vec<f64> = params.iter().map(|&x| x.value_into().unwrap()).collect();
         self.model.peak_time(&params_f64).map(|t| {
@@ -317,9 +283,8 @@ where
         'slf: 'a,
         'a: 'mcts,
     {
-        // Flatten all matched bands into flat f64 arrays, in the same band order as
-        // `self.model`'s internal band list (`self.passband_set`'s sorted iteration order, which
-        // is exactly how `model` was built in `new`).
+        // Flatten into flat f64 arrays; band order matches `self.model` (built from
+        // `passband_set`'s sorted order in `new`).
         mcts.with_mapping_mut(|_| {});
         let mapping = mcts.mapping().expect("mapping was just ensured");
 
@@ -371,9 +336,8 @@ where
     }
 }
 
-/// Serde/JsonSchema surrogate for [`RainbowFit`]: only the user-facing configuration is
-/// (de)serialized; `model`/`properties` are rebuilt from it (via [`RainbowFit::new`]) since they
-/// are derived state, not independent configuration.
+/// Serde/JsonSchema surrogate for [`RainbowFit`]: (de)serializes only the user-facing config;
+/// `model`/`properties` are derived state, rebuilt via [`RainbowFit::new`].
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(
     rename = "RainbowFit",

--- a/src/multicolor/rainbow/model.rs
+++ b/src/multicolor/rainbow/model.rs
@@ -1,0 +1,423 @@
+//! Composition of a chosen bolometric + temperature + spectral term (plus an optional per-band
+//! baseline) into the Rainbow flux model:
+//! $$
+//! \mathrm{flux}(t, \lambda) = \mathrm{bol}(t) \cdot \frac{B(\lambda, T(t))}{\mathrm{norm}(T(t))} \ [+ \ \mathrm{baseline}_\mathrm{band}],
+//! \quad \mathrm{norm}(T) = \frac{\sigma_{SB} T^4}{\pi\,\bar\nu},
+//! $$
+//! where $\bar\nu$ is the mean frequency across the fitted bands' wavelengths. This composition
+//! (and the `norm(T)` normalization, which always uses the Stefan-Boltzmann/Planck form
+//! regardless of which SED term is chosen -- only the SED's *shape* varies per term, not this
+//! amplitude normalization) mirrors Python's
+//! `light_curve_py.features.rainbow._base.BaseRainbowFit._lsq_model_{no_,with_}baseline`.
+//!
+//! This module works entirely in physical `f64` units on a fixed internal [`Band`] list (name +
+//! wavelength in cm); it has no awareness of the crate's generic `T: Float` or `P: PassbandTrait`
+//! -- [RainbowFit](super::RainbowFit) converts each configured passband's name/wavelength once at
+//! construction time and is the only place those generics matter.
+//!
+//! Since different bolometric/temperature/spectral term combinations (and band counts, when
+//! `with_baseline`) have different numbers of (possibly shared, e.g. `reference_time`)
+//! parameters, the parameter vector is a runtime-sized `&[f64]` rather than a fixed struct;
+//! [`ParamLayout`] records, for each term, which global parameter index its local parameters map
+//! to.
+
+use std::collections::HashMap;
+use std::f64::consts::PI;
+
+use super::constants::{SIGMA_SB, SPEED_OF_LIGHT};
+use super::terms::common::{max_min, median, ptp};
+use super::terms::{Bolometric, MAX_LOCAL_PARAMS, Spectral, Temperature};
+
+/// A photometric band: a name and its effective wavelength in cm.
+#[derive(Debug, Clone)]
+pub(crate) struct Band {
+    pub(crate) name: String,
+    pub(crate) wavelength_cm: f64,
+}
+
+fn baseline_param_name(band_name: &str) -> String {
+    format!("baseline_{band_name}")
+}
+
+/// Maps each term's local parameter indices (and, if `with_baseline`, each band's baseline
+/// parameter) to indices in the model's global (deduplicated-by-name) parameter vector.
+struct ParamLayout {
+    names: Vec<String>,
+    bol_map: Vec<usize>,
+    temp_map: Vec<usize>,
+    spec_map: Vec<usize>,
+    /// `baseline_map[band_idx]` = global parameter index, only populated when `with_baseline`.
+    baseline_map: Vec<usize>,
+}
+
+impl ParamLayout {
+    fn build(
+        bolometric: &Bolometric,
+        temperature: &Temperature,
+        spectral: &Spectral,
+        bands: &[Band],
+        with_baseline: bool,
+    ) -> Self {
+        let mut names: Vec<String> = Vec::new();
+        let mut name_to_idx: HashMap<String, usize> = HashMap::new();
+
+        let intern = |name: String, names: &mut Vec<String>, name_to_idx: &mut HashMap<String, usize>| -> usize {
+            if let Some(&idx) = name_to_idx.get(&name) {
+                idx
+            } else {
+                names.push(name.clone());
+                let idx = names.len() - 1;
+                name_to_idx.insert(name, idx);
+                idx
+            }
+        };
+
+        let bol_map: Vec<usize> = bolometric
+            .params()
+            .iter()
+            .map(|&n| intern(n.to_string(), &mut names, &mut name_to_idx))
+            .collect();
+        let temp_map: Vec<usize> = temperature
+            .params()
+            .iter()
+            .map(|&n| intern(n.to_string(), &mut names, &mut name_to_idx))
+            .collect();
+        let spec_map: Vec<usize> = spectral
+            .params()
+            .iter()
+            .map(|&n| intern(n.to_string(), &mut names, &mut name_to_idx))
+            .collect();
+
+        let baseline_map: Vec<usize> = if with_baseline {
+            bands
+                .iter()
+                .map(|b| intern(baseline_param_name(&b.name), &mut names, &mut name_to_idx))
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        Self { names, bol_map, temp_map, spec_map, baseline_map }
+    }
+}
+
+/// The Rainbow model: a chosen bolometric/temperature/spectral term combination (plus an
+/// optional per-band additive baseline) bound to a fixed set of bands.
+pub(crate) struct RainbowModel {
+    bolometric: Bolometric,
+    temperature: Temperature,
+    spectral: Spectral,
+    with_baseline: bool,
+    bands: Vec<Band>,
+    /// `speed_of_light / mean(wavelength)`, used to normalize the SED so that its scale is
+    /// carried entirely by `amplitude`.
+    average_nu: f64,
+    layout: ParamLayout,
+}
+
+impl RainbowModel {
+    pub(crate) fn new(
+        bolometric: Bolometric,
+        temperature: Temperature,
+        spectral: Spectral,
+        bands: Vec<Band>,
+        with_baseline: bool,
+    ) -> Self {
+        assert!(!bands.is_empty(), "RainbowModel requires at least one band");
+        let mean_wave_cm: f64 = bands.iter().map(|b| b.wavelength_cm).sum::<f64>() / bands.len() as f64;
+        let average_nu = SPEED_OF_LIGHT / mean_wave_cm;
+        let layout = ParamLayout::build(&bolometric, &temperature, &spectral, &bands, with_baseline);
+        Self { bolometric, temperature, spectral, with_baseline, bands, average_nu, layout }
+    }
+
+    pub(crate) fn n_params(&self) -> usize {
+        self.layout.names.len()
+    }
+
+    pub(crate) fn param_names(&self) -> &[String] {
+        &self.layout.names
+    }
+
+    pub(crate) fn bands(&self) -> &[Band] {
+        &self.bands
+    }
+
+    /// Evaluate the model flux at time `t` in the given band.
+    pub(crate) fn model(&self, t: f64, band_idx: usize, params: &[f64]) -> f64 {
+        self.model_and_gradient(t, band_idx, params).0
+    }
+
+    /// Evaluate the model flux and its gradient w.r.t. every global parameter (length
+    /// `n_params()`), mirroring `_lsq_jac_{no_,with_}baseline`'s chain rule through
+    /// `bol(t) * SED(wave, T(t)) / norm(T(t)) [+ baseline_band]`.
+    pub(crate) fn model_and_gradient(&self, t: f64, band_idx: usize, params: &[f64]) -> (f64, Vec<f64>) {
+        let wave_cm = self.bands[band_idx].wavelength_cm;
+
+        let n_bol = self.bolometric.n_params();
+        let n_temp = self.temperature.n_params();
+        let n_spec = self.spectral.n_params();
+
+        let mut bol_local = [0.0; MAX_LOCAL_PARAMS];
+        for i in 0..n_bol {
+            bol_local[i] = params[self.layout.bol_map[i]];
+        }
+        let mut bol_jac = [0.0; MAX_LOCAL_PARAMS];
+        let bol = self.bolometric.value_jac(t, &bol_local[..n_bol], &mut bol_jac[..n_bol]);
+
+        let mut temp_local = [0.0; MAX_LOCAL_PARAMS];
+        for i in 0..n_temp {
+            temp_local[i] = params[self.layout.temp_map[i]];
+        }
+        let mut temp_jac = [0.0; MAX_LOCAL_PARAMS];
+        let temp = self.temperature.value_jac(t, &temp_local[..n_temp], &mut temp_jac[..n_temp]);
+
+        let mut spec_local = [0.0; MAX_LOCAL_PARAMS];
+        for i in 0..n_spec {
+            spec_local[i] = params[self.layout.spec_map[i]];
+        }
+        let mut spec_jac = [0.0; MAX_LOCAL_PARAMS];
+        let (spectral_val, dspectral_dt) =
+            self.spectral.value_jac(wave_cm, temp, &spec_local[..n_spec], &mut spec_jac[..n_spec]);
+
+        // norm(T) is always the Stefan-Boltzmann/Planck-based normalization, regardless of which
+        // spectral term is in use (matches Python: only the SED *shape* varies per term, the
+        // amplitude normalization does not).
+        let norm = SIGMA_SB * temp.powi(4) / PI / self.average_nu;
+        let shape = spectral_val / norm;
+        // d(shape)/dT = d(spectral)/dT / norm - 4*shape/T, since d(norm)/dT = 4*norm/T.
+        let dshape_dt = dspectral_dt / norm - 4.0 * shape / temp;
+
+        let mut flux = bol * shape;
+
+        let mut grad = vec![0.0; self.n_params()];
+        for i in 0..n_bol {
+            grad[self.layout.bol_map[i]] += bol_jac[i] * shape;
+        }
+        for i in 0..n_temp {
+            grad[self.layout.temp_map[i]] += bol * dshape_dt * temp_jac[i];
+        }
+        for i in 0..n_spec {
+            grad[self.layout.spec_map[i]] += bol * spec_jac[i] / norm;
+        }
+
+        if self.with_baseline {
+            let g = self.layout.baseline_map[band_idx];
+            flux += params[g];
+            grad[g] += 1.0;
+        }
+
+        (flux, grad)
+    }
+
+    /// Assembles a per-term `Vec` (`bol`/`temp`/`spec`, each in that term's own `params()`
+    /// order) into the global parameter vector, first writer wins for shared names (e.g.
+    /// `reference_time`: the bolometric term's value is used, the temperature term's is computed
+    /// but discarded).
+    fn assemble<T: Copy + Default>(&self, bol: Vec<T>, temp: Vec<T>, spec: Vec<T>) -> Vec<T> {
+        let mut out = vec![T::default(); self.n_params()];
+        let mut filled = vec![false; self.n_params()];
+        for (i, v) in bol.into_iter().enumerate() {
+            let g = self.layout.bol_map[i];
+            out[g] = v;
+            filled[g] = true;
+        }
+        for (i, v) in temp.into_iter().enumerate() {
+            let g = self.layout.temp_map[i];
+            if !filled[g] {
+                out[g] = v;
+                filled[g] = true;
+            }
+        }
+        for (i, v) in spec.into_iter().enumerate() {
+            let g = self.layout.spec_map[i];
+            out[g] = v;
+        }
+        out
+    }
+
+    /// Per-band median flux, used as the baseline's own initial guess and to baseline-subtract
+    /// the data before computing every other term's initial guess / bounds (mirrors Python's
+    /// `_baseline_initial_guesses` + `m_corr`).
+    fn per_band_baseline_estimate(&self, flux: &[f64], band_idx: &[usize]) -> Vec<f64> {
+        (0..self.bands.len())
+            .map(|b| {
+                let band_flux: Vec<f64> =
+                    flux.iter().zip(band_idx).filter(|&(_, &bi)| bi == b).map(|(&f, _)| f).collect();
+                if band_flux.is_empty() { 0.0 } else { median(&band_flux) }
+            })
+            .collect()
+    }
+
+    /// Heuristic initial guess (physical units), same order as [`Self::param_names`].
+    pub(crate) fn initial_guess(&self, t: &[f64], flux: &[f64], flux_err: &[f64], band_idx: &[usize]) -> Vec<f64> {
+        let (flux_corrected, baseline_guess) = if self.with_baseline {
+            let baseline_guess = self.per_band_baseline_estimate(flux, band_idx);
+            let corrected: Vec<f64> = flux.iter().zip(band_idx).map(|(&f, &b)| f - baseline_guess[b]).collect();
+            (corrected, baseline_guess)
+        } else {
+            (flux.to_vec(), Vec::new())
+        };
+
+        let bol_guess = self.bolometric.initial_guess(t, &flux_corrected, flux_err);
+        let temp_guess = self.temperature.initial_guess(t, &flux_corrected, flux_err);
+        let spec_guess = self.spectral.initial_guess();
+
+        // Each term's guess is matched positionally against its own params() list (see
+        // layout.{bol,temp,spec}_map); a length mismatch here silently desyncs every subsequent
+        // parameter.
+        debug_assert_eq!(bol_guess.len(), self.bolometric.n_params());
+        debug_assert_eq!(temp_guess.len(), self.temperature.n_params());
+        debug_assert_eq!(spec_guess.len(), self.spectral.n_params());
+
+        let mut params = self.assemble(bol_guess, temp_guess, spec_guess);
+        for (b, g) in self.layout.baseline_map.iter().enumerate() {
+            params[*g] = baseline_guess[b];
+        }
+        params
+    }
+
+    /// Box bounds `(lower, upper)` (physical units), same order as [`Self::param_names`].
+    pub(crate) fn bounds(&self, t: &[f64], flux: &[f64], flux_err: &[f64], band_idx: &[usize]) -> Vec<(f64, f64)> {
+        let (flux_corrected, baseline_bounds) = if self.with_baseline {
+            let baseline_guess = self.per_band_baseline_estimate(flux, band_idx);
+            let corrected: Vec<f64> = flux.iter().zip(band_idx).map(|(&f, &b)| f - baseline_guess[b]).collect();
+            let bounds: Vec<(f64, f64)> = (0..self.bands.len())
+                .map(|b| {
+                    let band_flux: Vec<f64> =
+                        flux.iter().zip(band_idx).filter(|&(_, &bi)| bi == b).map(|(&f, _)| f).collect();
+                    if band_flux.is_empty() {
+                        (0.0, 0.0)
+                    } else {
+                        let (max, min) = max_min(&band_flux);
+                        (min - 10.0 * ptp(&band_flux), max)
+                    }
+                })
+                .collect();
+            (corrected, bounds)
+        } else {
+            (flux.to_vec(), Vec::new())
+        };
+
+        let bol_bounds = self.bolometric.bounds(t, &flux_corrected, flux_err);
+        let temp_bounds = self.temperature.bounds(t, &flux_corrected, flux_err);
+        let spec_bounds = self.spectral.bounds();
+
+        debug_assert_eq!(bol_bounds.len(), self.bolometric.n_params());
+        debug_assert_eq!(temp_bounds.len(), self.temperature.n_params());
+        debug_assert_eq!(spec_bounds.len(), self.spectral.n_params());
+
+        let mut bounds = self.assemble(bol_bounds, temp_bounds, spec_bounds);
+        for (b, g) in self.layout.baseline_map.iter().enumerate() {
+            bounds[*g] = baseline_bounds[b];
+        }
+        bounds
+    }
+
+    /// Analytic bolometric peak time, if defined for the chosen bolometric term.
+    pub(crate) fn peak_time(&self, params: &[f64]) -> Option<f64> {
+        let n_bol = self.bolometric.n_params();
+        let bol_local: Vec<f64> = (0..n_bol).map(|i| params[self.layout.bol_map[i]]).collect();
+        self.bolometric.peak_time(&bol_local)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_bands() -> Vec<Band> {
+        vec![
+            Band { name: "g".to_string(), wavelength_cm: 4770.0e-8 },
+            Band { name: "r".to_string(), wavelength_cm: 6231.0e-8 },
+        ]
+    }
+
+    fn check_gradient(model: &RainbowModel, params: &[f64], h: &[f64]) {
+        let t = 15.0;
+        let band_idx = 1;
+        let (_, analytic) = model.model_and_gradient(t, band_idx, params);
+        for k in 0..params.len() {
+            let mut plus = params.to_vec();
+            let mut minus = params.to_vec();
+            plus[k] += h[k];
+            minus[k] -= h[k];
+            let f_plus = model.model(t, band_idx, &plus);
+            let f_minus = model.model(t, band_idx, &minus);
+            let numeric = (f_plus - f_minus) / (2.0 * h[k]);
+            assert!(
+                (analytic[k] - numeric).abs() <= 1e-4 * numeric.abs().max(1.0),
+                "param {k}: analytic={}, numeric={}",
+                analytic[k],
+                numeric
+            );
+        }
+    }
+
+    #[test]
+    fn bazin_sigmoid_planck_gradient_matches_finite_difference() {
+        let model =
+            RainbowModel::new(Bolometric::Bazin, Temperature::Sigmoid, Spectral::Planck, sample_bands(), false);
+        // reference_time, amplitude, rise_time, fall_time, T, T_amplitude, t_color
+        let params = [10.0, 5.0, 3.0, 20.0, 9000.0, 0.2, 5.0];
+        let h = [1e-4, 1e-5, 1e-5, 1e-5, 1e-2, 1e-6, 1e-5];
+        check_gradient(&model, &params, &h);
+    }
+
+    #[test]
+    fn bazin_sigmoid_planck_with_baseline_gradient_matches_finite_difference() {
+        let model = RainbowModel::new(Bolometric::Bazin, Temperature::Sigmoid, Spectral::Planck, sample_bands(), true);
+        // reference_time, amplitude, rise_time, fall_time, T, T_amplitude, t_color, baseline_g, baseline_r
+        let params = [10.0, 5.0, 3.0, 20.0, 9000.0, 0.2, 5.0, 1.5, -0.7];
+        let h = [1e-4, 1e-5, 1e-5, 1e-5, 1e-2, 1e-6, 1e-5, 1e-5, 1e-5];
+        check_gradient(&model, &params, &h);
+    }
+
+    #[test]
+    fn sigmoid_bol_constant_genwien_gradient_matches_finite_difference() {
+        let model =
+            RainbowModel::new(Bolometric::Sigmoid, Temperature::Constant, Spectral::GenWien, sample_bands(), false);
+        // reference_time, amplitude, rise_time, T, spec_k
+        let params = [10.0, 5.0, 3.0, 9000.0, 1.3];
+        let h = [1e-4, 1e-5, 1e-5, 1e-2, 1e-6];
+        check_gradient(&model, &params, &h);
+    }
+
+    #[test]
+    fn doublexp_delayed_sigmoid_logparabola_gradient_matches_finite_difference() {
+        let model = RainbowModel::new(
+            Bolometric::Doublexp,
+            Temperature::DelayedSigmoid,
+            Spectral::LogParabola,
+            sample_bands(),
+            false,
+        );
+        // reference_time, amplitude, time1, time2, p, T, T_amplitude, t_color, t_delay, sp_a, sp_b
+        let params = [10.0, 5.0, 3.0, 4.0, 1.5, 9000.0, 0.2, 5.0, 1.0, 0.3, -0.2];
+        let h = [1e-4, 1e-5, 1e-5, 1e-5, 1e-5, 1e-2, 1e-6, 1e-5, 1e-5, 1e-6, 1e-6];
+        check_gradient(&model, &params, &h);
+    }
+
+    #[test]
+    fn shared_reference_time_deduplicated() {
+        let model =
+            RainbowModel::new(Bolometric::Bazin, Temperature::Sigmoid, Spectral::Planck, sample_bands(), false);
+        assert_eq!(model.n_params(), 7); // not 4+4+0=8; reference_time is shared
+        assert_eq!(model.param_names()[0], "reference_time");
+    }
+
+    #[test]
+    fn constant_temperature_has_no_reference_time_collision() {
+        let model =
+            RainbowModel::new(Bolometric::Bazin, Temperature::Constant, Spectral::Planck, sample_bands(), false);
+        assert_eq!(model.n_params(), 5); // 4 bol + 1 temp (T), no shared name
+    }
+
+    #[test]
+    fn baseline_params_appended_per_band() {
+        let model =
+            RainbowModel::new(Bolometric::Bazin, Temperature::Sigmoid, Spectral::Planck, sample_bands(), true);
+        assert_eq!(model.n_params(), 9); // 7 + baseline_g + baseline_r
+        assert_eq!(model.param_names()[7], "baseline_g");
+        assert_eq!(model.param_names()[8], "baseline_r");
+    }
+}

--- a/src/multicolor/rainbow/model.rs
+++ b/src/multicolor/rainbow/model.rs
@@ -41,6 +41,7 @@ fn baseline_param_name(band_name: &str) -> String {
 
 /// Maps each term's local parameter indices (and, if `with_baseline`, each band's baseline
 /// parameter) to indices in the model's global (deduplicated-by-name) parameter vector.
+#[derive(Clone)]
 struct ParamLayout {
     names: Vec<String>,
     bol_map: Vec<usize>,
@@ -61,7 +62,10 @@ impl ParamLayout {
         let mut names: Vec<String> = Vec::new();
         let mut name_to_idx: HashMap<String, usize> = HashMap::new();
 
-        let intern = |name: String, names: &mut Vec<String>, name_to_idx: &mut HashMap<String, usize>| -> usize {
+        let intern = |name: String,
+                      names: &mut Vec<String>,
+                      name_to_idx: &mut HashMap<String, usize>|
+         -> usize {
             if let Some(&idx) = name_to_idx.get(&name) {
                 idx
             } else {
@@ -97,12 +101,19 @@ impl ParamLayout {
             Vec::new()
         };
 
-        Self { names, bol_map, temp_map, spec_map, baseline_map }
+        Self {
+            names,
+            bol_map,
+            temp_map,
+            spec_map,
+            baseline_map,
+        }
     }
 }
 
 /// The Rainbow model: a chosen bolometric/temperature/spectral term combination (plus an
 /// optional per-band additive baseline) bound to a fixed set of bands.
+#[derive(Clone)]
 pub(crate) struct RainbowModel {
     bolometric: Bolometric,
     temperature: Temperature,
@@ -124,10 +135,20 @@ impl RainbowModel {
         with_baseline: bool,
     ) -> Self {
         assert!(!bands.is_empty(), "RainbowModel requires at least one band");
-        let mean_wave_cm: f64 = bands.iter().map(|b| b.wavelength_cm).sum::<f64>() / bands.len() as f64;
+        let mean_wave_cm: f64 =
+            bands.iter().map(|b| b.wavelength_cm).sum::<f64>() / bands.len() as f64;
         let average_nu = SPEED_OF_LIGHT / mean_wave_cm;
-        let layout = ParamLayout::build(&bolometric, &temperature, &spectral, &bands, with_baseline);
-        Self { bolometric, temperature, spectral, with_baseline, bands, average_nu, layout }
+        let layout =
+            ParamLayout::build(&bolometric, &temperature, &spectral, &bands, with_baseline);
+        Self {
+            bolometric,
+            temperature,
+            spectral,
+            with_baseline,
+            bands,
+            average_nu,
+            layout,
+        }
     }
 
     pub(crate) fn n_params(&self) -> usize {
@@ -138,10 +159,6 @@ impl RainbowModel {
         &self.layout.names
     }
 
-    pub(crate) fn bands(&self) -> &[Band] {
-        &self.bands
-    }
-
     /// Evaluate the model flux at time `t` in the given band.
     pub(crate) fn model(&self, t: f64, band_idx: usize, params: &[f64]) -> f64 {
         self.model_and_gradient(t, band_idx, params).0
@@ -150,7 +167,12 @@ impl RainbowModel {
     /// Evaluate the model flux and its gradient w.r.t. every global parameter (length
     /// `n_params()`), mirroring `_lsq_jac_{no_,with_}baseline`'s chain rule through
     /// `bol(t) * SED(wave, T(t)) / norm(T(t)) [+ baseline_band]`.
-    pub(crate) fn model_and_gradient(&self, t: f64, band_idx: usize, params: &[f64]) -> (f64, Vec<f64>) {
+    pub(crate) fn model_and_gradient(
+        &self,
+        t: f64,
+        band_idx: usize,
+        params: &[f64],
+    ) -> (f64, Vec<f64>) {
         let wave_cm = self.bands[band_idx].wavelength_cm;
 
         let n_bol = self.bolometric.n_params();
@@ -162,22 +184,30 @@ impl RainbowModel {
             bol_local[i] = params[self.layout.bol_map[i]];
         }
         let mut bol_jac = [0.0; MAX_LOCAL_PARAMS];
-        let bol = self.bolometric.value_jac(t, &bol_local[..n_bol], &mut bol_jac[..n_bol]);
+        let bol = self
+            .bolometric
+            .value_jac(t, &bol_local[..n_bol], &mut bol_jac[..n_bol]);
 
         let mut temp_local = [0.0; MAX_LOCAL_PARAMS];
         for i in 0..n_temp {
             temp_local[i] = params[self.layout.temp_map[i]];
         }
         let mut temp_jac = [0.0; MAX_LOCAL_PARAMS];
-        let temp = self.temperature.value_jac(t, &temp_local[..n_temp], &mut temp_jac[..n_temp]);
+        let temp = self
+            .temperature
+            .value_jac(t, &temp_local[..n_temp], &mut temp_jac[..n_temp]);
 
         let mut spec_local = [0.0; MAX_LOCAL_PARAMS];
         for i in 0..n_spec {
             spec_local[i] = params[self.layout.spec_map[i]];
         }
         let mut spec_jac = [0.0; MAX_LOCAL_PARAMS];
-        let (spectral_val, dspectral_dt) =
-            self.spectral.value_jac(wave_cm, temp, &spec_local[..n_spec], &mut spec_jac[..n_spec]);
+        let (spectral_val, dspectral_dt) = self.spectral.value_jac(
+            wave_cm,
+            temp,
+            &spec_local[..n_spec],
+            &mut spec_jac[..n_spec],
+        );
 
         // norm(T) is always the Stefan-Boltzmann/Planck-based normalization, regardless of which
         // spectral term is in use (matches Python: only the SED *shape* varies per term, the
@@ -241,18 +271,36 @@ impl RainbowModel {
     fn per_band_baseline_estimate(&self, flux: &[f64], band_idx: &[usize]) -> Vec<f64> {
         (0..self.bands.len())
             .map(|b| {
-                let band_flux: Vec<f64> =
-                    flux.iter().zip(band_idx).filter(|&(_, &bi)| bi == b).map(|(&f, _)| f).collect();
-                if band_flux.is_empty() { 0.0 } else { median(&band_flux) }
+                let band_flux: Vec<f64> = flux
+                    .iter()
+                    .zip(band_idx)
+                    .filter(|&(_, &bi)| bi == b)
+                    .map(|(&f, _)| f)
+                    .collect();
+                if band_flux.is_empty() {
+                    0.0
+                } else {
+                    median(&band_flux)
+                }
             })
             .collect()
     }
 
     /// Heuristic initial guess (physical units), same order as [`Self::param_names`].
-    pub(crate) fn initial_guess(&self, t: &[f64], flux: &[f64], flux_err: &[f64], band_idx: &[usize]) -> Vec<f64> {
+    pub(crate) fn initial_guess(
+        &self,
+        t: &[f64],
+        flux: &[f64],
+        flux_err: &[f64],
+        band_idx: &[usize],
+    ) -> Vec<f64> {
         let (flux_corrected, baseline_guess) = if self.with_baseline {
             let baseline_guess = self.per_band_baseline_estimate(flux, band_idx);
-            let corrected: Vec<f64> = flux.iter().zip(band_idx).map(|(&f, &b)| f - baseline_guess[b]).collect();
+            let corrected: Vec<f64> = flux
+                .iter()
+                .zip(band_idx)
+                .map(|(&f, &b)| f - baseline_guess[b])
+                .collect();
             (corrected, baseline_guess)
         } else {
             (flux.to_vec(), Vec::new())
@@ -277,14 +325,28 @@ impl RainbowModel {
     }
 
     /// Box bounds `(lower, upper)` (physical units), same order as [`Self::param_names`].
-    pub(crate) fn bounds(&self, t: &[f64], flux: &[f64], flux_err: &[f64], band_idx: &[usize]) -> Vec<(f64, f64)> {
+    pub(crate) fn bounds(
+        &self,
+        t: &[f64],
+        flux: &[f64],
+        flux_err: &[f64],
+        band_idx: &[usize],
+    ) -> Vec<(f64, f64)> {
         let (flux_corrected, baseline_bounds) = if self.with_baseline {
             let baseline_guess = self.per_band_baseline_estimate(flux, band_idx);
-            let corrected: Vec<f64> = flux.iter().zip(band_idx).map(|(&f, &b)| f - baseline_guess[b]).collect();
+            let corrected: Vec<f64> = flux
+                .iter()
+                .zip(band_idx)
+                .map(|(&f, &b)| f - baseline_guess[b])
+                .collect();
             let bounds: Vec<(f64, f64)> = (0..self.bands.len())
                 .map(|b| {
-                    let band_flux: Vec<f64> =
-                        flux.iter().zip(band_idx).filter(|&(_, &bi)| bi == b).map(|(&f, _)| f).collect();
+                    let band_flux: Vec<f64> = flux
+                        .iter()
+                        .zip(band_idx)
+                        .filter(|&(_, &bi)| bi == b)
+                        .map(|(&f, _)| f)
+                        .collect();
                     if band_flux.is_empty() {
                         (0.0, 0.0)
                     } else {
@@ -327,8 +389,14 @@ mod tests {
 
     fn sample_bands() -> Vec<Band> {
         vec![
-            Band { name: "g".to_string(), wavelength_cm: 4770.0e-8 },
-            Band { name: "r".to_string(), wavelength_cm: 6231.0e-8 },
+            Band {
+                name: "g".to_string(),
+                wavelength_cm: 4770.0e-8,
+            },
+            Band {
+                name: "r".to_string(),
+                wavelength_cm: 6231.0e-8,
+            },
         ]
     }
 
@@ -355,8 +423,13 @@ mod tests {
 
     #[test]
     fn bazin_sigmoid_planck_gradient_matches_finite_difference() {
-        let model =
-            RainbowModel::new(Bolometric::Bazin, Temperature::Sigmoid, Spectral::Planck, sample_bands(), false);
+        let model = RainbowModel::new(
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            sample_bands(),
+            false,
+        );
         // reference_time, amplitude, rise_time, fall_time, T, T_amplitude, t_color
         let params = [10.0, 5.0, 3.0, 20.0, 9000.0, 0.2, 5.0];
         let h = [1e-4, 1e-5, 1e-5, 1e-5, 1e-2, 1e-6, 1e-5];
@@ -365,7 +438,13 @@ mod tests {
 
     #[test]
     fn bazin_sigmoid_planck_with_baseline_gradient_matches_finite_difference() {
-        let model = RainbowModel::new(Bolometric::Bazin, Temperature::Sigmoid, Spectral::Planck, sample_bands(), true);
+        let model = RainbowModel::new(
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            sample_bands(),
+            true,
+        );
         // reference_time, amplitude, rise_time, fall_time, T, T_amplitude, t_color, baseline_g, baseline_r
         let params = [10.0, 5.0, 3.0, 20.0, 9000.0, 0.2, 5.0, 1.5, -0.7];
         let h = [1e-4, 1e-5, 1e-5, 1e-5, 1e-2, 1e-6, 1e-5, 1e-5, 1e-5];
@@ -374,8 +453,13 @@ mod tests {
 
     #[test]
     fn sigmoid_bol_constant_genwien_gradient_matches_finite_difference() {
-        let model =
-            RainbowModel::new(Bolometric::Sigmoid, Temperature::Constant, Spectral::GenWien, sample_bands(), false);
+        let model = RainbowModel::new(
+            Bolometric::Sigmoid,
+            Temperature::Constant,
+            Spectral::GenWien,
+            sample_bands(),
+            false,
+        );
         // reference_time, amplitude, rise_time, T, spec_k
         let params = [10.0, 5.0, 3.0, 9000.0, 1.3];
         let h = [1e-4, 1e-5, 1e-5, 1e-2, 1e-6];
@@ -393,29 +477,46 @@ mod tests {
         );
         // reference_time, amplitude, time1, time2, p, T, T_amplitude, t_color, t_delay, sp_a, sp_b
         let params = [10.0, 5.0, 3.0, 4.0, 1.5, 9000.0, 0.2, 5.0, 1.0, 0.3, -0.2];
-        let h = [1e-4, 1e-5, 1e-5, 1e-5, 1e-5, 1e-2, 1e-6, 1e-5, 1e-5, 1e-6, 1e-6];
+        let h = [
+            1e-4, 1e-5, 1e-5, 1e-5, 1e-5, 1e-2, 1e-6, 1e-5, 1e-5, 1e-6, 1e-6,
+        ];
         check_gradient(&model, &params, &h);
     }
 
     #[test]
     fn shared_reference_time_deduplicated() {
-        let model =
-            RainbowModel::new(Bolometric::Bazin, Temperature::Sigmoid, Spectral::Planck, sample_bands(), false);
+        let model = RainbowModel::new(
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            sample_bands(),
+            false,
+        );
         assert_eq!(model.n_params(), 7); // not 4+4+0=8; reference_time is shared
         assert_eq!(model.param_names()[0], "reference_time");
     }
 
     #[test]
     fn constant_temperature_has_no_reference_time_collision() {
-        let model =
-            RainbowModel::new(Bolometric::Bazin, Temperature::Constant, Spectral::Planck, sample_bands(), false);
+        let model = RainbowModel::new(
+            Bolometric::Bazin,
+            Temperature::Constant,
+            Spectral::Planck,
+            sample_bands(),
+            false,
+        );
         assert_eq!(model.n_params(), 5); // 4 bol + 1 temp (T), no shared name
     }
 
     #[test]
     fn baseline_params_appended_per_band() {
-        let model =
-            RainbowModel::new(Bolometric::Bazin, Temperature::Sigmoid, Spectral::Planck, sample_bands(), true);
+        let model = RainbowModel::new(
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            sample_bands(),
+            true,
+        );
         assert_eq!(model.n_params(), 9); // 7 + baseline_g + baseline_r
         assert_eq!(model.param_names()[7], "baseline_g");
         assert_eq!(model.param_names()[8], "baseline_r");

--- a/src/multicolor/rainbow/model.rs
+++ b/src/multicolor/rainbow/model.rs
@@ -4,22 +4,17 @@
 //! \mathrm{flux}(t, \lambda) = \mathrm{bol}(t) \cdot \frac{B(\lambda, T(t))}{\mathrm{norm}(T(t))} \ [+ \ \mathrm{baseline}_\mathrm{band}],
 //! \quad \mathrm{norm}(T) = \frac{\sigma_{SB} T^4}{\pi\,\bar\nu},
 //! $$
-//! where $\bar\nu$ is the mean frequency across the fitted bands' wavelengths. This composition
-//! (and the `norm(T)` normalization, which always uses the Stefan-Boltzmann/Planck form
-//! regardless of which SED term is chosen -- only the SED's *shape* varies per term, not this
-//! amplitude normalization) mirrors Python's
-//! `light_curve_py.features.rainbow._base.BaseRainbowFit._lsq_model_{no_,with_}baseline`.
+//! where $\bar\nu$ is the mean frequency across the fitted bands. `norm(T)` always uses the
+//! Stefan-Boltzmann/Planck form regardless of which SED term is chosen -- only the SED's
+//! *shape* varies per term. Mirrors Python's `BaseRainbowFit._lsq_model_{no_,with_}baseline`.
 //!
-//! This module works entirely in physical `f64` units on a fixed internal [`Band`] list (name +
-//! wavelength in cm); it has no awareness of the crate's generic `T: Float` or `P: PassbandTrait`
-//! -- [RainbowFit](super::RainbowFit) converts each configured passband's name/wavelength once at
-//! construction time and is the only place those generics matter.
+//! Works entirely in physical `f64` units on a fixed [`Band`] list; has no awareness of the
+//! crate's generic `T: Float`/`P: PassbandTrait` -- [RainbowFit](super::RainbowFit) converts
+//! once at construction and is the only place those generics matter.
 //!
-//! Since different bolometric/temperature/spectral term combinations (and band counts, when
-//! `with_baseline`) have different numbers of (possibly shared, e.g. `reference_time`)
-//! parameters, the parameter vector is a runtime-sized `&[f64]` rather than a fixed struct;
-//! [`ParamLayout`] records, for each term, which global parameter index its local parameters map
-//! to.
+//! Different term combinations have different (possibly shared, e.g. `reference_time`)
+//! parameter counts, so the parameter vector is a runtime-sized `&[f64]`; [`ParamLayout`] maps
+//! each term's local parameter indices into that shared global vector.
 
 use std::collections::HashMap;
 use std::f64::consts::PI;

--- a/src/multicolor/rainbow/terms/bolometric.rs
+++ b/src/multicolor/rainbow/terms/bolometric.rs
@@ -16,24 +16,14 @@ use super::common::{max_min, ptp, t0_and_weighted_centroid_sigma};
 // Bazin (symmetric, peak-normalized)
 // ---------------------------------------------------------------------
 
-fn bazin(t: f64, t0: f64, amplitude: f64, rise_time: f64, fall_time: f64) -> f64 {
-    let dt = t - t0;
-    if !(dt > -100.0 * rise_time && dt < 100.0 * fall_time) {
-        return 0.0;
-    }
-    let scale = bazin_scale(rise_time, fall_time);
-    amplitude * scale / ((-dt / rise_time).exp() + (dt / fall_time).exp())
-}
-
-fn bazin_scale(rise_time: f64, fall_time: f64) -> f64 {
-    let alpha = fall_time / rise_time;
-    let tau = rise_time + fall_time;
-    let u = rise_time / tau;
-    let v = fall_time / tau;
-    alpha.powf(u) + alpha.powf(-v)
-}
-
-fn bazin_jacobian(t: f64, t0: f64, amplitude: f64, rise_time: f64, fall_time: f64, jac: &mut [f64]) -> f64 {
+fn bazin_jacobian(
+    t: f64,
+    t0: f64,
+    amplitude: f64,
+    rise_time: f64,
+    fall_time: f64,
+    jac: &mut [f64],
+) -> f64 {
     let dt = t - t0;
     if !(dt > -100.0 * rise_time && dt < 100.0 * fall_time) {
         jac[..4].fill(0.0);
@@ -52,8 +42,10 @@ fn bazin_jacobian(t: f64, t0: f64, amplitude: f64, rise_time: f64, fall_time: f6
     let a1 = alpha.powf(u);
     let a2 = alpha.powf(-v);
     let scale = a1 + a2;
-    let dscale_dr = a1 * (v * log_alpha / tau - u / rise_time) + a2 * (v * log_alpha / tau + v / rise_time);
-    let dscale_df = a1 * u * (1.0 / fall_time - log_alpha / tau) + a2 * (-u * log_alpha / tau - v / fall_time);
+    let dscale_dr =
+        a1 * (v * log_alpha / tau - u / rise_time) + a2 * (v * log_alpha / tau + v / rise_time);
+    let dscale_df =
+        a1 * u * (1.0 / fall_time - log_alpha / tau) + a2 * (-u * log_alpha / tau - v / fall_time);
 
     let b = amplitude * scale / denom;
     let value = b;
@@ -73,14 +65,6 @@ fn bazin_jacobian(t: f64, t0: f64, amplitude: f64, rise_time: f64, fall_time: f6
 // ---------------------------------------------------------------------
 // Sigmoid
 // ---------------------------------------------------------------------
-
-fn sigmoid_bol(t: f64, t0: f64, amplitude: f64, rise_time: f64) -> f64 {
-    let dt = t - t0;
-    if dt <= -100.0 * rise_time {
-        return 0.0;
-    }
-    amplitude / ((-dt / rise_time).exp() + 1.0)
-}
 
 fn sigmoid_bol_jacobian(t: f64, t0: f64, amplitude: f64, rise_time: f64, jac: &mut [f64]) -> f64 {
     let dt = t - t0;
@@ -102,14 +86,6 @@ fn sigmoid_bol_jacobian(t: f64, t0: f64, amplitude: f64, rise_time: f64, jac: &m
 // ---------------------------------------------------------------------
 // Doublexp
 // ---------------------------------------------------------------------
-
-fn doublexp_bol(t: f64, t0: f64, amplitude: f64, time1: f64, time2: f64, p: f64) -> f64 {
-    let dt = t - t0;
-    let v = (-dt / time2).exp();
-    let a_inner = -(dt / time1) * (p - v);
-    let a_inner = a_inner.min(20.0);
-    amplitude * a_inner.exp()
-}
 
 fn doublexp_bol_jacobian(
     t: f64,
@@ -157,7 +133,11 @@ fn lambert_w0(x: f64) -> f64 {
     if x == 0.0 {
         return 0.0;
     }
-    let mut w = if x < 10.0 { (x + 1.0).ln().max(1e-4) } else { x.ln() - x.ln().ln() };
+    let mut w = if x < 10.0 {
+        (x + 1.0).ln().max(1e-4)
+    } else {
+        x.ln() - x.ln().ln()
+    };
     for _ in 0..50 {
         let ew = w.exp();
         let f = w * ew - x;
@@ -283,7 +263,11 @@ impl Bolometric {
             }
             Bolometric::Sigmoid => {
                 let (_, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
-                vec![reference_time_bounds, (0.0, 20.0 * ptp_flux), (dt / 100.0, 10.0 * ptp_t)]
+                vec![
+                    reference_time_bounds,
+                    (0.0, 20.0 * ptp_flux),
+                    (dt / 100.0, 10.0 * ptp_t),
+                ]
             }
             Bolometric::Doublexp => {
                 let (_, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
@@ -303,7 +287,10 @@ impl Bolometric {
         match self {
             Bolometric::Bazin => {
                 let (t0, _a, rise_time, fall_time) = (p[0], p[1], p[2], p[3]);
-                Some(t0 + (fall_time / rise_time).ln() * rise_time * fall_time / (rise_time + fall_time))
+                Some(
+                    t0 + (fall_time / rise_time).ln() * rise_time * fall_time
+                        / (rise_time + fall_time),
+                )
             }
             // Peak time is not defined for the sigmoid (monotonic), so it returns the
             // inflection point (mid-time of the rise) instead.
@@ -320,7 +307,12 @@ impl Bolometric {
 mod tests {
     use super::*;
 
-    fn finite_diff_check(name: &str, n: usize, value_jac: impl Fn(&[f64], &mut [f64]) -> f64, p: &[f64]) {
+    fn finite_diff_check(
+        name: &str,
+        n: usize,
+        value_jac: impl Fn(&[f64], &mut [f64]) -> f64,
+        p: &[f64],
+    ) {
         let mut jac = vec![0.0; n];
         value_jac(p, &mut jac);
         let h = 1e-6;
@@ -356,8 +348,10 @@ mod tests {
     #[test]
     fn bazin_peak_equals_amplitude() {
         let (t0, amplitude, rise_time, fall_time): (f64, f64, f64, f64) = (100.0, 5.0, 3.0, 20.0);
-        let peak_t = t0 + (fall_time / rise_time).ln() * rise_time * fall_time / (rise_time + fall_time);
-        let value = bazin(peak_t, t0, amplitude, rise_time, fall_time);
+        let peak_t =
+            t0 + (fall_time / rise_time).ln() * rise_time * fall_time / (rise_time + fall_time);
+        let mut jac = [0.0; 4];
+        let value = bazin_jacobian(peak_t, t0, amplitude, rise_time, fall_time, &mut jac);
         assert!((value - amplitude).abs() <= 1e-9 * amplitude);
     }
 
@@ -386,7 +380,10 @@ mod tests {
         for &x in &[0.1, 1.0, 2.0, 10.0, 100.0, 0.001] {
             let w = lambert_w0(x);
             let check = w * w.exp();
-            assert!((check - x).abs() <= 1e-8 * x.max(1.0), "x={x}, w={w}, w*e^w={check}");
+            assert!(
+                (check - x).abs() <= 1e-8 * x.max(1.0),
+                "x={x}, w={w}, w*e^w={check}"
+            );
         }
     }
 }

--- a/src/multicolor/rainbow/terms/bolometric.rs
+++ b/src/multicolor/rainbow/terms/bolometric.rs
@@ -1,0 +1,392 @@
+//! Bolometric (flux-vs-time envelope) terms for [RainbowFit](super::super::RainbowFit).
+//!
+//! `Linexp`, present in the Python reference implementation
+//! (`light_curve_py.features.rainbow.bolometric.LinexpBolometricTerm`), is deliberately not
+//! ported here: the Python docstring itself flags its guesses/limits as "not very stable", and a
+//! seed sweep during development of this port confirmed it -- roughly half of random seeds land
+//! the fit in a self-consistent-looking but wrong local optimum. Dropped rather than carried as a
+//! known-flaky term; can be revisited if someone wants to stabilize its initial guess.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::common::{max_min, ptp, t0_and_weighted_centroid_sigma};
+
+// ---------------------------------------------------------------------
+// Bazin (symmetric, peak-normalized)
+// ---------------------------------------------------------------------
+
+fn bazin(t: f64, t0: f64, amplitude: f64, rise_time: f64, fall_time: f64) -> f64 {
+    let dt = t - t0;
+    if !(dt > -100.0 * rise_time && dt < 100.0 * fall_time) {
+        return 0.0;
+    }
+    let scale = bazin_scale(rise_time, fall_time);
+    amplitude * scale / ((-dt / rise_time).exp() + (dt / fall_time).exp())
+}
+
+fn bazin_scale(rise_time: f64, fall_time: f64) -> f64 {
+    let alpha = fall_time / rise_time;
+    let tau = rise_time + fall_time;
+    let u = rise_time / tau;
+    let v = fall_time / tau;
+    alpha.powf(u) + alpha.powf(-v)
+}
+
+fn bazin_jacobian(t: f64, t0: f64, amplitude: f64, rise_time: f64, fall_time: f64, jac: &mut [f64]) -> f64 {
+    let dt = t - t0;
+    if !(dt > -100.0 * rise_time && dt < 100.0 * fall_time) {
+        jac[..4].fill(0.0);
+        return 0.0;
+    }
+
+    let e_r = (-dt / rise_time).exp();
+    let e_f = (dt / fall_time).exp();
+    let denom = e_r + e_f;
+
+    let alpha = fall_time / rise_time;
+    let tau = rise_time + fall_time;
+    let u = rise_time / tau;
+    let v = fall_time / tau;
+    let log_alpha = alpha.ln();
+    let a1 = alpha.powf(u);
+    let a2 = alpha.powf(-v);
+    let scale = a1 + a2;
+    let dscale_dr = a1 * (v * log_alpha / tau - u / rise_time) + a2 * (v * log_alpha / tau + v / rise_time);
+    let dscale_df = a1 * u * (1.0 / fall_time - log_alpha / tau) + a2 * (-u * log_alpha / tau - v / fall_time);
+
+    let b = amplitude * scale / denom;
+    let value = b;
+
+    // d(value)/d(t0)
+    jac[0] = (b / denom) * (e_f / fall_time - e_r / rise_time);
+    // d(value)/d(amplitude)
+    jac[1] = scale / denom;
+    // d(value)/d(rise_time)
+    jac[2] = b * (dscale_dr / scale - e_r * dt / (rise_time * rise_time * denom));
+    // d(value)/d(fall_time)
+    jac[3] = b * (dscale_df / scale + e_f * dt / (fall_time * fall_time * denom));
+
+    value
+}
+
+// ---------------------------------------------------------------------
+// Sigmoid
+// ---------------------------------------------------------------------
+
+fn sigmoid_bol(t: f64, t0: f64, amplitude: f64, rise_time: f64) -> f64 {
+    let dt = t - t0;
+    if dt <= -100.0 * rise_time {
+        return 0.0;
+    }
+    amplitude / ((-dt / rise_time).exp() + 1.0)
+}
+
+fn sigmoid_bol_jacobian(t: f64, t0: f64, amplitude: f64, rise_time: f64, jac: &mut [f64]) -> f64 {
+    let dt = t - t0;
+    if dt <= -100.0 * rise_time {
+        jac[..3].fill(0.0);
+        return 0.0;
+    }
+    let e = (-dt / rise_time).exp();
+    let s = 1.0 / (e + 1.0);
+    let s_1ms = e * s * s; // s * (1 - s)
+
+    jac[0] = -amplitude * s_1ms / rise_time;
+    jac[1] = s;
+    jac[2] = -amplitude * s_1ms * dt / (rise_time * rise_time);
+
+    amplitude * s
+}
+
+// ---------------------------------------------------------------------
+// Doublexp
+// ---------------------------------------------------------------------
+
+fn doublexp_bol(t: f64, t0: f64, amplitude: f64, time1: f64, time2: f64, p: f64) -> f64 {
+    let dt = t - t0;
+    let v = (-dt / time2).exp();
+    let a_inner = -(dt / time1) * (p - v);
+    let a_inner = a_inner.min(20.0);
+    amplitude * a_inner.exp()
+}
+
+fn doublexp_bol_jacobian(
+    t: f64,
+    t0: f64,
+    amplitude: f64,
+    time1: f64,
+    time2: f64,
+    p: f64,
+    jac: &mut [f64],
+) -> f64 {
+    let dt = t - t0;
+    let v = (-dt / time2).exp();
+    let a_inner = -(dt / time1) * (p - v);
+    let maxp = 20.0;
+    let clamped = a_inner > maxp;
+    let b = amplitude * a_inner.min(maxp).exp();
+
+    jac[1] = b / amplitude;
+
+    if clamped {
+        // Beyond the exponent clamp, the model is constant in every parameter but amplitude.
+        jac[0] = 0.0;
+        jac[2] = 0.0;
+        jac[3] = 0.0;
+        jac[4] = 0.0;
+    } else {
+        let da_dt0 = (p - v) / time1 + dt * v / (time1 * time2);
+        let da_dtime1 = dt * (p - v) / (time1 * time1);
+        let da_dtime2 = (dt * dt) * v / (time1 * time2 * time2);
+        let da_dp = -dt / time1;
+
+        jac[0] = b * da_dt0;
+        jac[2] = b * da_dtime1;
+        jac[3] = b * da_dtime2;
+        jac[4] = b * da_dp;
+    }
+
+    b
+}
+
+/// Principal branch (`W0`) of the Lambert W function for real `x >= -1/e`, via Halley's method.
+/// Only needed for [`Bolometric::peak_time`] of the Doublexp term; not exposed as a general
+/// utility since it isn't validated outside the range this needs (`x >= 0`, given `p > 0`).
+fn lambert_w0(x: f64) -> f64 {
+    if x == 0.0 {
+        return 0.0;
+    }
+    let mut w = if x < 10.0 { (x + 1.0).ln().max(1e-4) } else { x.ln() - x.ln().ln() };
+    for _ in 0..50 {
+        let ew = w.exp();
+        let f = w * ew - x;
+        let denom = ew * (w + 1.0) - (w + 2.0) * f / (2.0 * w + 2.0);
+        if denom == 0.0 {
+            break;
+        }
+        let step = f / denom;
+        w -= step;
+        if step.abs() < 1e-14 * w.abs().max(1.0) {
+            break;
+        }
+    }
+    w
+}
+
+// ---------------------------------------------------------------------
+// Enum wrapper
+// ---------------------------------------------------------------------
+
+/// Which parametric function models the bolometric (band-integrated) flux envelope $\mathrm{bol}(t)$.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[non_exhaustive]
+pub enum Bolometric {
+    /// Symmetric, peak-normalized Bazin function (Bazin et al. 2009,
+    /// [DOI:10.1051/0004-6361/200911847](https://doi.org/10.1051/0004-6361/200911847)):
+    /// $$
+    /// \mathrm{bol}(t) = A \cdot \frac{\alpha}{\mathrm{e}^{-(t-t_0)/\tau_\mathrm{rise}} + \mathrm{e}^{(t-t_0)/\tau_\mathrm{fall}}},
+    /// $$
+    /// where $\alpha$ is chosen so the peak value equals $A$ exactly:
+    /// $$
+    /// \alpha = \left(\frac{\tau_\mathrm{fall}}{\tau_\mathrm{rise}}\right)^{\tau_\mathrm{rise}/(\tau_\mathrm{rise}+\tau_\mathrm{fall})}
+    ///        + \left(\frac{\tau_\mathrm{fall}}{\tau_\mathrm{rise}}\right)^{-\tau_\mathrm{fall}/(\tau_\mathrm{rise}+\tau_\mathrm{fall})}.
+    /// $$
+    /// Parameters: `reference_time` ($t_0$), `amplitude` ($A$), `rise_time` ($\tau_\mathrm{rise}$),
+    /// `fall_time` ($\tau_\mathrm{fall}$). A good default for transients with a clear rise and
+    /// fall (e.g. supernovae).
+    Bazin,
+    /// Plain logistic rise, with no decline:
+    /// $$
+    /// \mathrm{bol}(t) = \frac{A}{1 + \mathrm{e}^{-(t-t_0)/\tau_\mathrm{rise}}}.
+    /// $$
+    /// Parameters: `reference_time` ($t_0$, the inflection point), `amplitude` ($A$, the
+    /// asymptotic plateau level), `rise_time` ($\tau_\mathrm{rise}$). Appropriate for sources
+    /// that rise and then plateau within the observed window, rather than declining (e.g. AGN,
+    /// TDEs observed only near onset).
+    Sigmoid,
+    /// Asymmetric rise/decline with an adjustable decline sharpness, fitted by symbolic
+    /// regression on ZTF SN Ia light curves (Russeil et al. 2024,
+    /// [arXiv:2402.04298](https://arxiv.org/abs/2402.04298)):
+    /// $$
+    /// \mathrm{bol}(t) = A \, \exp\!\left(-\frac{t-t_0}{\tau_1}\left(p - \mathrm{e}^{-(t-t_0)/\tau_2}\right)\right).
+    /// $$
+    /// Parameters: `reference_time` ($t_0$), `amplitude` ($A$), `time1` ($\tau_1$), `time2`
+    /// ($\tau_2$), `p`. Unlike Bazin, decline sharpness is a free parameter ($p$) rather than
+    /// tied to the same functional form as the rise, at the cost of two extra parameters.
+    Doublexp,
+}
+
+const BAZIN_PARAMS: [&str; 4] = ["reference_time", "amplitude", "rise_time", "fall_time"];
+const SIGMOID_BOL_PARAMS: [&str; 3] = ["reference_time", "amplitude", "rise_time"];
+const DOUBLEXP_PARAMS: [&str; 5] = ["reference_time", "amplitude", "time1", "time2", "p"];
+
+impl Bolometric {
+    pub(crate) fn params(&self) -> &'static [&'static str] {
+        match self {
+            Bolometric::Bazin => &BAZIN_PARAMS,
+            Bolometric::Sigmoid => &SIGMOID_BOL_PARAMS,
+            Bolometric::Doublexp => &DOUBLEXP_PARAMS,
+        }
+    }
+
+    pub(crate) fn n_params(&self) -> usize {
+        self.params().len()
+    }
+
+    /// Evaluates the term and writes its Jacobian (length `n_params()`) into `jac`, returning
+    /// the value.
+    pub(crate) fn value_jac(&self, t: f64, p: &[f64], jac: &mut [f64]) -> f64 {
+        match self {
+            Bolometric::Bazin => bazin_jacobian(t, p[0], p[1], p[2], p[3], jac),
+            Bolometric::Sigmoid => sigmoid_bol_jacobian(t, p[0], p[1], p[2], jac),
+            Bolometric::Doublexp => doublexp_bol_jacobian(t, p[0], p[1], p[2], p[3], p[4], jac),
+        }
+    }
+
+    /// Heuristic initial guess (physical units), same order as [`Self::params`].
+    pub(crate) fn initial_guess(&self, t: &[f64], flux: &[f64], flux_err: &[f64]) -> Vec<f64> {
+        let (max_flux, min_flux) = max_min(flux);
+        let ptp_flux = max_flux - min_flux;
+        match self {
+            Bolometric::Bazin => {
+                let (t0, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![t0, 1.5 * max_flux.max(ptp_flux), dt, dt]
+            }
+            Bolometric::Sigmoid => {
+                let peak_t = t[super::common::argmax(flux)];
+                vec![peak_t, ptp_flux, 1.0]
+            }
+            Bolometric::Doublexp => {
+                let (t0, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![t0, max_flux.max(ptp_flux), 2.0 * dt, 2.0 * dt, 1.0]
+            }
+        }
+    }
+
+    /// Box bounds `(lower, upper)` (physical units), same order as [`Self::params`].
+    pub(crate) fn bounds(&self, t: &[f64], flux: &[f64], flux_err: &[f64]) -> Vec<(f64, f64)> {
+        let (t_max, t_min) = max_min(t);
+        let ptp_t = t_max - t_min;
+        let ptp_flux = ptp(flux);
+        let reference_time_bounds = (t_min - 10.0 * ptp_t, t_max + 10.0 * ptp_t);
+
+        match self {
+            Bolometric::Bazin => {
+                let (_, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![
+                    reference_time_bounds,
+                    (0.0, 20.0 * ptp_flux),
+                    (dt / 100.0, 10.0 * ptp_t),
+                    (dt / 100.0, 10.0 * ptp_t),
+                ]
+            }
+            Bolometric::Sigmoid => {
+                let (_, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![reference_time_bounds, (0.0, 20.0 * ptp_flux), (dt / 100.0, 10.0 * ptp_t)]
+            }
+            Bolometric::Doublexp => {
+                let (_, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![
+                    reference_time_bounds,
+                    (0.0, 10.0 * ptp_flux),
+                    (dt / 10.0, 2.0 * ptp_t),
+                    (dt / 10.0, 2.0 * ptp_t),
+                    (1e-2, 100.0),
+                ]
+            }
+        }
+    }
+
+    /// Analytic bolometric peak time, if defined for this term.
+    pub(crate) fn peak_time(&self, p: &[f64]) -> Option<f64> {
+        match self {
+            Bolometric::Bazin => {
+                let (t0, _a, rise_time, fall_time) = (p[0], p[1], p[2], p[3]);
+                Some(t0 + (fall_time / rise_time).ln() * rise_time * fall_time / (rise_time + fall_time))
+            }
+            // Peak time is not defined for the sigmoid (monotonic), so it returns the
+            // inflection point (mid-time of the rise) instead.
+            Bolometric::Sigmoid => Some(p[0]),
+            Bolometric::Doublexp => {
+                let (t0, _a, _time1, _time2, pp) = (p[0], p[1], p[2], p[3], p[4]);
+                Some(t0 + (-lambert_w0(pp * std::f64::consts::E) + 1.0))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn finite_diff_check(name: &str, n: usize, value_jac: impl Fn(&[f64], &mut [f64]) -> f64, p: &[f64]) {
+        let mut jac = vec![0.0; n];
+        value_jac(p, &mut jac);
+        let h = 1e-6;
+        for k in 0..n {
+            let mut plus = p.to_vec();
+            let mut minus = p.to_vec();
+            plus[k] += h * plus[k].abs().max(1.0);
+            minus[k] -= h * minus[k].abs().max(1.0);
+            let step = plus[k] - minus[k];
+            let mut dummy = vec![0.0; n];
+            let f_plus = value_jac(&plus, &mut dummy);
+            let f_minus = value_jac(&minus, &mut dummy);
+            let numeric = (f_plus - f_minus) / step;
+            assert!(
+                (jac[k] - numeric).abs() <= 1e-4 * numeric.abs().max(1.0),
+                "{name} param {k}: analytic={}, numeric={}",
+                jac[k],
+                numeric
+            );
+        }
+    }
+
+    #[test]
+    fn bazin_jacobian_matches_finite_difference() {
+        finite_diff_check(
+            "bazin",
+            4,
+            |p, jac| bazin_jacobian(12.0, p[0], p[1], p[2], p[3], jac),
+            &[10.0, 5.0, 3.0, 20.0],
+        );
+    }
+
+    #[test]
+    fn bazin_peak_equals_amplitude() {
+        let (t0, amplitude, rise_time, fall_time): (f64, f64, f64, f64) = (100.0, 5.0, 3.0, 20.0);
+        let peak_t = t0 + (fall_time / rise_time).ln() * rise_time * fall_time / (rise_time + fall_time);
+        let value = bazin(peak_t, t0, amplitude, rise_time, fall_time);
+        assert!((value - amplitude).abs() <= 1e-9 * amplitude);
+    }
+
+    #[test]
+    fn sigmoid_bol_jacobian_matches_finite_difference() {
+        finite_diff_check(
+            "sigmoid_bol",
+            3,
+            |p, jac| sigmoid_bol_jacobian(12.0, p[0], p[1], p[2], jac),
+            &[10.0, 5.0, 3.0],
+        );
+    }
+
+    #[test]
+    fn doublexp_bol_jacobian_matches_finite_difference() {
+        finite_diff_check(
+            "doublexp_bol",
+            5,
+            |p, jac| doublexp_bol_jacobian(12.0, p[0], p[1], p[2], p[3], p[4], jac),
+            &[10.0, 5.0, 3.0, 4.0, 1.5],
+        );
+    }
+
+    #[test]
+    fn lambert_w0_matches_definition() {
+        for &x in &[0.1, 1.0, 2.0, 10.0, 100.0, 0.001] {
+            let w = lambert_w0(x);
+            let check = w * w.exp();
+            assert!((check - x).abs() <= 1e-8 * x.max(1.0), "x={x}, w={w}, w*e^w={check}");
+        }
+    }
+}

--- a/src/multicolor/rainbow/terms/common.rs
+++ b/src/multicolor/rainbow/terms/common.rs
@@ -1,13 +1,9 @@
 //! Shared initial-guess heuristics used by more than one bolometric/temperature term.
 
-/// Weighted centroid time and its spread, used as an initial guess for
-/// `reference_time` and various rise/fall/color timescales.
-///
-/// The centroid is computed only from points above the median flux (i.e. roughly the
-/// "bright half" of the light curve), weighted by `flux / flux_err`, so it approximates the
-/// peak position without needing to know the model shape in advance. The spread is the
-/// flux-weighted standard deviation of time around that centroid, used as a starting guess for
-/// timescale parameters (rise/fall/color).
+/// Weighted centroid time and its spread, used as an initial guess for `reference_time` and
+/// rise/fall/color timescales. Centroid uses only points above the median flux (the "bright
+/// half"), weighted by `flux / flux_err`, to approximate the peak position without assuming a
+/// model shape; spread is the flux-weighted time stddev around that centroid.
 pub fn t0_and_weighted_centroid_sigma(t: &[f64], flux: &[f64], flux_err: &[f64]) -> (f64, f64) {
     let min_flux = flux.iter().cloned().fold(f64::MAX, f64::min);
     let mc: Vec<f64> = flux.iter().map(|m| m - min_flux).collect();

--- a/src/multicolor/rainbow/terms/common.rs
+++ b/src/multicolor/rainbow/terms/common.rs
@@ -16,10 +16,18 @@ pub fn t0_and_weighted_centroid_sigma(t: &[f64], flux: &[f64], flux_err: &[f64])
     let idx: Vec<usize> = (0..t.len()).filter(|&i| flux[i] > median).collect();
 
     let weight_sum: f64 = idx.iter().map(|&i| flux[i] / flux_err[i]).sum();
-    let t0 = idx.iter().map(|&i| t[i] * flux[i] / flux_err[i]).sum::<f64>() / weight_sum;
+    let t0 = idx
+        .iter()
+        .map(|&i| t[i] * flux[i] / flux_err[i])
+        .sum::<f64>()
+        / weight_sum;
 
     let mc_weight_sum: f64 = idx.iter().map(|&i| mc[i] / flux_err[i]).sum();
-    let var = idx.iter().map(|&i| (t[i] - t0).powi(2) * mc[i] / flux_err[i]).sum::<f64>() / mc_weight_sum;
+    let var = idx
+        .iter()
+        .map(|&i| (t[i] - t0).powi(2) * mc[i] / flux_err[i])
+        .sum::<f64>()
+        / mc_weight_sum;
     let dt = var.sqrt();
 
     // Guard against a degenerate spread (e.g. all bright points at the same time): fall back to
@@ -36,7 +44,10 @@ pub fn t0_and_weighted_centroid_sigma(t: &[f64], flux: &[f64], flux_err: &[f64])
 }
 
 pub fn max_min(x: &[f64]) -> (f64, f64) {
-    (x.iter().cloned().fold(f64::MIN, f64::max), x.iter().cloned().fold(f64::MAX, f64::min))
+    (
+        x.iter().cloned().fold(f64::MIN, f64::max),
+        x.iter().cloned().fold(f64::MAX, f64::min),
+    )
 }
 
 pub fn ptp(x: &[f64]) -> f64 {
@@ -58,5 +69,9 @@ pub fn median(x: &[f64]) -> f64 {
     let mut sorted = x.to_vec();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
     let n = sorted.len();
-    if n % 2 == 1 { sorted[n / 2] } else { 0.5 * (sorted[n / 2 - 1] + sorted[n / 2]) }
+    if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        0.5 * (sorted[n / 2 - 1] + sorted[n / 2])
+    }
 }

--- a/src/multicolor/rainbow/terms/common.rs
+++ b/src/multicolor/rainbow/terms/common.rs
@@ -1,0 +1,62 @@
+//! Shared initial-guess heuristics used by more than one bolometric/temperature term.
+
+/// Weighted centroid time and its spread, used as an initial guess for
+/// `reference_time` and various rise/fall/color timescales.
+///
+/// The centroid is computed only from points above the median flux (i.e. roughly the
+/// "bright half" of the light curve), weighted by `flux / flux_err`, so it approximates the
+/// peak position without needing to know the model shape in advance. The spread is the
+/// flux-weighted standard deviation of time around that centroid, used as a starting guess for
+/// timescale parameters (rise/fall/color).
+pub fn t0_and_weighted_centroid_sigma(t: &[f64], flux: &[f64], flux_err: &[f64]) -> (f64, f64) {
+    let min_flux = flux.iter().cloned().fold(f64::MAX, f64::min);
+    let mc: Vec<f64> = flux.iter().map(|m| m - min_flux).collect();
+
+    let median = median(flux);
+    let idx: Vec<usize> = (0..t.len()).filter(|&i| flux[i] > median).collect();
+
+    let weight_sum: f64 = idx.iter().map(|&i| flux[i] / flux_err[i]).sum();
+    let t0 = idx.iter().map(|&i| t[i] * flux[i] / flux_err[i]).sum::<f64>() / weight_sum;
+
+    let mc_weight_sum: f64 = idx.iter().map(|&i| mc[i] / flux_err[i]).sum();
+    let var = idx.iter().map(|&i| (t[i] - t0).powi(2) * mc[i] / flux_err[i]).sum::<f64>() / mc_weight_sum;
+    let dt = var.sqrt();
+
+    // Guard against a degenerate spread (e.g. all bright points at the same time): fall back to
+    // a quarter of the light curve's time span, which is always positive and finite.
+    let dt = if dt.is_finite() && dt > 0.0 {
+        dt
+    } else {
+        let t_max = t.iter().cloned().fold(f64::MIN, f64::max);
+        let t_min = t.iter().cloned().fold(f64::MAX, f64::min);
+        ((t_max - t_min) / 4.0).max(1.0)
+    };
+
+    (t0, dt)
+}
+
+pub fn max_min(x: &[f64]) -> (f64, f64) {
+    (x.iter().cloned().fold(f64::MIN, f64::max), x.iter().cloned().fold(f64::MAX, f64::min))
+}
+
+pub fn ptp(x: &[f64]) -> f64 {
+    let (max, min) = max_min(x);
+    max - min
+}
+
+pub fn argmax(x: &[f64]) -> usize {
+    let mut best = 0;
+    for i in 1..x.len() {
+        if x[i] > x[best] {
+            best = i;
+        }
+    }
+    best
+}
+
+pub fn median(x: &[f64]) -> f64 {
+    let mut sorted = x.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let n = sorted.len();
+    if n % 2 == 1 { sorted[n / 2] } else { 0.5 * (sorted[n / 2 - 1] + sorted[n / 2]) }
+}

--- a/src/multicolor/rainbow/terms/mod.rs
+++ b/src/multicolor/rainbow/terms/mod.rs
@@ -1,0 +1,20 @@
+//! Pluggable bolometric / temperature / spectral terms composed by [RainbowFit](super::RainbowFit).
+//!
+//! Each term contributes a small, fixed number of named parameters (see each module's
+//! `params()`), a physical-unit initial guess (`initial_guess()`), and physical-unit box bounds
+//! (`bounds()`). See [super::fit] for how a parameter's bounds drive its optimizer
+//! reparametrization.
+
+pub mod bolometric;
+pub mod common;
+pub mod spectral;
+pub mod temperature;
+
+pub use bolometric::Bolometric;
+pub use spectral::Spectral;
+pub use temperature::Temperature;
+
+/// The largest number of parameters any single bolometric or temperature term has
+/// (`Doublexp` / `DelayedSigmoid`, both 5). Used to size fixed-length stack buffers and avoid
+/// heap allocation in the per-point model evaluation hot path.
+pub(crate) const MAX_LOCAL_PARAMS: usize = 5;

--- a/src/multicolor/rainbow/terms/spectral.rs
+++ b/src/multicolor/rainbow/terms/spectral.rs
@@ -1,0 +1,322 @@
+//! Spectral energy distribution (SED) terms for [RainbowFit](super::super::RainbowFit).
+//!
+//! Python's `BlanketedPlanckSpectralTerm` is deliberately not implemented here: its
+//! `lambda_scale` parameter anchors to the temperature term's own (possibly different)
+//! characteristic `T` parameter via cross-term parameter sharing (Python's `common_temp_spec`
+//! machinery), which is more involved than a straight port of the other terms and is deferred.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::super::constants::{BOLTZMANN_K, PLANCK_H, SPEED_OF_LIGHT};
+
+// ---------------------------------------------------------------------
+// Planck (plain blackbody, no free parameters)
+// ---------------------------------------------------------------------
+
+fn planck(wave_cm: f64, temperature: f64) -> f64 {
+    let nu = SPEED_OF_LIGHT / wave_cm;
+    let x = PLANCK_H * nu / (BOLTZMANN_K * temperature);
+    // B = (2h/c^2) nu^3 / (e^x - 1), written as nu^3 e^{-x} / (1 - e^{-x}) to stay overflow-safe
+    // at large x (cold T / blue wavelengths): e^x/expm1(x) overflows there, whereas e^{-x}
+    // underflows to 0 and B -> 0 (the Wien tail), which is the correct limit.
+    let neg_expm1 = -(-x).exp_m1();
+    (2.0 * PLANCK_H / (SPEED_OF_LIGHT * SPEED_OF_LIGHT)) * nu.powi(3) * (-x).exp() / neg_expm1
+}
+
+fn planck_dtemperature(wave_cm: f64, temperature: f64) -> f64 {
+    let nu = SPEED_OF_LIGHT / wave_cm;
+    let x = PLANCK_H * nu / (BOLTZMANN_K * temperature);
+    let neg_expm1 = -(-x).exp_m1();
+    let value = (2.0 * PLANCK_H / (SPEED_OF_LIGHT * SPEED_OF_LIGHT)) * nu.powi(3) * (-x).exp() / neg_expm1;
+    // d(planck)/dT = planck * x*e^x / (T*expm1(x)) = planck * x / (T * (1 - e^{-x})), the same
+    // overflow-safe rewrite as `planck` itself.
+    value * x / (temperature * neg_expm1)
+}
+
+// ---------------------------------------------------------------------
+// Generalized Wien: B(nu) ~ nu^3 * exp(-x^spec_k), x = h*nu/(k*T)
+// ---------------------------------------------------------------------
+
+fn genwien_x_value(wave_cm: f64, temperature: f64, spec_k: f64) -> (f64, f64) {
+    let nu = SPEED_OF_LIGHT / wave_cm;
+    let x = PLANCK_H * nu / (BOLTZMANN_K * temperature);
+    let value = (2.0 * PLANCK_H / (SPEED_OF_LIGHT * SPEED_OF_LIGHT)) * nu.powi(3) * (-x.powf(spec_k)).exp();
+    (x, value)
+}
+
+fn genwien(wave_cm: f64, temperature: f64, spec_k: f64) -> f64 {
+    genwien_x_value(wave_cm, temperature, spec_k).1
+}
+
+fn genwien_dtemperature(wave_cm: f64, temperature: f64, spec_k: f64) -> f64 {
+    let (x, value) = genwien_x_value(wave_cm, temperature, spec_k);
+    value * spec_k * x.powf(spec_k) / temperature
+}
+
+fn genwien_jacobian(wave_cm: f64, temperature: f64, spec_k: f64, jac: &mut [f64]) -> f64 {
+    let (x, value) = genwien_x_value(wave_cm, temperature, spec_k);
+    jac[0] = -value * x.powf(spec_k) * x.ln();
+    value
+}
+
+// ---------------------------------------------------------------------
+// Modified blackbody: Planck(wave, T) * (wave/wave_ref)^beta
+// ---------------------------------------------------------------------
+
+const MODIFIED_BB_WAVE_REF_CM: f64 = 6000e-8;
+
+fn modified_bb(wave_cm: f64, temperature: f64, beta: f64) -> f64 {
+    let tilt = (wave_cm / MODIFIED_BB_WAVE_REF_CM).powf(beta);
+    planck(wave_cm, temperature) * tilt
+}
+
+fn modified_bb_dtemperature(wave_cm: f64, temperature: f64, beta: f64) -> f64 {
+    let tilt = (wave_cm / MODIFIED_BB_WAVE_REF_CM).powf(beta);
+    planck_dtemperature(wave_cm, temperature) * tilt
+}
+
+fn modified_bb_jacobian(wave_cm: f64, temperature: f64, beta: f64, jac: &mut [f64]) -> f64 {
+    let rel = wave_cm / MODIFIED_BB_WAVE_REF_CM;
+    let value = planck(wave_cm, temperature) * rel.powf(beta);
+    jac[0] = value * rel.ln();
+    value
+}
+
+// ---------------------------------------------------------------------
+// Log-parabola: Planck(wave, T) * exp(sp_a*L + sp_b*L^2), L = ln(wave/wave_ref)
+// ---------------------------------------------------------------------
+
+const LOGPARABOLA_WAVE_REF_CM: f64 = 6000e-8;
+
+fn logparabola_l_fac(wave_cm: f64, sp_a: f64, sp_b: f64) -> (f64, f64) {
+    let ell = (wave_cm / LOGPARABOLA_WAVE_REF_CM).ln();
+    (ell, (sp_a * ell + sp_b * ell * ell).exp())
+}
+
+fn logparabola(wave_cm: f64, temperature: f64, sp_a: f64, sp_b: f64) -> f64 {
+    let (_ell, fac) = logparabola_l_fac(wave_cm, sp_a, sp_b);
+    planck(wave_cm, temperature) * fac
+}
+
+fn logparabola_dtemperature(wave_cm: f64, temperature: f64, sp_a: f64, sp_b: f64) -> f64 {
+    let (_ell, fac) = logparabola_l_fac(wave_cm, sp_a, sp_b);
+    planck_dtemperature(wave_cm, temperature) * fac
+}
+
+fn logparabola_jacobian(wave_cm: f64, temperature: f64, sp_a: f64, sp_b: f64, jac: &mut [f64]) -> f64 {
+    let (ell, fac) = logparabola_l_fac(wave_cm, sp_a, sp_b);
+    let value = planck(wave_cm, temperature) * fac;
+    jac[0] = value * ell;
+    jac[1] = value * ell * ell;
+    value
+}
+
+// ---------------------------------------------------------------------
+// Enum wrapper
+// ---------------------------------------------------------------------
+
+/// Which parametric spectral energy distribution (SED) describes the flux shape across bands at
+/// fixed temperature $T$.
+///
+/// Every variant's amplitude is normalized away in [the model composition](super::super::model)
+/// (divided by a Stefan-Boltzmann-based `norm(T)` shared across all variants), so only the SED's
+/// *shape* -- not its absolute scale -- matters here; the overall bolometric amplitude is carried
+/// entirely by the bolometric term. This also means the physical "bolometric luminosity"
+/// interpretation of `amplitude` is only exact for [`Spectral::Planck`]; the other variants trade
+/// that physical interpretation for extra shape flexibility.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[non_exhaustive]
+pub enum Spectral {
+    /// Standard blackbody spectrum (Planck's law), no free parameters:
+    /// $$
+    /// B_\nu(\lambda, T) = \frac{2h}{c^2}\,\nu^3\,\frac{1}{\mathrm{e}^{h\nu/k_BT} - 1}, \quad \nu = c/\lambda.
+    /// $$
+    /// The physically-motivated default; use this unless the data show a clear deviation from a
+    /// pure blackbody.
+    Planck,
+    /// Generalized-Wien SED, replacing the Planck denominator's exponent with a free power
+    /// $\mathrm{spec\_k}$:
+    /// $$
+    /// B(\nu) \propto \nu^3\,\mathrm{e}^{-x^{\mathrm{spec\_k}}}, \quad x = h\nu/(k_BT).
+    /// $$
+    /// $\mathrm{spec\_k} \approx 1$ recovers the Wien tail (equal to Planck for cool sources,
+    /// where $x$ is large); $\mathrm{spec\_k} > 1$ sharpens the blue cutoff, mimicking the UV
+    /// deficit of hot sources. One parameter, `spec_k`. Note the fitted `T` under this term is
+    /// *not* a physical temperature once `spec_k` deviates from 1 -- `spec_k` and `T` trade off,
+    /// so treat `(T, spec_k)` jointly as an SED-shape descriptor rather than separately
+    /// physically meaningful values.
+    GenWien,
+    /// Planck spectrum tilted by a wavelength power law:
+    /// $$
+    /// F(\lambda) = B_\nu(\lambda, T) \cdot (\lambda/\lambda_\mathrm{ref})^\beta, \quad \lambda_\mathrm{ref} = 6000\,\text{\AA}.
+    /// $$
+    /// $\beta = 0$ is exactly Planck, so `T` stays physical; $\beta > 0$ suppresses the blue
+    /// (gentle UV blanketing), $\beta < 0$ enhances it. One parameter, `beta`. Because the
+    /// deviation is a single tilt of an otherwise-intact Planck core, `beta` and `T` stay close
+    /// to orthogonal, making this the best-conditioned of the non-Planck SEDs when a small,
+    /// physically-motivated deviation is expected.
+    ModifiedBlackBody,
+    /// Planck spectrum modulated by a log-parabola in wavelength:
+    /// $$
+    /// F(\lambda) = B_\nu(\lambda, T) \cdot \mathrm{e}^{\mathrm{sp\_a} L + \mathrm{sp\_b} L^2}, \quad L = \ln(\lambda/\lambda_\mathrm{ref}), \quad \lambda_\mathrm{ref} = 6000\,\text{\AA}.
+    /// $$
+    /// Two parameters, `sp_a` (tilt) and `sp_b` (curvature), both anchored at the pure-Planck
+    /// value 0. The most flexible of the deviation terms -- its curvature captures sharper blue
+    /// cutoffs than [`Spectral::ModifiedBlackBody`]'s single tilt can -- at the cost of `(T,
+    /// sp_a, sp_b)` being genuinely degenerate for smooth, close-to-blackbody spectra, where `T`
+    /// can be biased without a prior pulling `sp_a`/`sp_b` back toward 0 (not yet implemented
+    /// here; see the module-level documentation).
+    LogParabola,
+}
+
+const PLANCK_PARAMS: [&str; 0] = [];
+const GENWIEN_PARAMS: [&str; 1] = ["spec_k"];
+const MODIFIED_BB_PARAMS: [&str; 1] = ["beta"];
+const LOGPARABOLA_PARAMS: [&str; 2] = ["sp_a", "sp_b"];
+
+impl Spectral {
+    pub(crate) fn params(&self) -> &'static [&'static str] {
+        match self {
+            Spectral::Planck => &PLANCK_PARAMS,
+            Spectral::GenWien => &GENWIEN_PARAMS,
+            Spectral::ModifiedBlackBody => &MODIFIED_BB_PARAMS,
+            Spectral::LogParabola => &LOGPARABOLA_PARAMS,
+        }
+    }
+
+    pub(crate) fn n_params(&self) -> usize {
+        self.params().len()
+    }
+
+    /// Evaluates the SED and writes its Jacobian w.r.t. this term's own local parameters
+    /// (length `n_params()`, NOT including `T`) into `jac`, returning `(value, d(value)/dT)`.
+    pub(crate) fn value_jac(&self, wave_cm: f64, temperature: f64, p: &[f64], jac: &mut [f64]) -> (f64, f64) {
+        match self {
+            Spectral::Planck => (planck(wave_cm, temperature), planck_dtemperature(wave_cm, temperature)),
+            Spectral::GenWien => {
+                let value = genwien_jacobian(wave_cm, temperature, p[0], jac);
+                (value, genwien_dtemperature(wave_cm, temperature, p[0]))
+            }
+            Spectral::ModifiedBlackBody => {
+                let value = modified_bb_jacobian(wave_cm, temperature, p[0], jac);
+                (value, modified_bb_dtemperature(wave_cm, temperature, p[0]))
+            }
+            Spectral::LogParabola => {
+                let value = logparabola_jacobian(wave_cm, temperature, p[0], p[1], jac);
+                (value, logparabola_dtemperature(wave_cm, temperature, p[0], p[1]))
+            }
+        }
+    }
+
+    pub(crate) fn initial_guess(&self) -> Vec<f64> {
+        match self {
+            Spectral::Planck => vec![],
+            Spectral::GenWien => vec![1.0],
+            Spectral::ModifiedBlackBody => vec![0.0],
+            Spectral::LogParabola => vec![0.0, 0.0],
+        }
+    }
+
+    /// Box bounds `(lower, upper)` (physical units), same order as [`Self::params`]. None of
+    /// these are data-dependent.
+    pub(crate) fn bounds(&self) -> Vec<(f64, f64)> {
+        match self {
+            Spectral::Planck => vec![],
+            Spectral::GenWien => vec![(0.3, 3.0)],
+            Spectral::ModifiedBlackBody => vec![(-6.0, 10.0)],
+            Spectral::LogParabola => vec![(-6.0, 6.0), (-4.0, 4.0)],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn finite_diff_check_local(name: &str, n: usize, value_jac: impl Fn(&[f64], &mut [f64]) -> f64, p: &[f64]) {
+        let mut jac = vec![0.0; n];
+        value_jac(p, &mut jac);
+        let h = 1e-6;
+        for k in 0..n {
+            let mut plus = p.to_vec();
+            let mut minus = p.to_vec();
+            plus[k] += h * plus[k].abs().max(1.0);
+            minus[k] -= h * minus[k].abs().max(1.0);
+            let step = plus[k] - minus[k];
+            let mut dummy = vec![0.0; n];
+            let f_plus = value_jac(&plus, &mut dummy);
+            let f_minus = value_jac(&minus, &mut dummy);
+            let numeric = (f_plus - f_minus) / step;
+            assert!(
+                (jac[k] - numeric).abs() <= 1e-4 * numeric.abs().max(1.0),
+                "{name} param {k}: analytic={}, numeric={}",
+                jac[k],
+                numeric
+            );
+        }
+    }
+
+    fn finite_diff_check_dt(name: &str, value: impl Fn(f64) -> f64, dvalue: impl Fn(f64) -> f64, t: f64) {
+        let h = 1e-2;
+        let numeric = (value(t + h) - value(t - h)) / (2.0 * h);
+        let analytic = dvalue(t);
+        assert!(
+            (analytic - numeric).abs() <= 1e-5 * numeric.abs().max(1.0),
+            "{name}: analytic={analytic}, numeric={numeric}"
+        );
+    }
+
+    const WAVE_CM: f64 = 5.0e-5;
+    const TEMP: f64 = 9000.0;
+
+    #[test]
+    fn planck_dtemperature_matches_finite_difference() {
+        finite_diff_check_dt("planck_dT", |t| planck(WAVE_CM, t), |t| planck_dtemperature(WAVE_CM, t), TEMP);
+    }
+
+    #[test]
+    fn genwien_jacobian_matches_finite_difference() {
+        finite_diff_check_local("genwien", 1, |p, jac| genwien_jacobian(WAVE_CM, TEMP, p[0], jac), &[1.3]);
+        finite_diff_check_dt(
+            "genwien_dT",
+            |t| genwien(WAVE_CM, t, 1.3),
+            |t| genwien_dtemperature(WAVE_CM, t, 1.3),
+            TEMP,
+        );
+    }
+
+    #[test]
+    fn modified_bb_jacobian_matches_finite_difference() {
+        finite_diff_check_local("modified_bb", 1, |p, jac| modified_bb_jacobian(WAVE_CM, TEMP, p[0], jac), &[0.5]);
+        finite_diff_check_dt(
+            "modified_bb_dT",
+            |t| modified_bb(WAVE_CM, t, 0.5),
+            |t| modified_bb_dtemperature(WAVE_CM, t, 0.5),
+            TEMP,
+        );
+    }
+
+    #[test]
+    fn logparabola_jacobian_matches_finite_difference() {
+        finite_diff_check_local(
+            "logparabola",
+            2,
+            |p, jac| logparabola_jacobian(WAVE_CM, TEMP, p[0], p[1], jac),
+            &[0.3, -0.2],
+        );
+        finite_diff_check_dt(
+            "logparabola_dT",
+            |t| logparabola(WAVE_CM, t, 0.3, -0.2),
+            |t| logparabola_dtemperature(WAVE_CM, t, 0.3, -0.2),
+            TEMP,
+        );
+    }
+
+    #[test]
+    fn modified_bb_beta_zero_equals_planck() {
+        let a = modified_bb(WAVE_CM, TEMP, 0.0);
+        let b = planck(WAVE_CM, TEMP);
+        assert!((a - b).abs() <= 1e-9 * b);
+    }
+}

--- a/src/multicolor/rainbow/terms/spectral.rs
+++ b/src/multicolor/rainbow/terms/spectral.rs
@@ -28,7 +28,8 @@ fn planck_dtemperature(wave_cm: f64, temperature: f64) -> f64 {
     let nu = SPEED_OF_LIGHT / wave_cm;
     let x = PLANCK_H * nu / (BOLTZMANN_K * temperature);
     let neg_expm1 = -(-x).exp_m1();
-    let value = (2.0 * PLANCK_H / (SPEED_OF_LIGHT * SPEED_OF_LIGHT)) * nu.powi(3) * (-x).exp() / neg_expm1;
+    let value =
+        (2.0 * PLANCK_H / (SPEED_OF_LIGHT * SPEED_OF_LIGHT)) * nu.powi(3) * (-x).exp() / neg_expm1;
     // d(planck)/dT = planck * x*e^x / (T*expm1(x)) = planck * x / (T * (1 - e^{-x})), the same
     // overflow-safe rewrite as `planck` itself.
     value * x / (temperature * neg_expm1)
@@ -41,12 +42,9 @@ fn planck_dtemperature(wave_cm: f64, temperature: f64) -> f64 {
 fn genwien_x_value(wave_cm: f64, temperature: f64, spec_k: f64) -> (f64, f64) {
     let nu = SPEED_OF_LIGHT / wave_cm;
     let x = PLANCK_H * nu / (BOLTZMANN_K * temperature);
-    let value = (2.0 * PLANCK_H / (SPEED_OF_LIGHT * SPEED_OF_LIGHT)) * nu.powi(3) * (-x.powf(spec_k)).exp();
+    let value =
+        (2.0 * PLANCK_H / (SPEED_OF_LIGHT * SPEED_OF_LIGHT)) * nu.powi(3) * (-x.powf(spec_k)).exp();
     (x, value)
-}
-
-fn genwien(wave_cm: f64, temperature: f64, spec_k: f64) -> f64 {
-    genwien_x_value(wave_cm, temperature, spec_k).1
 }
 
 fn genwien_dtemperature(wave_cm: f64, temperature: f64, spec_k: f64) -> f64 {
@@ -65,11 +63,6 @@ fn genwien_jacobian(wave_cm: f64, temperature: f64, spec_k: f64, jac: &mut [f64]
 // ---------------------------------------------------------------------
 
 const MODIFIED_BB_WAVE_REF_CM: f64 = 6000e-8;
-
-fn modified_bb(wave_cm: f64, temperature: f64, beta: f64) -> f64 {
-    let tilt = (wave_cm / MODIFIED_BB_WAVE_REF_CM).powf(beta);
-    planck(wave_cm, temperature) * tilt
-}
 
 fn modified_bb_dtemperature(wave_cm: f64, temperature: f64, beta: f64) -> f64 {
     let tilt = (wave_cm / MODIFIED_BB_WAVE_REF_CM).powf(beta);
@@ -94,17 +87,18 @@ fn logparabola_l_fac(wave_cm: f64, sp_a: f64, sp_b: f64) -> (f64, f64) {
     (ell, (sp_a * ell + sp_b * ell * ell).exp())
 }
 
-fn logparabola(wave_cm: f64, temperature: f64, sp_a: f64, sp_b: f64) -> f64 {
-    let (_ell, fac) = logparabola_l_fac(wave_cm, sp_a, sp_b);
-    planck(wave_cm, temperature) * fac
-}
-
 fn logparabola_dtemperature(wave_cm: f64, temperature: f64, sp_a: f64, sp_b: f64) -> f64 {
     let (_ell, fac) = logparabola_l_fac(wave_cm, sp_a, sp_b);
     planck_dtemperature(wave_cm, temperature) * fac
 }
 
-fn logparabola_jacobian(wave_cm: f64, temperature: f64, sp_a: f64, sp_b: f64, jac: &mut [f64]) -> f64 {
+fn logparabola_jacobian(
+    wave_cm: f64,
+    temperature: f64,
+    sp_a: f64,
+    sp_b: f64,
+    jac: &mut [f64],
+) -> f64 {
     let (ell, fac) = logparabola_l_fac(wave_cm, sp_a, sp_b);
     let value = planck(wave_cm, temperature) * fac;
     jac[0] = value * ell;
@@ -191,9 +185,18 @@ impl Spectral {
 
     /// Evaluates the SED and writes its Jacobian w.r.t. this term's own local parameters
     /// (length `n_params()`, NOT including `T`) into `jac`, returning `(value, d(value)/dT)`.
-    pub(crate) fn value_jac(&self, wave_cm: f64, temperature: f64, p: &[f64], jac: &mut [f64]) -> (f64, f64) {
+    pub(crate) fn value_jac(
+        &self,
+        wave_cm: f64,
+        temperature: f64,
+        p: &[f64],
+        jac: &mut [f64],
+    ) -> (f64, f64) {
         match self {
-            Spectral::Planck => (planck(wave_cm, temperature), planck_dtemperature(wave_cm, temperature)),
+            Spectral::Planck => (
+                planck(wave_cm, temperature),
+                planck_dtemperature(wave_cm, temperature),
+            ),
             Spectral::GenWien => {
                 let value = genwien_jacobian(wave_cm, temperature, p[0], jac);
                 (value, genwien_dtemperature(wave_cm, temperature, p[0]))
@@ -204,7 +207,10 @@ impl Spectral {
             }
             Spectral::LogParabola => {
                 let value = logparabola_jacobian(wave_cm, temperature, p[0], p[1], jac);
-                (value, logparabola_dtemperature(wave_cm, temperature, p[0], p[1]))
+                (
+                    value,
+                    logparabola_dtemperature(wave_cm, temperature, p[0], p[1]),
+                )
             }
         }
     }
@@ -234,7 +240,12 @@ impl Spectral {
 mod tests {
     use super::*;
 
-    fn finite_diff_check_local(name: &str, n: usize, value_jac: impl Fn(&[f64], &mut [f64]) -> f64, p: &[f64]) {
+    fn finite_diff_check_local(
+        name: &str,
+        n: usize,
+        value_jac: impl Fn(&[f64], &mut [f64]) -> f64,
+        p: &[f64],
+    ) {
         let mut jac = vec![0.0; n];
         value_jac(p, &mut jac);
         let h = 1e-6;
@@ -257,7 +268,12 @@ mod tests {
         }
     }
 
-    fn finite_diff_check_dt(name: &str, value: impl Fn(f64) -> f64, dvalue: impl Fn(f64) -> f64, t: f64) {
+    fn finite_diff_check_dt(
+        name: &str,
+        value: impl Fn(f64) -> f64,
+        dvalue: impl Fn(f64) -> f64,
+        t: f64,
+    ) {
         let h = 1e-2;
         let numeric = (value(t + h) - value(t - h)) / (2.0 * h);
         let analytic = dvalue(t);
@@ -272,15 +288,25 @@ mod tests {
 
     #[test]
     fn planck_dtemperature_matches_finite_difference() {
-        finite_diff_check_dt("planck_dT", |t| planck(WAVE_CM, t), |t| planck_dtemperature(WAVE_CM, t), TEMP);
+        finite_diff_check_dt(
+            "planck_dT",
+            |t| planck(WAVE_CM, t),
+            |t| planck_dtemperature(WAVE_CM, t),
+            TEMP,
+        );
     }
 
     #[test]
     fn genwien_jacobian_matches_finite_difference() {
-        finite_diff_check_local("genwien", 1, |p, jac| genwien_jacobian(WAVE_CM, TEMP, p[0], jac), &[1.3]);
+        finite_diff_check_local(
+            "genwien",
+            1,
+            |p, jac| genwien_jacobian(WAVE_CM, TEMP, p[0], jac),
+            &[1.3],
+        );
         finite_diff_check_dt(
             "genwien_dT",
-            |t| genwien(WAVE_CM, t, 1.3),
+            |t| genwien_jacobian(WAVE_CM, t, 1.3, &mut [0.0; 1]),
             |t| genwien_dtemperature(WAVE_CM, t, 1.3),
             TEMP,
         );
@@ -288,10 +314,15 @@ mod tests {
 
     #[test]
     fn modified_bb_jacobian_matches_finite_difference() {
-        finite_diff_check_local("modified_bb", 1, |p, jac| modified_bb_jacobian(WAVE_CM, TEMP, p[0], jac), &[0.5]);
+        finite_diff_check_local(
+            "modified_bb",
+            1,
+            |p, jac| modified_bb_jacobian(WAVE_CM, TEMP, p[0], jac),
+            &[0.5],
+        );
         finite_diff_check_dt(
             "modified_bb_dT",
-            |t| modified_bb(WAVE_CM, t, 0.5),
+            |t| modified_bb_jacobian(WAVE_CM, t, 0.5, &mut [0.0; 1]),
             |t| modified_bb_dtemperature(WAVE_CM, t, 0.5),
             TEMP,
         );
@@ -307,7 +338,7 @@ mod tests {
         );
         finite_diff_check_dt(
             "logparabola_dT",
-            |t| logparabola(WAVE_CM, t, 0.3, -0.2),
+            |t| logparabola_jacobian(WAVE_CM, t, 0.3, -0.2, &mut [0.0; 2]),
             |t| logparabola_dtemperature(WAVE_CM, t, 0.3, -0.2),
             TEMP,
         );
@@ -315,7 +346,7 @@ mod tests {
 
     #[test]
     fn modified_bb_beta_zero_equals_planck() {
-        let a = modified_bb(WAVE_CM, TEMP, 0.0);
+        let a = modified_bb_jacobian(WAVE_CM, TEMP, 0.0, &mut [0.0; 1]);
         let b = planck(WAVE_CM, TEMP);
         assert!((a - b).abs() <= 1e-9 * b);
     }

--- a/src/multicolor/rainbow/terms/temperature.rs
+++ b/src/multicolor/rainbow/terms/temperature.rs
@@ -1,0 +1,269 @@
+//! Temperature-vs-time terms for [RainbowFit](super::super::RainbowFit).
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::common::{max_min, t0_and_weighted_centroid_sigma};
+
+// ---------------------------------------------------------------------
+// Constant
+// ---------------------------------------------------------------------
+
+fn constant_temperature_jacobian(temperature: f64, jac: &mut [f64]) -> f64 {
+    jac[0] = 1.0;
+    temperature
+}
+
+// ---------------------------------------------------------------------
+// Sigmoid
+// ---------------------------------------------------------------------
+
+fn sigmoid_temperature(t: f64, t0: f64, temperature: f64, temperature_amplitude: f64, t_color: f64) -> f64 {
+    let dt = t - t0;
+    if dt <= -100.0 * t_color {
+        return temperature * (1.0 + temperature_amplitude);
+    }
+    if dt >= 100.0 * t_color {
+        return temperature * (1.0 - temperature_amplitude);
+    }
+    let s = 1.0 / (1.0 + (dt / t_color).exp());
+    temperature * (1.0 + temperature_amplitude * (2.0 * s - 1.0))
+}
+
+fn sigmoid_temperature_jacobian(
+    t: f64,
+    t0: f64,
+    temperature: f64,
+    temperature_amplitude: f64,
+    t_color: f64,
+    jac: &mut [f64],
+) -> f64 {
+    let dt = t - t0;
+    if dt <= -100.0 * t_color {
+        jac[0] = 0.0;
+        jac[1] = 1.0 + temperature_amplitude;
+        jac[2] = temperature;
+        jac[3] = 0.0;
+        return temperature * (1.0 + temperature_amplitude);
+    }
+    if dt >= 100.0 * t_color {
+        jac[0] = 0.0;
+        jac[1] = 1.0 - temperature_amplitude;
+        jac[2] = -temperature;
+        jac[3] = 0.0;
+        return temperature * (1.0 - temperature_amplitude);
+    }
+
+    let e = (dt / t_color).exp();
+    let inv_1p_e = 1.0 / (1.0 + e);
+    let s = inv_1p_e;
+    let s_1ms = e * inv_1p_e * inv_1p_e; // s * (1 - s)
+    let two_s_m1 = 2.0 * s - 1.0;
+
+    jac[0] = 2.0 * temperature * temperature_amplitude * s_1ms / t_color;
+    jac[1] = 1.0 + temperature_amplitude * two_s_m1;
+    jac[2] = temperature * two_s_m1;
+    jac[3] = 2.0 * temperature * temperature_amplitude * s_1ms * dt / (t_color * t_color);
+
+    temperature * (1.0 + temperature_amplitude * two_s_m1)
+}
+
+// ---------------------------------------------------------------------
+// Delayed sigmoid
+// ---------------------------------------------------------------------
+
+fn delayed_sigmoid_temperature_jacobian(
+    t: f64,
+    t0: f64,
+    temperature: f64,
+    temperature_amplitude: f64,
+    t_color: f64,
+    t_delay: f64,
+    jac: &mut [f64],
+) -> f64 {
+    let mut sigmoid_jac = [0.0; 4];
+    let value =
+        sigmoid_temperature_jacobian(t, t0 + t_delay, temperature, temperature_amplitude, t_color, &mut sigmoid_jac);
+    jac[0] = sigmoid_jac[0]; // d/d(reference_time)
+    jac[1] = sigmoid_jac[1]; // d/d(T)
+    jac[2] = sigmoid_jac[2]; // d/d(T_amplitude)
+    jac[3] = sigmoid_jac[3]; // d/d(t_color)
+    jac[4] = sigmoid_jac[0]; // d/d(t_delay) = d/d(reference_time), since both enter as their sum
+    value
+}
+
+// ---------------------------------------------------------------------
+// Enum wrapper
+// ---------------------------------------------------------------------
+
+/// Which parametric function models the temperature-vs-time curve $T(t)$.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[non_exhaustive]
+pub enum Temperature {
+    /// Time-independent temperature: $T(t) = T$. One parameter, `T`. Appropriate when the SED
+    /// shape isn't expected to evolve over the observed window (e.g. a short-duration event, or
+    /// one where cooling isn't the dominant behavior).
+    Constant,
+    /// Logistic transition between two temperature plateaus, parametrized by the mid-temperature
+    /// $T$ and a dimensionless relative amplitude $T_\mathrm{amplitude} \in (-1, 1)$ so that
+    /// $T_\mathrm{max} = T(1 + T_\mathrm{amplitude})$ and $T_\mathrm{min} = T(1 - T_\mathrm{amplitude})$:
+    /// $$
+    /// T(t) = T\bigl(1 + T_\mathrm{amplitude}(2s - 1)\bigr), \quad s = \frac{1}{1 + \mathrm{e}^{(t-t_0)/\tau_\mathrm{color}}}.
+    /// $$
+    /// $s$ runs from 1 (early, hot) to 0 (late, cool), so $T(t)$ runs from $T_\mathrm{max}$ down
+    /// to $T_\mathrm{min}$; $T_\mathrm{amplitude} = 0$ recovers the constant-temperature case.
+    /// Parameters: `reference_time` ($t_0$, shared with the bolometric term when both use it),
+    /// `T`, `T_amplitude`, `t_color` ($\tau_\mathrm{color}$). The standard choice for cooling
+    /// transients such as supernovae.
+    Sigmoid,
+    /// Same logistic transition as [`Temperature::Sigmoid`], but with an extra `t_delay`
+    /// parameter offsetting the temperature's own reference time from the bolometric one:
+    /// $$
+    /// T(t) = T\bigl(1 + T_\mathrm{amplitude}(2s - 1)\bigr), \quad s = \frac{1}{1 + \mathrm{e}^{(t-t_0-\tau_\mathrm{delay})/\tau_\mathrm{color}}}.
+    /// $$
+    /// Parameters: `reference_time` ($t_0$), `T`, `T_amplitude`, `t_color`, `t_delay`
+    /// ($\tau_\mathrm{delay}$). Useful when the temperature evolution is expected to lag (or
+    /// lead) the bolometric peak rather than track it exactly.
+    DelayedSigmoid,
+}
+
+const CONSTANT_PARAMS: [&str; 1] = ["T"];
+const SIGMOID_TEMP_PARAMS: [&str; 4] = ["reference_time", "T", "T_amplitude", "t_color"];
+const DELAYED_SIGMOID_PARAMS: [&str; 5] = ["reference_time", "T", "T_amplitude", "t_color", "t_delay"];
+
+impl Temperature {
+    pub(crate) fn params(&self) -> &'static [&'static str] {
+        match self {
+            Temperature::Constant => &CONSTANT_PARAMS,
+            Temperature::Sigmoid => &SIGMOID_TEMP_PARAMS,
+            Temperature::DelayedSigmoid => &DELAYED_SIGMOID_PARAMS,
+        }
+    }
+
+    pub(crate) fn n_params(&self) -> usize {
+        self.params().len()
+    }
+
+    pub(crate) fn value_jac(&self, t: f64, p: &[f64], jac: &mut [f64]) -> f64 {
+        match self {
+            Temperature::Constant => constant_temperature_jacobian(p[0], jac),
+            Temperature::Sigmoid => sigmoid_temperature_jacobian(t, p[0], p[1], p[2], p[3], jac),
+            Temperature::DelayedSigmoid => delayed_sigmoid_temperature_jacobian(t, p[0], p[1], p[2], p[3], p[4], jac),
+        }
+    }
+
+    /// Returns exactly `n_params()` values in [`Self::params`] order. Unlike Python (which
+    /// merges initial guesses by *name* and so may omit a term's shared `reference_time`), every
+    /// entry here is positional, so `reference_time` guesses are included even though they end
+    /// up unused when shared with the bolometric term (see `RainbowModel::initial_guess`, whose
+    /// assembly takes the bolometric term's guess for any name both terms declare).
+    pub(crate) fn initial_guess(&self, t: &[f64], flux: &[f64], flux_err: &[f64]) -> Vec<f64> {
+        match self {
+            Temperature::Constant => vec![8000.0],
+            Temperature::Sigmoid => {
+                let (t0, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![t0, 10_000.0, 0.0, 2.0 * dt]
+            }
+            Temperature::DelayedSigmoid => {
+                let (t0, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![t0, 10_000.0, 0.0, 2.0 * dt, 0.0]
+            }
+        }
+    }
+
+    /// Box bounds `(lower, upper)` (physical units), same order as [`Self::params`].
+    pub(crate) fn bounds(&self, t: &[f64], flux: &[f64], flux_err: &[f64]) -> Vec<(f64, f64)> {
+        const T_BOUNDS: (f64, f64) = (1e3, 2e6);
+        const T_AMPLITUDE_BOUNDS: (f64, f64) = (-0.99, 0.99);
+        match self {
+            Temperature::Constant => vec![T_BOUNDS],
+            Temperature::Sigmoid => {
+                let (t_max, t_min) = max_min(t);
+                let ptp_t = t_max - t_min;
+                let (_, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![
+                    (t_min - 10.0 * ptp_t, t_max + 10.0 * ptp_t),
+                    T_BOUNDS,
+                    T_AMPLITUDE_BOUNDS,
+                    (dt / 3.0, 10.0 * ptp_t),
+                ]
+            }
+            Temperature::DelayedSigmoid => {
+                let (t_max, t_min) = max_min(t);
+                let ptp_t = t_max - t_min;
+                let (_, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![
+                    (t_min - 10.0 * ptp_t, t_max + 10.0 * ptp_t),
+                    T_BOUNDS,
+                    T_AMPLITUDE_BOUNDS,
+                    (dt / 3.0, 10.0 * ptp_t),
+                    (-ptp_t, ptp_t),
+                ]
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn finite_diff_check(name: &str, n: usize, value_jac: impl Fn(&[f64], &mut [f64]) -> f64, p: &[f64]) {
+        let mut jac = vec![0.0; n];
+        value_jac(p, &mut jac);
+        let h = 1e-6;
+        for k in 0..n {
+            let mut plus = p.to_vec();
+            let mut minus = p.to_vec();
+            plus[k] += h * plus[k].abs().max(1.0);
+            minus[k] -= h * minus[k].abs().max(1.0);
+            let step = plus[k] - minus[k];
+            let mut dummy = vec![0.0; n];
+            let f_plus = value_jac(&plus, &mut dummy);
+            let f_minus = value_jac(&minus, &mut dummy);
+            let numeric = (f_plus - f_minus) / step;
+            assert!(
+                (jac[k] - numeric).abs() <= 1e-4 * numeric.abs().max(1.0),
+                "{name} param {k}: analytic={}, numeric={}",
+                jac[k],
+                numeric
+            );
+        }
+    }
+
+    #[test]
+    fn sigmoid_temperature_jacobian_matches_finite_difference() {
+        finite_diff_check(
+            "sigmoid_temperature",
+            4,
+            |p, jac| sigmoid_temperature_jacobian(11.5, p[0], p[1], p[2], p[3], jac),
+            &[10.0, 8000.0, 0.3, 2.0],
+        );
+    }
+
+    #[test]
+    fn sigmoid_temperature_plateaus() {
+        let (t0, temperature, temperature_amplitude, t_color) = (10.0, 8000.0, 0.3, 2.0);
+        let early = sigmoid_temperature(t0 - 1000.0, t0, temperature, temperature_amplitude, t_color);
+        let late = sigmoid_temperature(t0 + 1000.0, t0, temperature, temperature_amplitude, t_color);
+        assert!((early - temperature * 1.3).abs() <= 1e-9 * temperature);
+        assert!((late - temperature * 0.7).abs() <= 1e-9 * temperature);
+    }
+
+    #[test]
+    fn delayed_sigmoid_jacobian_matches_finite_difference() {
+        finite_diff_check(
+            "delayed_sigmoid",
+            5,
+            |p, jac| delayed_sigmoid_temperature_jacobian(11.5, p[0], p[1], p[2], p[3], p[4], jac),
+            &[10.0, 8000.0, 0.3, 2.0, 1.0],
+        );
+    }
+
+    #[test]
+    fn constant_temperature_is_constant() {
+        let mut jac = [0.0; 1];
+        assert_eq!(constant_temperature_jacobian(9000.0, &mut jac), 9000.0);
+        assert_eq!(jac[0], 1.0);
+    }
+}

--- a/src/multicolor/rainbow/terms/temperature.rs
+++ b/src/multicolor/rainbow/terms/temperature.rs
@@ -18,18 +18,6 @@ fn constant_temperature_jacobian(temperature: f64, jac: &mut [f64]) -> f64 {
 // Sigmoid
 // ---------------------------------------------------------------------
 
-fn sigmoid_temperature(t: f64, t0: f64, temperature: f64, temperature_amplitude: f64, t_color: f64) -> f64 {
-    let dt = t - t0;
-    if dt <= -100.0 * t_color {
-        return temperature * (1.0 + temperature_amplitude);
-    }
-    if dt >= 100.0 * t_color {
-        return temperature * (1.0 - temperature_amplitude);
-    }
-    let s = 1.0 / (1.0 + (dt / t_color).exp());
-    temperature * (1.0 + temperature_amplitude * (2.0 * s - 1.0))
-}
-
 fn sigmoid_temperature_jacobian(
     t: f64,
     t0: f64,
@@ -82,8 +70,14 @@ fn delayed_sigmoid_temperature_jacobian(
     jac: &mut [f64],
 ) -> f64 {
     let mut sigmoid_jac = [0.0; 4];
-    let value =
-        sigmoid_temperature_jacobian(t, t0 + t_delay, temperature, temperature_amplitude, t_color, &mut sigmoid_jac);
+    let value = sigmoid_temperature_jacobian(
+        t,
+        t0 + t_delay,
+        temperature,
+        temperature_amplitude,
+        t_color,
+        &mut sigmoid_jac,
+    );
     jac[0] = sigmoid_jac[0]; // d/d(reference_time)
     jac[1] = sigmoid_jac[1]; // d/d(T)
     jac[2] = sigmoid_jac[2]; // d/d(T_amplitude)
@@ -129,7 +123,8 @@ pub enum Temperature {
 
 const CONSTANT_PARAMS: [&str; 1] = ["T"];
 const SIGMOID_TEMP_PARAMS: [&str; 4] = ["reference_time", "T", "T_amplitude", "t_color"];
-const DELAYED_SIGMOID_PARAMS: [&str; 5] = ["reference_time", "T", "T_amplitude", "t_color", "t_delay"];
+const DELAYED_SIGMOID_PARAMS: [&str; 5] =
+    ["reference_time", "T", "T_amplitude", "t_color", "t_delay"];
 
 impl Temperature {
     pub(crate) fn params(&self) -> &'static [&'static str] {
@@ -148,7 +143,9 @@ impl Temperature {
         match self {
             Temperature::Constant => constant_temperature_jacobian(p[0], jac),
             Temperature::Sigmoid => sigmoid_temperature_jacobian(t, p[0], p[1], p[2], p[3], jac),
-            Temperature::DelayedSigmoid => delayed_sigmoid_temperature_jacobian(t, p[0], p[1], p[2], p[3], p[4], jac),
+            Temperature::DelayedSigmoid => {
+                delayed_sigmoid_temperature_jacobian(t, p[0], p[1], p[2], p[3], p[4], jac)
+            }
         }
     }
 
@@ -208,7 +205,12 @@ impl Temperature {
 mod tests {
     use super::*;
 
-    fn finite_diff_check(name: &str, n: usize, value_jac: impl Fn(&[f64], &mut [f64]) -> f64, p: &[f64]) {
+    fn finite_diff_check(
+        name: &str,
+        n: usize,
+        value_jac: impl Fn(&[f64], &mut [f64]) -> f64,
+        p: &[f64],
+    ) {
         let mut jac = vec![0.0; n];
         value_jac(p, &mut jac);
         let h = 1e-6;
@@ -244,8 +246,23 @@ mod tests {
     #[test]
     fn sigmoid_temperature_plateaus() {
         let (t0, temperature, temperature_amplitude, t_color) = (10.0, 8000.0, 0.3, 2.0);
-        let early = sigmoid_temperature(t0 - 1000.0, t0, temperature, temperature_amplitude, t_color);
-        let late = sigmoid_temperature(t0 + 1000.0, t0, temperature, temperature_amplitude, t_color);
+        let mut jac = [0.0; 4];
+        let early = sigmoid_temperature_jacobian(
+            t0 - 1000.0,
+            t0,
+            temperature,
+            temperature_amplitude,
+            t_color,
+            &mut jac,
+        );
+        let late = sigmoid_temperature_jacobian(
+            t0 + 1000.0,
+            t0,
+            temperature,
+            temperature_amplitude,
+            t_color,
+            &mut jac,
+        );
         assert!((early - temperature * 1.3).abs() <= 1e-9 * temperature);
         assert!((late - temperature * 0.7).abs() <= 1e-9 * temperature);
     }


### PR DESCRIPTION
## What

A Rust port of `light_curve_py.features.rainbow.RainbowFit` (currently pure Python, using
`iminuit`/`scipy`) as a real `light-curve-feature` multi-color feature. Jointly fits a
per-band flux model

```
flux(t, band) = bolometric(t) * SED(wavelength_band, temperature(t)) / norm(temperature(t))  [+ baseline_band]
```

with pluggable sub-models:
- bolometric envelope: Bazin, Sigmoid, or Doublexp
- temperature-vs-time: Constant, Sigmoid, or DelayedSigmoid
- spectral energy distribution: Planck, GenWien, ModifiedBlackBody, or LogParabola

plus an optional per-band additive baseline. Returns fitted parameters, their 1-sigma
uncertainties (Gauss-Newton `inv(JᵀJ)` covariance, cheap to compute alongside the fit), and
reduced chi2 (standard `chi2/dof` convention -- note this reads 2x higher than
`light_curve_py`'s reported value, which follows iminuit's `NLL/dof = 0.5*chi2/dof`
convention; same underlying fit quality, different definition).

A companion PR to `light-curve-python` (Rust-backed Python bindings) is ready and linked below.

Motivation: the Python implementation takes tens of ms per fit; this is ~17x faster on a
single light curve and ~11x faster measured across 90 real (LSST, multi-band,
uneven cadence) light curves, with 89/90 converging under identical settings where Python
converges on all 90 -- the one holdout is a genuinely underconstrained fit (20 points across
3 bands for 8 free parameters).

## Why this PR includes some design decisions rather than just proposing them

This ended up large enough, with real design choices, that code + a working benchmark seemed
more useful to react to than a proposal in the abstract. Happy to adjust any of the following
based on your take:

1. **New dependency category.** Needs a nonlinear least-squares solver whose parameter count
   varies at runtime (depends on which sub-models are chosen), which doesn't fit `nl_fit`'s
   compile-time-fixed `NPARAMS` design. Uses `levenberg-marquardt` (pure Rust, pulls in
   `nalgebra`, pinned to `=0.34.2` to match) -- the first pure-Rust linear-algebra dependency
   in this crate (existing fits use GSL/Ceres via FFI, or `nl_fit`'s fixed-size-array
   machinery with no linear algebra dependency at all). Gated behind a new opt-in Cargo
   feature (`rainbow`), following the `gsl`/`ceres-*` precedent -- not part of `default`.

2. **`PassbandTrait::wavelength()`.** Rainbow needs each band's effective wavelength, but
   `PassbandTrait` only exposed a name; only the concrete `MonochromePassband` carries a
   wavelength. Added `fn wavelength(&self) -> Option<f64> { None }` as a backward-compatible
   default method, overridden by `MonochromePassband`. Keeps `RainbowFit` usable through the
   same generic `MultiColorFeature<P, T>` registry as every other feature. This is
   probably the single most relevant point, as it may clash with a future broader multiband interface.

3. **Output layout / uncertainties.** Every other feature returns a flat vector of point
   values; uncertainty estimation is handled generically by wrapping a feature in
   `Bootstrap`/`MultiColorBootstrap`. Because Rainbow's Gauss-Newton uncertainties are nearly
   free here (reuse the fit's own per-point gradient), this bakes them directly into the
   output as `<param>_sigma` columns (`[params..., params..._sigma..., reduced_chi2]`,
   `2*n_params + 1` values total). Open question: keep this, or drop it in favor of the
   existing `Bootstrap` convention?

4. **Convergence tolerance.** `levenberg-marquardt`'s default tolerance
   (`f64::EPSILON * 30 ~= 6.7e-15`) turned out far tighter than real light curve data can
   satisfy within its default evaluation budget -- diagnosed via two real light curves that
   reported non-convergence despite the optimizer already having reached essentially the
   final point a looser tolerance would accept. Switched to `tol=1e-8` (matching
   `scipy.curve_fit`/iminuit convention) with a larger evaluation budget. Also tried a
   jittered-restart retry on failure; measured it against every real non-converging case
   found and it never improved the result (sometimes converging to something ~100x worse),
   while roughly doubling worst-case runtime -- removed it rather than ship dead weight.

## Explicitly not included

- `bolometric = "linexp"` from the Python reference: its own docstring flags the
  guesses/limits as unstable; a seed sweep confirmed roughly half of random seeds land the
  fit in a self-consistent-looking but wrong local optimum.
- `spectral = "blanketed"`: its `lambda_scale` parameter anchors to the temperature term's own
  characteristic `T` via Python's cross-term `common_temp_spec` sharing, more involved than a
  straight port of the other terms.
- Gaussian priors that the Python version uses to break some parameter degeneracies (e.g.
  `T_amplitude`, `beta` anchored toward 0), and non-detection/upper-limit support (Python's
  Tobit-model likelihood term). These are the most likely explanation for the one
  still-underconstrained-light-curve holdout mentioned above.

## Status

All tests pass (`cargo test --no-default-features --features=ceres-source,fftw-source,gsl,rainbow`),
including `cargo clippy --all-targets --features rainbow -- -D warnings` and `cargo fmt --check`.
CI's feature-combination matrix (`.github/workflows/test.yml`) updated to include `rainbow`
everywhere else it tests `gsl,ceres-source,fftw-source`.