### PR TITLE
Generalize nl_fit to runtime-sized parameter vectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ paste = "1"
 rand = { version = "0.10" }
 schemars = "^0.8"
 serde = { version = "1", features = ["derive"] }
+smallvec = "1"
 special = "0.13"
 take_mut = "0.2.2"
 thiserror = "2"

--- a/src/features/bazin_fit.rs
+++ b/src/features/bazin_fit.rs
@@ -5,6 +5,7 @@ use crate::nl_fit::{
 };
 
 use conv::ConvUtil;
+use smallvec::{SmallVec, smallvec};
 
 const NPARAMS: usize = 5;
 
@@ -113,8 +114,8 @@ lazy_info!(
 );
 
 struct Params<'a, T> {
-    internal: &'a [T; NPARAMS],
-    external: [T; NPARAMS],
+    internal: &'a [T],
+    external: SmallVec<[T; MAX_INLINE_PARAMS]>,
 }
 
 impl<T> Params<'_, T>
@@ -162,12 +163,12 @@ where
     }
 }
 
-impl<T, U> FitModelTrait<T, U, NPARAMS> for BazinFit
+impl<T, U> FitModelTrait<T, U> for BazinFit
 where
     T: Float + Into<U>,
     U: LikeFloat,
 {
-    fn model(t: T, param: &[U; NPARAMS]) -> U
+    fn model(t: T, param: &[U]) -> U
     where
         T: Float + Into<U>,
         U: LikeFloat,
@@ -183,13 +184,13 @@ where
     }
 }
 
-impl<T> FitFunctionTrait<T, NPARAMS> for BazinFit where T: Float {}
+impl<T> FitFunctionTrait<T> for BazinFit where T: Float {}
 
-impl<T> FitDerivalivesTrait<T, NPARAMS> for BazinFit
+impl<T> FitDerivalivesTrait<T> for BazinFit
 where
     T: Float,
 {
-    fn derivatives(t: T, param: &[T; NPARAMS], jac: &mut [T; NPARAMS]) {
+    fn derivatives(t: T, param: &[T], jac: &mut [T]) {
         let x = Params {
             internal: param,
             external: Self::internal_to_dimensionless(param),
@@ -212,11 +213,11 @@ where
     }
 }
 
-impl<T> FitInitsBoundsTrait<T, NPARAMS> for BazinFit
+impl<T> FitInitsBoundsTrait<T> for BazinFit
 where
     T: Float,
 {
-    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         match &self.inits_bounds {
             BazinInitsBounds::Default => BazinInitsBounds::default_from_ts(ts),
             BazinInitsBounds::Arrays(arrays) => arrays.as_ref().clone(),
@@ -227,12 +228,9 @@ where
     }
 }
 
-impl FitParametersOriginalDimLessTrait<NPARAMS> for BazinFit {
-    fn orig_to_dimensionless(
-        norm_data: &NormalizedData<f64>,
-        orig: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
-        [
+impl FitParametersOriginalDimLessTrait for BazinFit {
+    fn orig_to_dimensionless(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
+        vec![
             norm_data.m_to_norm_scale(orig[0]), // A amplitude
             norm_data.m_to_norm(orig[1]),       // c baseline
             norm_data.t_to_norm(orig[2]),       // t_0 reference_time
@@ -241,11 +239,8 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for BazinFit {
         ]
     }
 
-    fn dimensionless_to_orig(
-        norm_data: &NormalizedData<f64>,
-        norm: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
-        [
+    fn dimensionless_to_orig(norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
+        vec![
             norm_data.m_to_orig_scale(norm[0]), // A amplitude
             norm_data.m_to_orig(norm[1]),       // c baseline
             norm_data.t_to_orig(norm[2]),       // t_0 reference_time
@@ -255,16 +250,16 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for BazinFit {
     }
 }
 
-impl<U> FitParametersInternalDimlessTrait<U, NPARAMS> for BazinFit
+impl<U> FitParametersInternalDimlessTrait<U> for BazinFit
 where
     U: LikeFloat,
 {
-    fn dimensionless_to_internal(params: &[U; NPARAMS]) -> [U; NPARAMS] {
-        *params
+    fn dimensionless_to_internal(params: &[U]) -> SmallVec<[U; MAX_INLINE_PARAMS]> {
+        SmallVec::from_slice(params)
     }
 
-    fn internal_to_dimensionless(params: &[U; NPARAMS]) -> [U; NPARAMS] {
-        [
+    fn internal_to_dimensionless(params: &[U]) -> SmallVec<[U; MAX_INLINE_PARAMS]> {
+        smallvec![
             params[0].abs(),
             params[1],
             params[2],
@@ -274,11 +269,11 @@ where
     }
 }
 
-impl FitParametersInternalExternalTrait<NPARAMS> for BazinFit {
+impl FitParametersInternalExternalTrait for BazinFit {
     fn jacobian_internal_to_external(
         norm_data: &NormalizedData<f64>,
-        internal: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
+        internal: &[f64],
+    ) -> Vec<f64> {
         // The full transformation is: external = dimensionless_to_orig(internal_to_dimensionless(internal))
         // internal_to_dimensionless applies abs() to params[0], [3], [4]
         // dimensionless_to_orig scales by m_std (params 0,1) and t_std (params 2,3,4)
@@ -286,7 +281,7 @@ impl FitParametersInternalExternalTrait<NPARAMS> for BazinFit {
         // ∂|x|/∂x = sign(x), so the Jacobian is:
         let m_std = norm_data.m_std();
         let t_std = norm_data.t_std();
-        [
+        vec![
             internal[0].signum() * m_std, // A amplitude: |internal[0]| * m_std
             m_std,                        // B baseline: internal[1] * m_std + m_mean
             t_std,                        // t0: internal[2] * t_std + t_mean
@@ -296,12 +291,12 @@ impl FitParametersInternalExternalTrait<NPARAMS> for BazinFit {
     }
 }
 
-impl FitFeatureEvaluatorGettersTrait<NPARAMS> for BazinFit {
+impl FitFeatureEvaluatorGettersTrait for BazinFit {
     fn get_algorithm(&self) -> &CurveFitAlgorithm {
         &self.algorithm
     }
 
-    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior {
         self.ln_prior.ln_prior_from_ts(ts)
     }
 }
@@ -342,13 +337,13 @@ where
 pub enum BazinInitsBounds {
     #[default]
     Default,
-    Arrays(Box<FitInitsBoundsArrays<NPARAMS>>),
-    OptionArrays(Box<OptionFitInitsBoundsArrays<NPARAMS>>),
+    Arrays(Box<FitInitsBoundsArrays>),
+    OptionArrays(Box<OptionFitInitsBoundsArrays>),
 }
 
 impl BazinInitsBounds {
     pub fn arrays(init: [f64; NPARAMS], lower: [f64; NPARAMS], upper: [f64; NPARAMS]) -> Self {
-        Self::Arrays(FitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::Arrays(FitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into())
     }
 
     pub fn option_arrays(
@@ -356,10 +351,12 @@ impl BazinInitsBounds {
         lower: [Option<f64>; NPARAMS],
         upper: [Option<f64>; NPARAMS],
     ) -> Self {
-        Self::OptionArrays(OptionFitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::OptionArrays(
+            OptionFitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into(),
+        )
     }
 
-    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         let t_min: f64 = ts.t.get_min().value_into().unwrap();
         let t_max: f64 = ts.t.get_max().value_into().unwrap();
         let t_amplitude = t_max - t_min;
@@ -384,9 +381,9 @@ impl BazinInitsBounds {
         let (fall_lower, fall_upper) = (0.0, 10.0 * t_amplitude);
 
         FitInitsBoundsArrays {
-            init: [a_init, c_init, t0_init, rise_init, fall_init].into(),
-            lower: [a_lower, c_lower, t0_lower, rise_lower, fall_lower].into(),
-            upper: [a_upper, c_upper, t0_upper, rise_upper, fall_upper].into(),
+            init: vec![a_init, c_init, t0_init, rise_init, fall_init],
+            lower: vec![a_lower, c_lower, t0_lower, rise_lower, fall_lower],
+            upper: vec![a_upper, c_upper, t0_upper, rise_upper, fall_upper],
         }
     }
 }
@@ -394,23 +391,23 @@ impl BazinInitsBounds {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum BazinLnPrior {
-    Fixed(Box<LnPrior<NPARAMS>>),
+    Fixed(Box<LnPrior>),
 }
 
 impl BazinLnPrior {
-    pub fn fixed(ln_prior: LnPrior<NPARAMS>) -> Self {
+    pub fn fixed(ln_prior: LnPrior) -> Self {
         Self::Fixed(ln_prior.into())
     }
 
-    pub fn ln_prior_from_ts<T: Float>(&self, _ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    pub fn ln_prior_from_ts<T: Float>(&self, _ts: &mut TimeSeries<T>) -> LnPrior {
         match self {
             Self::Fixed(ln_prior) => ln_prior.as_ref().clone(),
         }
     }
 }
 
-impl From<LnPrior<NPARAMS>> for BazinLnPrior {
-    fn from(item: LnPrior<NPARAMS>) -> Self {
+impl From<LnPrior> for BazinLnPrior {
+    fn from(item: LnPrior) -> Self {
         Self::fixed(item)
     }
 }
@@ -515,7 +512,7 @@ mod tests {
     //     let lmsder = CeresCurveFit::new();
     //     let mcmc = McmcCurveFit::new(512, Some(lmsder.into()));
     //     bazin_fit_noisy(BazinFit::new(
-    //         CeresCurveFit::new().into(),
+    //         mcmc.into(),
     //         LnPrior::none(),
     //         BazinInitsBounds::option_arrays(
     //             [None; 5],
@@ -614,8 +611,7 @@ mod tests {
                 let result = bazin.eval(&mut ts).unwrap();
 
                 let t_model = Array1::linspace(t[0] - 1.0, t[t.len() - 1] + 1.0, 100);
-                let flux_model =
-                    t_model.mapv(|x| BazinFit::model(x, &result[..NPARAMS].try_into().unwrap()));
+                let flux_model = t_model.mapv(|x| BazinFit::model(x, &result[..NPARAMS]));
                 flux_model.mapv(|y| -2.5 * f64::log10(y / f0))
             })
             .collect();

--- a/src/features/bazin_fit.rs
+++ b/src/features/bazin_fit.rs
@@ -229,8 +229,11 @@ where
 }
 
 impl FitParametersOriginalDimLessTrait for BazinFit {
-    fn orig_to_dimensionless(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
-        vec![
+    fn orig_to_dimensionless(
+        norm_data: &NormalizedData<f64>,
+        orig: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
+        smallvec![
             norm_data.m_to_norm_scale(orig[0]), // A amplitude
             norm_data.m_to_norm(orig[1]),       // c baseline
             norm_data.t_to_norm(orig[2]),       // t_0 reference_time
@@ -239,8 +242,11 @@ impl FitParametersOriginalDimLessTrait for BazinFit {
         ]
     }
 
-    fn dimensionless_to_orig(norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
-        vec![
+    fn dimensionless_to_orig(
+        norm_data: &NormalizedData<f64>,
+        norm: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
+        smallvec![
             norm_data.m_to_orig_scale(norm[0]), // A amplitude
             norm_data.m_to_orig(norm[1]),       // c baseline
             norm_data.t_to_orig(norm[2]),       // t_0 reference_time
@@ -273,7 +279,7 @@ impl FitParametersInternalExternalTrait for BazinFit {
     fn jacobian_internal_to_external(
         norm_data: &NormalizedData<f64>,
         internal: &[f64],
-    ) -> Vec<f64> {
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
         // The full transformation is: external = dimensionless_to_orig(internal_to_dimensionless(internal))
         // internal_to_dimensionless applies abs() to params[0], [3], [4]
         // dimensionless_to_orig scales by m_std (params 0,1) and t_std (params 2,3,4)
@@ -281,7 +287,7 @@ impl FitParametersInternalExternalTrait for BazinFit {
         // ∂|x|/∂x = sign(x), so the Jacobian is:
         let m_std = norm_data.m_std();
         let t_std = norm_data.t_std();
-        vec![
+        smallvec![
             internal[0].signum() * m_std, // A amplitude: |internal[0]| * m_std
             m_std,                        // B baseline: internal[1] * m_std + m_mean
             t_std,                        // t0: internal[2] * t_std + t_mean

--- a/src/features/linexp_fit.rs
+++ b/src/features/linexp_fit.rs
@@ -212,8 +212,11 @@ where
 }
 
 impl FitParametersOriginalDimLessTrait for LinexpFit {
-    fn orig_to_dimensionless(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
-        vec![
+    fn orig_to_dimensionless(
+        norm_data: &NormalizedData<f64>,
+        orig: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
+        smallvec![
             norm_data.m_to_norm_scale(orig[0]), // A amplitude
             norm_data.t_to_norm(orig[1]),       // t_0 reference_time
             norm_data.t_to_norm_scale(orig[2]), // tau fall time
@@ -221,8 +224,11 @@ impl FitParametersOriginalDimLessTrait for LinexpFit {
         ]
     }
 
-    fn dimensionless_to_orig(norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
-        vec![
+    fn dimensionless_to_orig(
+        norm_data: &NormalizedData<f64>,
+        norm: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
+        smallvec![
             norm_data.m_to_orig_scale(norm[0]), // A amplitude
             norm_data.t_to_orig(norm[1]),       // t_0 reference_time
             norm_data.t_to_orig_scale(norm[2]), // tau fall time
@@ -248,7 +254,7 @@ impl FitParametersInternalExternalTrait for LinexpFit {
     fn jacobian_internal_to_external(
         norm_data: &NormalizedData<f64>,
         internal: &[f64],
-    ) -> Vec<f64> {
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
         // The full transformation is: external = dimensionless_to_orig(internal_to_dimensionless(internal))
         // internal_to_dimensionless applies abs() to params[0], [2]
         // dimensionless_to_orig scales by m_std (params 0,3) and t_std (params 1,2)
@@ -256,7 +262,7 @@ impl FitParametersInternalExternalTrait for LinexpFit {
         // ∂|x|/∂x = sign(x), so the Jacobian is:
         let m_std = norm_data.m_std();
         let t_std = norm_data.t_std();
-        vec![
+        smallvec![
             internal[0].signum() * m_std, // A amplitude: |internal[0]| * m_std
             t_std,                        // t0: internal[1] * t_std + t_mean
             internal[2].signum() * t_std, // tau: |internal[2]| * t_std

--- a/src/features/linexp_fit.rs
+++ b/src/features/linexp_fit.rs
@@ -5,6 +5,7 @@ use crate::nl_fit::{
 };
 
 use conv::ConvUtil;
+use smallvec::{SmallVec, smallvec};
 
 const NPARAMS: usize = 4;
 
@@ -111,8 +112,8 @@ lazy_info!(
 );
 
 struct Params<'a, T> {
-    internal: &'a [T; NPARAMS],
-    external: [T; NPARAMS],
+    internal: &'a [T],
+    external: SmallVec<[T; MAX_INLINE_PARAMS]>,
 }
 
 impl<T> Params<'_, T>
@@ -150,12 +151,12 @@ where
     }
 }
 
-impl<T, U> FitModelTrait<T, U, NPARAMS> for LinexpFit
+impl<T, U> FitModelTrait<T, U> for LinexpFit
 where
     T: Float + Into<U>,
     U: LikeFloat,
 {
-    fn model(t: T, param: &[U; NPARAMS]) -> U
+    fn model(t: T, param: &[U]) -> U
     where
         T: Float + Into<U>,
         U: LikeFloat,
@@ -170,13 +171,13 @@ where
     }
 }
 
-impl<T> FitFunctionTrait<T, NPARAMS> for LinexpFit where T: Float {}
+impl<T> FitFunctionTrait<T> for LinexpFit where T: Float {}
 
-impl<T> FitDerivalivesTrait<T, NPARAMS> for LinexpFit
+impl<T> FitDerivalivesTrait<T> for LinexpFit
 where
     T: Float,
 {
-    fn derivatives(t: T, param: &[T; NPARAMS], jac: &mut [T; NPARAMS]) {
+    fn derivatives(t: T, param: &[T], jac: &mut [T]) {
         let x = Params {
             internal: param,
             external: Self::internal_to_dimensionless(param),
@@ -195,11 +196,11 @@ where
     }
 }
 
-impl<T> FitInitsBoundsTrait<T, NPARAMS> for LinexpFit
+impl<T> FitInitsBoundsTrait<T> for LinexpFit
 where
     T: Float,
 {
-    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         match &self.inits_bounds {
             LinexpInitsBounds::Default => LinexpInitsBounds::default_from_ts(ts),
             LinexpInitsBounds::Arrays(arrays) => arrays.as_ref().clone(),
@@ -210,12 +211,9 @@ where
     }
 }
 
-impl FitParametersOriginalDimLessTrait<NPARAMS> for LinexpFit {
-    fn orig_to_dimensionless(
-        norm_data: &NormalizedData<f64>,
-        orig: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
-        [
+impl FitParametersOriginalDimLessTrait for LinexpFit {
+    fn orig_to_dimensionless(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
+        vec![
             norm_data.m_to_norm_scale(orig[0]), // A amplitude
             norm_data.t_to_norm(orig[1]),       // t_0 reference_time
             norm_data.t_to_norm_scale(orig[2]), // tau fall time
@@ -223,11 +221,8 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for LinexpFit {
         ]
     }
 
-    fn dimensionless_to_orig(
-        norm_data: &NormalizedData<f64>,
-        norm: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
-        [
+    fn dimensionless_to_orig(norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
+        vec![
             norm_data.m_to_orig_scale(norm[0]), // A amplitude
             norm_data.t_to_orig(norm[1]),       // t_0 reference_time
             norm_data.t_to_orig_scale(norm[2]), // tau fall time
@@ -236,24 +231,24 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for LinexpFit {
     }
 }
 
-impl<U> FitParametersInternalDimlessTrait<U, NPARAMS> for LinexpFit
+impl<U> FitParametersInternalDimlessTrait<U> for LinexpFit
 where
     U: LikeFloat,
 {
-    fn dimensionless_to_internal(params: &[U; NPARAMS]) -> [U; NPARAMS] {
-        *params
+    fn dimensionless_to_internal(params: &[U]) -> SmallVec<[U; MAX_INLINE_PARAMS]> {
+        SmallVec::from_slice(params)
     }
 
-    fn internal_to_dimensionless(params: &[U; NPARAMS]) -> [U; NPARAMS] {
-        [params[0].abs(), params[1], params[2].abs(), params[3]]
+    fn internal_to_dimensionless(params: &[U]) -> SmallVec<[U; MAX_INLINE_PARAMS]> {
+        smallvec![params[0].abs(), params[1], params[2].abs(), params[3]]
     }
 }
 
-impl FitParametersInternalExternalTrait<NPARAMS> for LinexpFit {
+impl FitParametersInternalExternalTrait for LinexpFit {
     fn jacobian_internal_to_external(
         norm_data: &NormalizedData<f64>,
-        internal: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
+        internal: &[f64],
+    ) -> Vec<f64> {
         // The full transformation is: external = dimensionless_to_orig(internal_to_dimensionless(internal))
         // internal_to_dimensionless applies abs() to params[0], [2]
         // dimensionless_to_orig scales by m_std (params 0,3) and t_std (params 1,2)
@@ -261,7 +256,7 @@ impl FitParametersInternalExternalTrait<NPARAMS> for LinexpFit {
         // ∂|x|/∂x = sign(x), so the Jacobian is:
         let m_std = norm_data.m_std();
         let t_std = norm_data.t_std();
-        [
+        vec![
             internal[0].signum() * m_std, // A amplitude: |internal[0]| * m_std
             t_std,                        // t0: internal[1] * t_std + t_mean
             internal[2].signum() * t_std, // tau: |internal[2]| * t_std
@@ -270,12 +265,12 @@ impl FitParametersInternalExternalTrait<NPARAMS> for LinexpFit {
     }
 }
 
-impl FitFeatureEvaluatorGettersTrait<NPARAMS> for LinexpFit {
+impl FitFeatureEvaluatorGettersTrait for LinexpFit {
     fn get_algorithm(&self) -> &CurveFitAlgorithm {
         &self.algorithm
     }
 
-    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior {
         self.ln_prior.ln_prior_from_ts(ts)
     }
 }
@@ -314,13 +309,13 @@ where
 pub enum LinexpInitsBounds {
     #[default]
     Default,
-    Arrays(Box<FitInitsBoundsArrays<NPARAMS>>),
-    OptionArrays(Box<OptionFitInitsBoundsArrays<NPARAMS>>),
+    Arrays(Box<FitInitsBoundsArrays>),
+    OptionArrays(Box<OptionFitInitsBoundsArrays>),
 }
 
 impl LinexpInitsBounds {
     pub fn arrays(init: [f64; NPARAMS], lower: [f64; NPARAMS], upper: [f64; NPARAMS]) -> Self {
-        Self::Arrays(FitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::Arrays(FitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into())
     }
 
     pub fn option_arrays(
@@ -328,10 +323,12 @@ impl LinexpInitsBounds {
         lower: [Option<f64>; NPARAMS],
         upper: [Option<f64>; NPARAMS],
     ) -> Self {
-        Self::OptionArrays(OptionFitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::OptionArrays(
+            OptionFitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into(),
+        )
     }
 
-    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         let t_min: f64 = ts.t.get_min().value_into().unwrap();
         let t_max: f64 = ts.t.get_max().value_into().unwrap();
         let t_amplitude = t_max - t_min;
@@ -358,9 +355,9 @@ impl LinexpInitsBounds {
         let (b_lower, b_upper) = (m_min - 100.0 * m_amplitude, m_max + 100.0 * m_amplitude);
 
         FitInitsBoundsArrays {
-            init: [a_init, t0_init, tau_init, b_init].into(),
-            lower: [a_lower, t0_lower, tau_lower, b_lower].into(),
-            upper: [a_upper, t0_upper, tau_upper, b_upper].into(),
+            init: vec![a_init, t0_init, tau_init, b_init],
+            lower: vec![a_lower, t0_lower, tau_lower, b_lower],
+            upper: vec![a_upper, t0_upper, tau_upper, b_upper],
         }
     }
 }
@@ -368,23 +365,23 @@ impl LinexpInitsBounds {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[non_exhaustive]
 pub enum LinexpLnPrior {
-    Fixed(Box<LnPrior<NPARAMS>>),
+    Fixed(Box<LnPrior>),
 }
 
 impl LinexpLnPrior {
-    pub fn fixed(ln_prior: LnPrior<NPARAMS>) -> Self {
+    pub fn fixed(ln_prior: LnPrior) -> Self {
         Self::Fixed(ln_prior.into())
     }
 
-    pub fn ln_prior_from_ts<T: Float>(&self, _ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    pub fn ln_prior_from_ts<T: Float>(&self, _ts: &mut TimeSeries<T>) -> LnPrior {
         match self {
             Self::Fixed(ln_prior) => ln_prior.as_ref().clone(),
         }
     }
 }
 
-impl From<LnPrior<NPARAMS>> for LinexpLnPrior {
-    fn from(item: LnPrior<NPARAMS>) -> Self {
+impl From<LnPrior> for LinexpLnPrior {
+    fn from(item: LnPrior) -> Self {
         Self::fixed(item)
     }
 }

--- a/src/features/villar_fit.rs
+++ b/src/features/villar_fit.rs
@@ -6,6 +6,7 @@ use crate::nl_fit::{
 
 use conv::ConvUtil;
 use ordered_float::NotNan;
+use smallvec::{SmallVec, smallvec};
 
 const NPARAMS: usize = 7;
 
@@ -131,12 +132,12 @@ lazy_info!(
     variability_required: true,
 );
 
-impl<T, U> FitModelTrait<T, U, NPARAMS> for VillarFit
+impl<T, U> FitModelTrait<T, U> for VillarFit
 where
     T: Float + Into<U>,
     U: LikeFloat,
 {
-    fn model(t: T, param: &[U; NPARAMS]) -> U {
+    fn model(t: T, param: &[U]) -> U {
         let t: U = t.into();
         let x = Params {
             internal: param,
@@ -146,13 +147,13 @@ where
     }
 }
 
-impl<T> FitFunctionTrait<T, NPARAMS> for VillarFit where T: Float {}
+impl<T> FitFunctionTrait<T> for VillarFit where T: Float {}
 
-impl<T> FitDerivalivesTrait<T, NPARAMS> for VillarFit
+impl<T> FitDerivalivesTrait<T> for VillarFit
 where
     T: Float,
 {
-    fn derivatives(t: T, param: &[T; NPARAMS], jac: &mut [T; NPARAMS]) {
+    fn derivatives(t: T, param: &[T], jac: &mut [T]) {
         let x = Params {
             internal: param,
             external: Self::internal_to_dimensionless(param),
@@ -206,11 +207,11 @@ where
     }
 }
 
-impl<T> FitInitsBoundsTrait<T, NPARAMS> for VillarFit
+impl<T> FitInitsBoundsTrait<T> for VillarFit
 where
     T: Float,
 {
-    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         match &self.inits_bounds {
             VillarInitsBounds::Default => VillarInitsBounds::default_from_ts(ts),
             VillarInitsBounds::Arrays(arrays) => arrays.as_ref().clone(),
@@ -221,12 +222,9 @@ where
     }
 }
 
-impl FitParametersOriginalDimLessTrait<NPARAMS> for VillarFit {
-    fn orig_to_dimensionless(
-        norm_data: &NormalizedData<f64>,
-        orig: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
-        [
+impl FitParametersOriginalDimLessTrait for VillarFit {
+    fn orig_to_dimensionless(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
+        vec![
             norm_data.m_to_norm_scale(orig[0]), // A amplitude
             norm_data.m_to_norm(orig[1]),       // c baseline
             norm_data.t_to_norm(orig[2]),       // t_0 reference time
@@ -237,11 +235,8 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for VillarFit {
         ]
     }
 
-    fn dimensionless_to_orig(
-        norm_data: &NormalizedData<f64>,
-        norm: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
-        [
+    fn dimensionless_to_orig(norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
+        vec![
             norm_data.m_to_orig_scale(norm[0]), // A amplitude
             norm_data.m_to_orig(norm[1]),       // c baseline
             norm_data.t_to_orig(norm[2]),       // t_0 reference time
@@ -253,12 +248,12 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for VillarFit {
     }
 }
 
-impl<U> FitParametersInternalDimlessTrait<U, NPARAMS> for VillarFit
+impl<U> FitParametersInternalDimlessTrait<U> for VillarFit
 where
     U: LikeFloat,
 {
-    fn dimensionless_to_internal(params: &[U; NPARAMS]) -> [U; NPARAMS] {
-        [
+    fn dimensionless_to_internal(params: &[U]) -> SmallVec<[U; MAX_INLINE_PARAMS]> {
+        smallvec![
             params[0],
             params[1],
             params[2],
@@ -269,8 +264,8 @@ where
         ]
     }
 
-    fn internal_to_dimensionless(params: &[U; NPARAMS]) -> [U; NPARAMS] {
-        [
+    fn internal_to_dimensionless(params: &[U]) -> SmallVec<[U; MAX_INLINE_PARAMS]> {
+        smallvec![
             params[0].abs(),
             params[1],
             params[2],
@@ -282,11 +277,11 @@ where
     }
 }
 
-impl FitParametersInternalExternalTrait<NPARAMS> for VillarFit {
+impl FitParametersInternalExternalTrait for VillarFit {
     fn jacobian_internal_to_external(
         norm_data: &NormalizedData<f64>,
-        internal: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
+        internal: &[f64],
+    ) -> Vec<f64> {
         // The full transformation is: external = dimensionless_to_orig(internal_to_dimensionless(internal))
         //
         // internal_to_dimensionless:
@@ -305,7 +300,7 @@ impl FitParametersInternalExternalTrait<NPARAMS> for VillarFit {
         let nu = Self::b_to_nu(internal[5]);
         let d_nu_d_b = (1.0 - nu.powi(2)) * internal[5].signum();
 
-        [
+        vec![
             internal[0].signum() * m_std, // A amplitude: |internal[0]| * m_std
             m_std,                        // c baseline: internal[1] * m_std + m_mean
             t_std,                        // t0: internal[2] * t_std + t_mean
@@ -317,12 +312,12 @@ impl FitParametersInternalExternalTrait<NPARAMS> for VillarFit {
     }
 }
 
-impl FitFeatureEvaluatorGettersTrait<NPARAMS> for VillarFit {
+impl FitFeatureEvaluatorGettersTrait for VillarFit {
     fn get_algorithm(&self) -> &CurveFitAlgorithm {
         &self.algorithm
     }
 
-    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior {
         self.ln_prior.ln_prior_from_ts(ts)
     }
 }
@@ -363,8 +358,8 @@ where
 }
 
 struct Params<'a, T> {
-    internal: &'a [T; NPARAMS],
-    external: [T; NPARAMS],
+    internal: &'a [T],
+    external: SmallVec<[T; MAX_INLINE_PARAMS]>,
 }
 
 impl<T> Params<'_, T>
@@ -472,13 +467,13 @@ where
 pub enum VillarInitsBounds {
     #[default]
     Default,
-    Arrays(Box<FitInitsBoundsArrays<NPARAMS>>),
-    OptionArrays(Box<OptionFitInitsBoundsArrays<NPARAMS>>),
+    Arrays(Box<FitInitsBoundsArrays>),
+    OptionArrays(Box<OptionFitInitsBoundsArrays>),
 }
 
 impl VillarInitsBounds {
     pub fn arrays(init: [f64; NPARAMS], lower: [f64; NPARAMS], upper: [f64; NPARAMS]) -> Self {
-        Self::Arrays(FitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::Arrays(FitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into())
     }
 
     pub fn option_arrays(
@@ -486,10 +481,12 @@ impl VillarInitsBounds {
         lower: [Option<f64>; NPARAMS],
         upper: [Option<f64>; NPARAMS],
     ) -> Self {
-        Self::OptionArrays(OptionFitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::OptionArrays(
+            OptionFitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into(),
+        )
     }
 
-    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         let t_min: f64 = ts.t.get_min().value_into().unwrap();
         let t_max: f64 = ts.t.get_max().value_into().unwrap();
         let t_amplitude = t_max - t_min;
@@ -521,7 +518,7 @@ impl VillarInitsBounds {
         let (gamma_lower, gamma_upper) = (0.0, 10.0 * t_amplitude);
 
         FitInitsBoundsArrays {
-            init: [
+            init: vec![
                 a_init,
                 c_init,
                 t0_init,
@@ -529,9 +526,8 @@ impl VillarInitsBounds {
                 tau_fall_init,
                 nu_init,
                 gamma_init,
-            ]
-            .into(),
-            lower: [
+            ],
+            lower: vec![
                 a_lower,
                 c_lower,
                 t0_lower,
@@ -539,9 +535,8 @@ impl VillarInitsBounds {
                 tau_fall_lower,
                 nu_lower,
                 gamma_lower,
-            ]
-            .into(),
-            upper: [
+            ],
+            upper: vec![
                 a_upper,
                 c_upper,
                 t0_upper,
@@ -549,8 +544,7 @@ impl VillarInitsBounds {
                 tau_fall_upper,
                 nu_upper,
                 gamma_upper,
-            ]
-            .into(),
+            ],
         }
     }
 }
@@ -559,7 +553,7 @@ impl VillarInitsBounds {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[non_exhaustive]
 pub enum VillarLnPrior {
-    Fixed(Box<LnPrior<NPARAMS>>),
+    Fixed(Box<LnPrior>),
     /// Adopted from Hosseinzadeh, et al. 2020, table 2
     ///
     /// `time_units_in_day` specifies the units of time you use in yout `TimeSeries` object, it
@@ -572,7 +566,7 @@ pub enum VillarLnPrior {
 }
 
 impl VillarLnPrior {
-    pub fn fixed(ln_prior: LnPrior<NPARAMS>) -> Self {
+    pub fn fixed(ln_prior: LnPrior) -> Self {
         Self::Fixed(ln_prior.into())
     }
 
@@ -584,7 +578,7 @@ impl VillarLnPrior {
         }
     }
 
-    pub fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    pub fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior {
         match self {
             Self::Fixed(ln_prior) => ln_prior.as_ref().clone(),
             Self::Hosseinzadeh2020 {
@@ -598,7 +592,7 @@ impl VillarLnPrior {
                 let day = day.into_inner();
                 let min_amplitude = min_amplitude.into_inner();
 
-                LnPrior::ind_components([
+                LnPrior::ind_components(vec![
                     LnPrior1D::log_uniform(min_amplitude, 100.0 * m_amplitude), // amplitude
                     LnPrior1D::none(), // offset, not used in the original paper
                     LnPrior1D::uniform(t_peak - 50.0 * day, t_peak + 300.0 * day), // reference time
@@ -615,8 +609,8 @@ impl VillarLnPrior {
     }
 }
 
-impl From<LnPrior<NPARAMS>> for VillarLnPrior {
-    fn from(item: LnPrior<NPARAMS>) -> Self {
+impl From<LnPrior> for VillarLnPrior {
+    fn from(item: LnPrior) -> Self {
         Self::fixed(item)
     }
 }

--- a/src/features/villar_fit.rs
+++ b/src/features/villar_fit.rs
@@ -223,8 +223,11 @@ where
 }
 
 impl FitParametersOriginalDimLessTrait for VillarFit {
-    fn orig_to_dimensionless(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
-        vec![
+    fn orig_to_dimensionless(
+        norm_data: &NormalizedData<f64>,
+        orig: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
+        smallvec![
             norm_data.m_to_norm_scale(orig[0]), // A amplitude
             norm_data.m_to_norm(orig[1]),       // c baseline
             norm_data.t_to_norm(orig[2]),       // t_0 reference time
@@ -235,8 +238,11 @@ impl FitParametersOriginalDimLessTrait for VillarFit {
         ]
     }
 
-    fn dimensionless_to_orig(norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
-        vec![
+    fn dimensionless_to_orig(
+        norm_data: &NormalizedData<f64>,
+        norm: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
+        smallvec![
             norm_data.m_to_orig_scale(norm[0]), // A amplitude
             norm_data.m_to_orig(norm[1]),       // c baseline
             norm_data.t_to_orig(norm[2]),       // t_0 reference time
@@ -281,7 +287,7 @@ impl FitParametersInternalExternalTrait for VillarFit {
     fn jacobian_internal_to_external(
         norm_data: &NormalizedData<f64>,
         internal: &[f64],
-    ) -> Vec<f64> {
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
         // The full transformation is: external = dimensionless_to_orig(internal_to_dimensionless(internal))
         //
         // internal_to_dimensionless:
@@ -300,7 +306,7 @@ impl FitParametersInternalExternalTrait for VillarFit {
         let nu = Self::b_to_nu(internal[5]);
         let d_nu_d_b = (1.0 - nu.powi(2)) * internal[5].signum();
 
-        vec![
+        smallvec![
             internal[0].signum() * m_std, // A amplitude: |internal[0]| * m_std
             m_std,                        // c baseline: internal[1] * m_std + m_mean
             t_std,                        // t0: internal[2] * t_std + t_mean

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -132,9 +132,9 @@ macro_rules! fit_eval {
 
             let (x0, lower, upper) = {
                 let FitInitsBoundsArrays {
-                    init: FitArray(mut x0),
-                    lower: FitArray(mut lower),
-                    upper: FitArray(mut upper),
+                    init: mut x0,
+                    lower: mut lower,
+                    upper: mut upper,
                 } = self.init_and_bounds_from_ts(ts);
                 x0 = Self::convert_to_internal(&norm_data, &x0);
                 lower = Self::convert_to_internal(&norm_data, &lower);
@@ -154,8 +154,7 @@ macro_rules! fit_eval {
                     self.ln_prior_from_ts(ts)
                         .with_fit_parameters_transformation::<Self>(&norm_data),
                 );
-                let result =
-                    Self::convert_to_external(&norm_data, (&x as &[_]).try_into().unwrap());
+                let result = Self::convert_to_external(&norm_data, &x);
                 result
                     .into_iter()
                     .chain(std::iter::once(reduced_chi2))

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -131,14 +131,10 @@ macro_rules! fit_eval {
             let norm_data = NormalizedData::<f64>::from_ts(ts);
 
             let (x0, lower, upper) = {
-                let FitInitsBoundsArrays {
-                    init: mut x0,
-                    lower: mut lower,
-                    upper: mut upper,
-                } = self.init_and_bounds_from_ts(ts);
-                x0 = Self::convert_to_internal(&norm_data, &x0);
-                lower = Self::convert_to_internal(&norm_data, &lower);
-                upper = Self::convert_to_internal(&norm_data, &upper);
+                let FitInitsBoundsArrays { init, lower, upper } = self.init_and_bounds_from_ts(ts);
+                let x0 = Self::convert_to_internal(&norm_data, &init);
+                let lower = Self::convert_to_internal(&norm_data, &lower);
+                let upper = Self::convert_to_internal(&norm_data, &upper);
                 (x0, lower, upper)
             };
 

--- a/src/nl_fit/bounds.rs
+++ b/src/nl_fit/bounds.rs
@@ -2,10 +2,8 @@ pub(super) fn within_bounds<T>(x: &[T], lower: &[T], upper: &[T]) -> bool
 where
     T: PartialOrd,
 {
-    for i in 0..x.len() {
-        if x[i] < lower[i] || x[i] > upper[i] {
-            return false;
-        }
-    }
-    true
+    x.iter()
+        .zip(lower)
+        .zip(upper)
+        .all(|((xi, li), ui)| xi >= li && xi <= ui)
 }

--- a/src/nl_fit/bounds.rs
+++ b/src/nl_fit/bounds.rs
@@ -1,12 +1,8 @@
-pub(super) fn within_bounds<T, const NPARAMS: usize>(
-    x: &[T; NPARAMS],
-    lower: &[T; NPARAMS],
-    upper: &[T; NPARAMS],
-) -> bool
+pub(super) fn within_bounds<T>(x: &[T], lower: &[T], upper: &[T]) -> bool
 where
     T: PartialOrd,
 {
-    for i in 0..NPARAMS {
+    for i in 0..x.len() {
         if x[i] < lower[i] || x[i] > upper[i] {
             return false;
         }

--- a/src/nl_fit/ceres.rs
+++ b/src/nl_fit/ceres.rs
@@ -1,6 +1,7 @@
 use crate::nl_fit::constants::PARAMETER_TOLERANCE;
 use crate::nl_fit::curve_fit::{CurveFitResult, CurveFitTrait};
 use crate::nl_fit::data::Data;
+use crate::nl_fit::evaluator::MAX_INLINE_PARAMS;
 use crate::nl_fit::prior::ln_prior::LnPriorEvaluator;
 
 use ceres_solver::{CurveFitProblem1D, CurveFunctionType, LossFunction, SolverOptions};
@@ -8,6 +9,7 @@ use ndarray::Zip;
 use ordered_float::NotNan;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use smallvec::{SmallVec, smallvec};
 use std::rc::Rc;
 
 /// Ceres-Solver non-linear least-squares wrapper
@@ -78,7 +80,8 @@ impl CurveFitTrait for CeresCurveFit {
         // Ceres calls this closure once per data point (unlike GSL, which loops over all
         // points inside a single call), so the derivative scratch buffer is allocated once
         // and reused via RefCell rather than fresh on every point.
-        let der_buf = std::cell::RefCell::new(vec![0.0; nparams]);
+        let der_buf: std::cell::RefCell<SmallVec<[f64; MAX_INLINE_PARAMS]>> =
+            std::cell::RefCell::new(smallvec![0.0; nparams]);
         let func: CurveFunctionType = {
             let model = model.clone();
             Box::new(move |t, parameters, y, jacobians| {
@@ -103,8 +106,10 @@ impl CurveFitTrait for CeresCurveFit {
             })
         };
 
-        let lower_bounds: Vec<_> = bounds.0.iter().map(|&v| Some(v)).collect();
-        let upper_bounds: Vec<_> = bounds.1.iter().map(|&v| Some(v)).collect();
+        let lower_bounds: SmallVec<[_; MAX_INLINE_PARAMS]> =
+            bounds.0.iter().map(|&v| Some(v)).collect();
+        let upper_bounds: SmallVec<[_; MAX_INLINE_PARAMS]> =
+            bounds.1.iter().map(|&v| Some(v)).collect();
 
         let options = SolverOptions::builder()
             .parameter_tolerance(PARAMETER_TOLERANCE)

--- a/src/nl_fit/ceres.rs
+++ b/src/nl_fit/ceres.rs
@@ -60,37 +60,37 @@ impl Default for CeresCurveFit {
 }
 
 impl CurveFitTrait for CeresCurveFit {
-    fn curve_fit<F, DF, LP, const NPARAMS: usize>(
+    fn curve_fit<F, DF, LP>(
         &self,
         ts: Rc<Data<f64>>,
-        x0: &[f64; NPARAMS],
-        bounds: (&[f64; NPARAMS], &[f64; NPARAMS]),
+        x0: &[f64],
+        bounds: (&[f64], &[f64]),
         model: F,
         derivatives: DF,
         _ln_prior: LP,
-    ) -> CurveFitResult<f64, NPARAMS>
+    ) -> CurveFitResult<f64>
     where
-        F: 'static + Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-        DF: 'static + Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-        LP: LnPriorEvaluator<NPARAMS>,
+        F: 'static + Clone + Fn(f64, &[f64]) -> f64,
+        DF: 'static + Clone + Fn(f64, &[f64], &mut [f64]),
+        LP: LnPriorEvaluator,
     {
+        let nparams = x0.len();
+        // Ceres calls this closure once per data point (unlike GSL, which loops over all
+        // points inside a single call), so the derivative scratch buffer is allocated once
+        // and reused via RefCell rather than fresh on every point.
+        let der_buf = std::cell::RefCell::new(vec![0.0; nparams]);
         let func: CurveFunctionType = {
             let model = model.clone();
             Box::new(move |t, parameters, y, jacobians| {
-                let parameters = parameters.try_into().unwrap();
                 *y = model(t, parameters);
                 if !y.is_finite() {
                     *y = f64::MAX.sqrt();
                     return false;
                 }
                 if let Some(jacobians) = jacobians {
-                    let jacobians: &mut [_; NPARAMS] = jacobians.try_into().unwrap();
-                    let der = {
-                        let mut der = [0.0; NPARAMS];
-                        derivatives(t, parameters, &mut der);
-                        der
-                    };
-                    for (input, output) in der.into_iter().zip(jacobians.iter_mut()) {
+                    let mut der = der_buf.borrow_mut();
+                    derivatives(t, parameters, &mut der);
+                    for (&input, output) in der.iter().zip(jacobians.iter_mut()) {
                         if let Some(output) = output {
                             if !input.is_finite() {
                                 return false;
@@ -124,7 +124,7 @@ impl CurveFitTrait for CeresCurveFit {
             problem_builder = problem_builder.loss(LossFunction::cauchy(loss_factor.into()));
         };
         let solution = problem_builder.build().unwrap().solve(&options);
-        let x = solution.parameters.try_into().unwrap();
+        let x = solution.parameters;
         let success = solution.summary.is_solution_usable();
 
         let reduced_chi2 = Zip::from(&ts.t)
@@ -133,7 +133,7 @@ impl CurveFitTrait for CeresCurveFit {
             .fold(0.0, |acc, &t, &m, &inv_err| {
                 acc + ((model(t, &x) - m) * inv_err).powi(2)
             })
-            / (ts.t.len() - NPARAMS) as f64;
+            / (ts.t.len() - nparams) as f64;
         CurveFitResult {
             x,
             reduced_chi2,
@@ -153,11 +153,11 @@ mod tests {
     use rand::prelude::*;
     use rand_distr::StandardNormal;
 
-    fn nonlinear_func(t: f64, param: &[f64; 3]) -> f64 {
+    fn nonlinear_func(t: f64, param: &[f64]) -> f64 {
         param[1] * f64::exp(-param[0] * t) * t.powi(2) + param[2]
     }
 
-    fn nonlinear_func_derivatives(t: f64, param: &[f64; 3], derivatives: &mut [f64; 3]) {
+    fn nonlinear_func_derivatives(t: f64, param: &[f64], derivatives: &mut [f64]) {
         derivatives[0] = -param[1] * f64::exp(-param[2] * t) * t.powi(3);
         derivatives[1] = f64::exp(-param[0] * t) * t.powi(2);
         derivatives[2] = 1.0;

--- a/src/nl_fit/curve_fit.rs
+++ b/src/nl_fit/curve_fit.rs
@@ -15,27 +15,27 @@ use std::fmt::Debug;
 use std::rc::Rc;
 
 #[derive(Clone, Debug)]
-pub struct CurveFitResult<T, const NPARAMS: usize> {
-    pub x: [T; NPARAMS],
+pub struct CurveFitResult<T> {
+    pub x: Vec<T>,
     pub reduced_chi2: T,
     pub success: bool,
 }
 
 #[enum_dispatch]
 pub trait CurveFitTrait: Clone + Debug + Serialize + DeserializeOwned {
-    fn curve_fit<F, DF, LP, const NPARAMS: usize>(
+    fn curve_fit<F, DF, LP>(
         &self,
         ts: Rc<Data<f64>>,
-        x0: &[f64; NPARAMS],
-        bounds: (&[f64; NPARAMS], &[f64; NPARAMS]),
+        x0: &[f64],
+        bounds: (&[f64], &[f64]),
         model: F,
         derivatives: DF,
         ln_prior: LP,
-    ) -> CurveFitResult<f64, NPARAMS>
+    ) -> CurveFitResult<f64>
     where
-        F: 'static + Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-        DF: 'static + Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-        LP: LnPriorEvaluator<NPARAMS>;
+        F: 'static + Clone + Fn(f64, &[f64]) -> f64,
+        DF: 'static + Clone + Fn(f64, &[f64], &mut [f64]),
+        LP: LnPriorEvaluator;
 }
 
 /// Optimization algorithm for non-linear least squares

--- a/src/nl_fit/evaluator.rs
+++ b/src/nl_fit/evaluator.rs
@@ -3,224 +3,109 @@ use crate::float_trait::Float;
 use crate::nl_fit::{CurveFitAlgorithm, LikeFloat, LnPrior, data::NormalizedData};
 
 use schemars::JsonSchema;
-use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
+use smallvec::SmallVec;
 
-pub trait FitModelTrait<T, U, const NPARAMS: usize>
+/// Inline capacity for [`FitParametersInternalDimlessTrait`]'s per-point-hot transforms: covers
+/// every current fixed-`NPARAMS` feature (Bazin=5, Linexp=4, Villar=7) without spilling to the
+/// heap. Larger parameter counts still work, just via a heap allocation past this size.
+pub const MAX_INLINE_PARAMS: usize = 8;
+
+pub trait FitModelTrait<T, U>
 where
     T: Float + Into<U>,
     U: LikeFloat,
 {
-    fn model(t: T, param: &[U; NPARAMS]) -> U
+    fn model(t: T, param: &[U]) -> U
     where
         T: Float + Into<U>,
         U: LikeFloat;
 }
 
-pub trait FitFunctionTrait<T: Float, const NPARAMS: usize>:
-    FitModelTrait<T, T, NPARAMS> + FitParametersInternalDimlessTrait<T, NPARAMS>
+pub trait FitFunctionTrait<T: Float>:
+    FitModelTrait<T, T> + FitParametersInternalDimlessTrait<T>
 {
     fn f(t: T, values: &[T]) -> T {
-        let internal = Self::dimensionless_to_internal(
-            values[..NPARAMS]
-                .try_into()
-                .expect("values slice's length is too small"),
-        );
+        let internal = Self::dimensionless_to_internal(values);
         Self::model(t, &internal)
     }
 }
 
-pub trait FitDerivalivesTrait<T: Float, const NPARAMS: usize> {
-    fn derivatives(t: T, param: &[T; NPARAMS], jac: &mut [T; NPARAMS]);
+pub trait FitDerivalivesTrait<T: Float> {
+    fn derivatives(t: T, param: &[T], jac: &mut [T]);
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
-#[serde(
-    into = "FitArraySerde<T>",
-    try_from = "FitArraySerde<T>",
-    bound = "T: Debug + Clone + Serialize + DeserializeOwned + JsonSchema"
-)]
-pub struct FitArray<T, const NPARAMS: usize>(pub [T; NPARAMS]);
-
-impl<T, const NPARAMS: usize> JsonSchema for FitArray<T, NPARAMS>
-where
-    T: schemars::JsonSchema,
-{
-    fn is_referenceable() -> bool {
-        false
-    }
-
-    fn schema_name() -> String {
-        FitArraySerde::<T>::schema_name()
-    }
-
-    fn json_schema(r#gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
-        FitArraySerde::<T>::json_schema(r#gen)
-    }
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct FitInitsBoundsArrays {
+    pub init: Vec<f64>,
+    pub lower: Vec<f64>,
+    pub upper: Vec<f64>,
 }
 
-impl<T, const NPARAMS: usize> From<[T; NPARAMS]> for FitArray<T, NPARAMS> {
-    fn from(item: [T; NPARAMS]) -> Self {
-        Self(item)
-    }
-}
-
-impl<T, const NPARAMS: usize> std::ops::Deref for FitArray<T, NPARAMS> {
-    type Target = [T; NPARAMS];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T, const NPARAMS: usize> From<FitArray<T, NPARAMS>> for FitArray<Option<T>, NPARAMS>
-where
-    T: Copy,
-{
-    fn from(item: FitArray<T, NPARAMS>) -> Self {
-        let mut opt = [None; NPARAMS];
-        for (&x, y) in item.0.iter().zip(opt.iter_mut()) {
-            *y = Some(x);
-        }
-        opt.into()
-    }
-}
-
-impl<T, const NPARAMS: usize> FitArray<Option<T>, NPARAMS>
-where
-    T: Clone,
-{
-    fn unwrap_with(&self, with: &FitArray<T, NPARAMS>) -> FitArray<T, NPARAMS> {
-        let mut a = with.clone();
-        for (opt, x) in self.0.iter().zip(a.0.iter_mut()) {
-            if let Some(value) = opt {
-                *x = value.clone()
-            }
-        }
-        a
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(
-    rename = "FitArray",
-    bound = "T: Debug + Clone + Serialize + DeserializeOwned + JsonSchema"
-)]
-struct FitArraySerde<T>(Vec<T>);
-
-impl<T, const NPARAMS: usize> From<FitArray<T, NPARAMS>> for FitArraySerde<T> {
-    fn from(item: FitArray<T, NPARAMS>) -> Self {
-        Self(item.0.into())
-    }
-}
-
-impl<T, const NPARAMS: usize> TryFrom<FitArraySerde<T>> for FitArray<T, NPARAMS> {
-    type Error = &'static str;
-
-    fn try_from(item: FitArraySerde<T>) -> Result<Self, Self::Error> {
-        Ok(Self(
-            item.0
-                .try_into()
-                .map_err(|_| "wrong size of the FitArray object")?,
-        ))
+impl FitInitsBoundsArrays {
+    pub fn new(init: Vec<f64>, lower: Vec<f64>, upper: Vec<f64>) -> Self {
+        Self { init, lower, upper }
     }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
-pub struct FitInitsBoundsArrays<const NPARAMS: usize> {
-    pub init: FitArray<f64, NPARAMS>,
-    pub lower: FitArray<f64, NPARAMS>,
-    pub upper: FitArray<f64, NPARAMS>,
+pub struct OptionFitInitsBoundsArrays {
+    pub init: Vec<Option<f64>>,
+    pub lower: Vec<Option<f64>>,
+    pub upper: Vec<Option<f64>>,
 }
 
-impl<const NPARAMS: usize> FitInitsBoundsArrays<NPARAMS> {
-    pub fn new(init: [f64; NPARAMS], lower: [f64; NPARAMS], upper: [f64; NPARAMS]) -> Self {
-        Self {
-            init: init.into(),
-            lower: lower.into(),
-            upper: upper.into(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
-pub struct OptionFitInitsBoundsArrays<const NPARAMS: usize> {
-    pub init: FitArray<Option<f64>, NPARAMS>,
-    pub lower: FitArray<Option<f64>, NPARAMS>,
-    pub upper: FitArray<Option<f64>, NPARAMS>,
-}
-
-impl<const NPARAMS: usize> OptionFitInitsBoundsArrays<NPARAMS> {
-    pub fn new(
-        init: [Option<f64>; NPARAMS],
-        lower: [Option<f64>; NPARAMS],
-        upper: [Option<f64>; NPARAMS],
-    ) -> Self {
-        Self {
-            init: init.into(),
-            lower: lower.into(),
-            upper: upper.into(),
-        }
+impl OptionFitInitsBoundsArrays {
+    pub fn new(init: Vec<Option<f64>>, lower: Vec<Option<f64>>, upper: Vec<Option<f64>>) -> Self {
+        Self { init, lower, upper }
     }
 
-    pub fn unwrap_with(&self, x: &FitInitsBoundsArrays<NPARAMS>) -> FitInitsBoundsArrays<NPARAMS> {
+    pub fn unwrap_with(&self, x: &FitInitsBoundsArrays) -> FitInitsBoundsArrays {
+        let unwrap_slice = |opt: &[Option<f64>], with: &[f64]| -> Vec<f64> {
+            opt.iter().zip(with).map(|(o, &w)| o.unwrap_or(w)).collect()
+        };
         FitInitsBoundsArrays {
-            init: self.init.unwrap_with(&x.init),
-            lower: self.lower.unwrap_with(&x.lower),
-            upper: self.upper.unwrap_with(&x.upper),
+            init: unwrap_slice(&self.init, &x.init),
+            lower: unwrap_slice(&self.lower, &x.lower),
+            upper: unwrap_slice(&self.upper, &x.upper),
         }
     }
 }
 
-impl<const NPARAMS: usize> From<FitInitsBoundsArrays<NPARAMS>>
-    for OptionFitInitsBoundsArrays<NPARAMS>
-{
-    fn from(item: FitInitsBoundsArrays<NPARAMS>) -> Self {
+impl From<FitInitsBoundsArrays> for OptionFitInitsBoundsArrays {
+    fn from(item: FitInitsBoundsArrays) -> Self {
         Self {
-            init: item.init.into(),
-            lower: item.lower.into(),
-            upper: item.upper.into(),
+            init: item.init.into_iter().map(Some).collect(),
+            lower: item.lower.into_iter().map(Some).collect(),
+            upper: item.upper.into_iter().map(Some).collect(),
         }
     }
 }
 
-pub trait FitInitsBoundsTrait<T: Float, const NPARAMS: usize> {
-    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS>;
+pub trait FitInitsBoundsTrait<T: Float> {
+    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays;
 }
 
-pub trait FitParametersInternalDimlessTrait<U: LikeFloat, const NPARAMS: usize> {
-    fn dimensionless_to_internal(params: &[U; NPARAMS]) -> [U; NPARAMS];
+pub trait FitParametersInternalDimlessTrait<U: LikeFloat> {
+    fn dimensionless_to_internal(params: &[U]) -> SmallVec<[U; MAX_INLINE_PARAMS]>;
 
-    fn internal_to_dimensionless(params: &[U; NPARAMS]) -> [U; NPARAMS];
+    fn internal_to_dimensionless(params: &[U]) -> SmallVec<[U; MAX_INLINE_PARAMS]>;
 }
 
-pub trait FitParametersOriginalDimLessTrait<const NPARAMS: usize> {
-    fn orig_to_dimensionless(
-        norm_data: &NormalizedData<f64>,
-        orig: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS];
+pub trait FitParametersOriginalDimLessTrait {
+    fn orig_to_dimensionless(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64>;
 
-    fn dimensionless_to_orig(
-        norm_data: &NormalizedData<f64>,
-        norm: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS];
+    fn dimensionless_to_orig(norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64>;
 }
 
-pub trait FitParametersInternalExternalTrait<const NPARAMS: usize>:
-    FitParametersInternalDimlessTrait<f64, NPARAMS> + FitParametersOriginalDimLessTrait<NPARAMS>
+pub trait FitParametersInternalExternalTrait:
+    FitParametersInternalDimlessTrait<f64> + FitParametersOriginalDimLessTrait
 {
-    fn convert_to_internal(
-        norm_data: &NormalizedData<f64>,
-        orig: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
-        Self::dimensionless_to_internal(&Self::orig_to_dimensionless(norm_data, orig))
+    fn convert_to_internal(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
+        Self::dimensionless_to_internal(&Self::orig_to_dimensionless(norm_data, orig)).into_vec()
     }
 
-    fn convert_to_external(
-        norm_data: &NormalizedData<f64>,
-        params: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
+    fn convert_to_external(norm_data: &NormalizedData<f64>, params: &[f64]) -> Vec<f64> {
         Self::dimensionless_to_orig(norm_data, &Self::internal_to_dimensionless(params))
     }
 
@@ -240,14 +125,12 @@ pub trait FitParametersInternalExternalTrait<const NPARAMS: usize>:
     /// 2. `dimensionless_to_orig`: linear scaling by `t_std`, `m_std`, etc.
     ///
     /// Since both transformations are element-wise, the full Jacobian is diagonal.
-    fn jacobian_internal_to_external(
-        norm_data: &NormalizedData<f64>,
-        internal: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS];
+    fn jacobian_internal_to_external(norm_data: &NormalizedData<f64>, internal: &[f64])
+    -> Vec<f64>;
 }
 
-pub trait FitFeatureEvaluatorGettersTrait<const NPARAMS: usize> {
+pub trait FitFeatureEvaluatorGettersTrait {
     fn get_algorithm(&self) -> &CurveFitAlgorithm;
 
-    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS>;
+    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior;
 }

--- a/src/nl_fit/evaluator.rs
+++ b/src/nl_fit/evaluator.rs
@@ -93,19 +93,31 @@ pub trait FitParametersInternalDimlessTrait<U: LikeFloat> {
 }
 
 pub trait FitParametersOriginalDimLessTrait {
-    fn orig_to_dimensionless(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64>;
+    fn orig_to_dimensionless(
+        norm_data: &NormalizedData<f64>,
+        orig: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]>;
 
-    fn dimensionless_to_orig(norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64>;
+    fn dimensionless_to_orig(
+        norm_data: &NormalizedData<f64>,
+        norm: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]>;
 }
 
 pub trait FitParametersInternalExternalTrait:
     FitParametersInternalDimlessTrait<f64> + FitParametersOriginalDimLessTrait
 {
-    fn convert_to_internal(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
-        Self::dimensionless_to_internal(&Self::orig_to_dimensionless(norm_data, orig)).into_vec()
+    fn convert_to_internal(
+        norm_data: &NormalizedData<f64>,
+        orig: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
+        Self::dimensionless_to_internal(&Self::orig_to_dimensionless(norm_data, orig))
     }
 
-    fn convert_to_external(norm_data: &NormalizedData<f64>, params: &[f64]) -> Vec<f64> {
+    fn convert_to_external(
+        norm_data: &NormalizedData<f64>,
+        params: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
         Self::dimensionless_to_orig(norm_data, &Self::internal_to_dimensionless(params))
     }
 
@@ -125,8 +137,10 @@ pub trait FitParametersInternalExternalTrait:
     /// 2. `dimensionless_to_orig`: linear scaling by `t_std`, `m_std`, etc.
     ///
     /// Since both transformations are element-wise, the full Jacobian is diagonal.
-    fn jacobian_internal_to_external(norm_data: &NormalizedData<f64>, internal: &[f64])
-    -> Vec<f64>;
+    fn jacobian_internal_to_external(
+        norm_data: &NormalizedData<f64>,
+        internal: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]>;
 }
 
 pub trait FitFeatureEvaluatorGettersTrait {

--- a/src/nl_fit/lmsder.rs
+++ b/src/nl_fit/lmsder.rs
@@ -50,24 +50,25 @@ impl Default for LmsderCurveFit {
 }
 
 impl CurveFitTrait for LmsderCurveFit {
-    fn curve_fit<F, DF, LP, const NPARAMS: usize>(
+    fn curve_fit<F, DF, LP>(
         &self,
         ts: Rc<Data<f64>>,
-        x0: &[f64; NPARAMS],
-        _bounds: (&[f64; NPARAMS], &[f64; NPARAMS]),
+        x0: &[f64],
+        _bounds: (&[f64], &[f64]),
         model: F,
         derivatives: DF,
         _ln_prior: LP,
-    ) -> CurveFitResult<f64, NPARAMS>
+    ) -> CurveFitResult<f64>
     where
-        F: 'static + Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-        DF: 'static + Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-        LP: LnPriorEvaluator<NPARAMS>,
+        F: 'static + Clone + Fn(f64, &[f64]) -> f64,
+        DF: 'static + Clone + Fn(f64, &[f64], &mut [f64]),
+        LP: LnPriorEvaluator,
     {
+        let nparams = x0.len();
         let f = {
             let ts = ts.clone();
             move |param: VectorF64, mut residual: VectorF64| {
-                let param = param.as_slice().unwrap().try_into().unwrap();
+                let param = param.as_slice().unwrap();
                 Zip::from(&ts.t)
                     .and(&ts.m)
                     .and(&ts.inv_err)
@@ -81,8 +82,8 @@ impl CurveFitTrait for LmsderCurveFit {
         let df = {
             let ts = ts.clone();
             move |param: VectorF64, mut jacobian: MatrixF64| {
-                let param = param.as_slice().unwrap().try_into().unwrap();
-                let mut buffer = [0.0; NPARAMS];
+                let param = param.as_slice().unwrap();
+                let mut buffer = vec![0.0; nparams];
                 Zip::indexed(&ts.t)
                     .and(&ts.inv_err)
                     .for_each(|i, &t, &inv_err| {
@@ -95,18 +96,14 @@ impl CurveFitTrait for LmsderCurveFit {
             }
         };
 
-        let mut problem = NlsProblem::from_f_df(ts.t.len(), NPARAMS, f, df);
+        let mut problem = NlsProblem::from_f_df(ts.t.len(), nparams, f, df);
         problem.max_iter = self.niterations;
         let result = problem.solve(VectorF64::from_slice(x0).unwrap());
-        let x = {
-            let x = result.x();
-            let x: &[_; NPARAMS] = x.as_slice().unwrap().try_into().unwrap();
-            *x
-        };
+        let x = result.x().as_slice().unwrap().to_vec();
 
         CurveFitResult {
             x,
-            reduced_chi2: result.loss() / ((ts.t.len() - NPARAMS) as f64),
+            reduced_chi2: result.loss() / ((ts.t.len() - nparams) as f64),
             success: result.status == Value::Success,
         }
     }

--- a/src/nl_fit/lmsder.rs
+++ b/src/nl_fit/lmsder.rs
@@ -3,6 +3,7 @@ use crate::float_trait::Float;
 use crate::nl_fit::constants::PARAMETER_TOLERANCE;
 use crate::nl_fit::curve_fit::{CurveFitResult, CurveFitTrait};
 use crate::nl_fit::data::Data;
+use crate::nl_fit::evaluator::MAX_INLINE_PARAMS;
 use crate::nl_fit::prior::ln_prior::LnPriorEvaluator;
 
 #[cfg(test)]
@@ -16,6 +17,7 @@ use rgsl::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use smallvec::smallvec;
 #[cfg(test)]
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -83,7 +85,8 @@ impl CurveFitTrait for LmsderCurveFit {
             let ts = ts.clone();
             move |param: VectorF64, mut jacobian: MatrixF64| {
                 let param = param.as_slice().unwrap();
-                let mut buffer = vec![0.0; nparams];
+                let mut buffer: smallvec::SmallVec<[f64; MAX_INLINE_PARAMS]> =
+                    smallvec![0.0; nparams];
                 Zip::indexed(&ts.t)
                     .and(&ts.inv_err)
                     .for_each(|i, &t, &inv_err| {

--- a/src/nl_fit/mcmc.rs
+++ b/src/nl_fit/mcmc.rs
@@ -6,7 +6,6 @@ use crate::nl_fit::prior::ln_prior::LnPriorEvaluator;
 
 use emcee::{EnsembleSampler, Guess, Prob};
 use emcee_rand::{distributions::IndependentSample, *};
-use itertools::Itertools;
 use ndarray::Zip;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -59,22 +58,23 @@ impl Default for McmcCurveFit {
 }
 
 impl CurveFitTrait for McmcCurveFit {
-    fn curve_fit<F, DF, LP, const NPARAMS: usize>(
+    fn curve_fit<F, DF, LP>(
         &self,
         ts: Rc<Data<f64>>,
-        x0: &[f64; NPARAMS],
-        bounds: (&[f64; NPARAMS], &[f64; NPARAMS]),
+        x0: &[f64],
+        bounds: (&[f64], &[f64]),
         model: F,
         derivatives: DF,
         ln_prior: LP,
-    ) -> CurveFitResult<f64, NPARAMS>
+    ) -> CurveFitResult<f64>
     where
-        F: 'static + Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-        DF: 'static + Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-        LP: LnPriorEvaluator<NPARAMS>,
+        F: 'static + Clone + Fn(f64, &[f64]) -> f64,
+        DF: 'static + Clone + Fn(f64, &[f64], &mut [f64]),
+        LP: LnPriorEvaluator,
     {
         const NWALKERS_PER_DIMENSION: usize = 4;
-        let nwalkers = NWALKERS_PER_DIMENSION * NPARAMS;
+        let nparams = x0.len();
+        let nwalkers = NWALKERS_PER_DIMENSION * nparams;
         let nsamples = ts.t.len();
 
         let lnlike = {
@@ -82,7 +82,7 @@ impl CurveFitTrait for McmcCurveFit {
             let model = model.clone();
             move |guess: &Guess| {
                 let mut residual = 0.0;
-                let params = slice_to_array(&guess.values);
+                let params = slice_to_vec(&guess.values);
                 Zip::from(&ts.t)
                     .and(&ts.m)
                     .and(&ts.inv_err)
@@ -95,13 +95,13 @@ impl CurveFitTrait for McmcCurveFit {
         let lnprior = {
             let ln_prior = ln_prior.clone();
             move |guess: &Guess| {
-                let params = slice_to_array(&guess.values);
+                let params = slice_to_vec(&guess.values);
                 ln_prior.ln_prior(&params, None) as f32
             }
         };
 
-        let x0_f32: [_; NPARAMS] = slice_to_array(x0);
-        let bounds_f32 = (slice_to_array(bounds.0), slice_to_array(bounds.1));
+        let x0_f32: Vec<f32> = slice_to_vec(x0);
+        let bounds_f32 = (slice_to_vec(bounds.0), slice_to_vec(bounds.1));
 
         let initial_guesses = generate_initial_guesses(
             nwalkers,
@@ -116,7 +116,7 @@ impl CurveFitTrait for McmcCurveFit {
             lower: &bounds_f32.0,
             upper: &bounds_f32.1,
         };
-        let mut sampler = EnsembleSampler::new(nwalkers, NPARAMS, &emcee_model).unwrap();
+        let mut sampler = EnsembleSampler::new(nwalkers, nparams, &emcee_model).unwrap();
         sampler.seed(&[]);
 
         let (best_x, best_lnprob) = {
@@ -139,17 +139,10 @@ impl CurveFitTrait for McmcCurveFit {
         };
 
         match self.fine_tuning_algorithm.as_ref() {
-            Some(algo) => algo.curve_fit(
-                ts,
-                &best_x.try_into().unwrap(),
-                bounds,
-                model,
-                derivatives,
-                ln_prior,
-            ),
+            Some(algo) => algo.curve_fit(ts, &best_x, bounds, model, derivatives, ln_prior),
             None => CurveFitResult {
-                x: best_x.try_into().unwrap(),
-                reduced_chi2: -best_lnprob / ((nsamples - NPARAMS) as f64),
+                x: best_x,
+                reduced_chi2: -best_lnprob / ((nsamples - nparams) as f64),
                 success: true,
             },
         }
@@ -157,23 +150,21 @@ impl CurveFitTrait for McmcCurveFit {
 }
 
 #[inline]
-fn slice_to_array<T, U, const NPARAMS: usize>(sl: &[T]) -> [U; NPARAMS]
+fn slice_to_vec<T, U>(sl: &[T]) -> Vec<U>
 where
     T: Float,
     U: Float,
 {
-    let mut array = [U::zero(); NPARAMS];
-    for (input, output) in sl.iter().zip_eq(array.iter_mut()) {
-        *output = num_traits::cast::cast(*input).unwrap();
-    }
-    array
+    sl.iter()
+        .map(|&x| num_traits::cast::cast(x).unwrap())
+        .collect()
 }
 
 #[inline]
-fn generate_initial_guesses<R, const NPARAMS: usize>(
+fn generate_initial_guesses<R>(
     nwalkers: usize,
-    x0: &[f32; NPARAMS],
-    bounds: (&[f32; NPARAMS], &[f32; NPARAMS]),
+    x0: &[f32],
+    bounds: (&[f32], &[f32]),
     rng: &mut R,
 ) -> Vec<Guess>
 where
@@ -221,14 +212,14 @@ where
         .collect()
 }
 
-struct EmceeModel<'b, F, LP, const NPARAMS: usize> {
+struct EmceeModel<'b, F, LP> {
     ln_like: F,
     ln_prior: LP,
-    lower: &'b [f32; NPARAMS],
-    upper: &'b [f32; NPARAMS],
+    lower: &'b [f32],
+    upper: &'b [f32],
 }
 
-impl<F, LP, const NPARAMS: usize> Prob for EmceeModel<'_, F, LP, NPARAMS>
+impl<F, LP> Prob for EmceeModel<'_, F, LP>
 where
     F: Fn(&Guess) -> f32,
     LP: Fn(&Guess) -> f32,
@@ -238,11 +229,7 @@ where
     }
 
     fn lnprior(&self, params: &Guess) -> f32 {
-        if !within_bounds(
-            (&params.values[..]).try_into().unwrap(),
-            self.lower,
-            self.upper,
-        ) {
+        if !within_bounds(&params.values, self.lower, self.upper) {
             return f32::NEG_INFINITY;
         }
         (self.ln_prior)(params)

--- a/src/nl_fit/mcmc.rs
+++ b/src/nl_fit/mcmc.rs
@@ -2,6 +2,7 @@ use crate::float_trait::Float;
 use crate::nl_fit::bounds::within_bounds;
 use crate::nl_fit::curve_fit::{CurveFitAlgorithm, CurveFitResult, CurveFitTrait};
 use crate::nl_fit::data::Data;
+use crate::nl_fit::evaluator::MAX_INLINE_PARAMS;
 use crate::nl_fit::prior::ln_prior::LnPriorEvaluator;
 
 use emcee::{EnsembleSampler, Guess, Prob};
@@ -9,6 +10,7 @@ use emcee_rand::{distributions::IndependentSample, *};
 use ndarray::Zip;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 use std::fmt::Debug;
 use std::rc::Rc;
 
@@ -100,7 +102,7 @@ impl CurveFitTrait for McmcCurveFit {
             }
         };
 
-        let x0_f32: Vec<f32> = slice_to_vec(x0);
+        let x0_f32: SmallVec<[f32; MAX_INLINE_PARAMS]> = slice_to_vec(x0);
         let bounds_f32 = (slice_to_vec(bounds.0), slice_to_vec(bounds.1));
 
         let initial_guesses = generate_initial_guesses(
@@ -150,7 +152,7 @@ impl CurveFitTrait for McmcCurveFit {
 }
 
 #[inline]
-fn slice_to_vec<T, U>(sl: &[T]) -> Vec<U>
+fn slice_to_vec<T, U>(sl: &[T]) -> SmallVec<[U; MAX_INLINE_PARAMS]>
 where
     T: Float,
     U: Float,

--- a/src/nl_fit/mod.rs
+++ b/src/nl_fit/mod.rs
@@ -95,7 +95,7 @@
 //! Models implement [`FitModelTrait`](evaluator::FitModelTrait):
 //!
 //! ```text
-//! fn model(t: T, internal_params: &[U; NPARAMS]) -> U
+//! fn model(t: T, internal_params: &[U]) -> U
 //! ```
 //!
 //! The model receives **internal** parameters and typically transforms them to dimensionless

--- a/src/nl_fit/nuts.rs
+++ b/src/nl_fit/nuts.rs
@@ -68,16 +68,15 @@ impl Default for NutsCurveFit {
     }
 }
 
+/// `logp` no longer has a fallible conversion step (it now takes `params: &[f64]` directly,
+/// rather than converting to a fixed-size array first), so this error can never actually be
+/// constructed -- kept as an uninhabited type only because `CpuLogpFunc::LogpError` requires one.
 #[derive(Debug)]
-enum NutsLogpError {
-    NonRecoverable,
-}
+enum NutsLogpError {}
 
 impl std::fmt::Display for NutsLogpError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            NutsLogpError::NonRecoverable => write!(f, "Non-recoverable error in logp calculation"),
-        }
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {}
     }
 }
 
@@ -85,69 +84,68 @@ impl std::error::Error for NutsLogpError {}
 
 impl LogpError for NutsLogpError {
     fn is_recoverable(&self) -> bool {
-        false
+        match *self {}
     }
 }
 
-struct LogpFunc<F, DF, LP, const NPARAMS: usize> {
+struct LogpFunc<F, DF, LP> {
     ts: Rc<Data<f64>>,
     model: F,
     derivatives: DF,
     ln_prior: LP,
-    lower: [f64; NPARAMS],
-    upper: [f64; NPARAMS],
+    lower: Vec<f64>,
+    upper: Vec<f64>,
 }
 
-impl<F, DF, LP, const NPARAMS: usize> HasDims for LogpFunc<F, DF, LP, NPARAMS> {
+impl<F, DF, LP> HasDims for LogpFunc<F, DF, LP> {
     fn dim_sizes(&self) -> HashMap<String, u64> {
+        let nparams = self.lower.len() as u64;
         HashMap::from([
-            ("unconstrained_parameter".to_string(), NPARAMS as u64),
-            ("dim".to_string(), NPARAMS as u64),
+            ("unconstrained_parameter".to_string(), nparams),
+            ("dim".to_string(), nparams),
         ])
     }
 }
 
-impl<F, DF, LP, const NPARAMS: usize> CpuLogpFunc for LogpFunc<F, DF, LP, NPARAMS>
+impl<F, DF, LP> CpuLogpFunc for LogpFunc<F, DF, LP>
 where
-    F: Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-    DF: Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-    LP: LnPriorEvaluator<NPARAMS>,
+    F: Clone + Fn(f64, &[f64]) -> f64,
+    DF: Clone + Fn(f64, &[f64], &mut [f64]),
+    LP: LnPriorEvaluator,
 {
     type LogpError = NutsLogpError;
     type FlowParameters = ();
     type ExpandedVector = Vec<f64>;
 
     fn dim(&self) -> usize {
-        NPARAMS
+        self.lower.len()
     }
 
     fn logp(&mut self, params: &[f64], grad: &mut [f64]) -> Result<f64, Self::LogpError> {
-        // Check boundaries
-        let params_array: [f64; NPARAMS] = params
-            .try_into()
-            .map_err(|_| NutsLogpError::NonRecoverable)?;
+        let nparams = self.lower.len();
 
-        if !within_bounds(&params_array, &self.lower, &self.upper) {
+        // Check boundaries
+        if !within_bounds(params, &self.lower, &self.upper) {
             return Ok(f64::NEG_INFINITY);
         }
 
         // Calculate log-likelihood (negative chi-squared)
         let mut residual = 0.0;
-        let mut grad_array = [0.0; NPARAMS];
+        let mut grad_array = vec![0.0; nparams];
 
         // Compute -chi^2/2 and its gradient
+        let mut model_grad = vec![0.0; nparams];
         Zip::from(&self.ts.t)
             .and(&self.ts.m)
             .and(&self.ts.inv_err)
             .for_each(|&t, &m, &inv_err| {
-                let model_val = (self.model)(t, &params_array);
+                let model_val = (self.model)(t, params);
                 let diff = model_val - m;
                 residual += (inv_err * diff).powi(2);
 
                 // Gradient of chi^2 with respect to parameters
-                let mut model_grad = [0.0; NPARAMS];
-                (self.derivatives)(t, &params_array, &mut model_grad);
-                for i in 0..NPARAMS {
+                (self.derivatives)(t, params, &mut model_grad);
+                for i in 0..nparams {
                     grad_array[i] += 2.0 * inv_err.powi(2) * diff * model_grad[i];
                 }
             });
@@ -155,13 +153,13 @@ where
         let lnlike = -0.5 * residual;
 
         // Add prior and compute its gradient
-        let mut prior_grad = [0.0; NPARAMS];
-        let lnprior = self.ln_prior.ln_prior(&params_array, Some(&mut prior_grad));
+        let mut prior_grad = vec![0.0; nparams];
+        let lnprior = self.ln_prior.ln_prior(params, Some(&mut prior_grad));
 
         // Gradient is d(lnlike + lnprior)/d(params)
         // = d(lnlike)/d(params) + d(lnprior)/d(params)
         // = -0.5 * d(chi^2)/d(params) + d(lnprior)/d(params)
-        for i in 0..NPARAMS {
+        for i in 0..nparams {
             grad[i] = -0.5 * grad_array[i] + prior_grad[i];
         }
 
@@ -178,20 +176,21 @@ where
 }
 
 impl CurveFitTrait for NutsCurveFit {
-    fn curve_fit<F, DF, LP, const NPARAMS: usize>(
+    fn curve_fit<F, DF, LP>(
         &self,
         ts: Rc<Data<f64>>,
-        x0: &[f64; NPARAMS],
-        bounds: (&[f64; NPARAMS], &[f64; NPARAMS]),
+        x0: &[f64],
+        bounds: (&[f64], &[f64]),
         model: F,
         derivatives: DF,
         ln_prior: LP,
-    ) -> CurveFitResult<f64, NPARAMS>
+    ) -> CurveFitResult<f64>
     where
-        F: 'static + Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-        DF: 'static + Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-        LP: LnPriorEvaluator<NPARAMS>,
+        F: 'static + Clone + Fn(f64, &[f64]) -> f64,
+        DF: 'static + Clone + Fn(f64, &[f64], &mut [f64]),
+        LP: LnPriorEvaluator,
     {
+        let nparams = x0.len();
         let nsamples = ts.t.len();
 
         let logp_func = LogpFunc {
@@ -199,8 +198,8 @@ impl CurveFitTrait for NutsCurveFit {
             model: model.clone(),
             derivatives: derivatives.clone(),
             ln_prior: ln_prior.clone(),
-            lower: *bounds.0,
-            upper: *bounds.1,
+            lower: bounds.0.to_vec(),
+            upper: bounds.1.to_vec(),
         };
 
         let math = CpuMath::new(logp_func);
@@ -215,7 +214,7 @@ impl CurveFitTrait for NutsCurveFit {
         let mut sampler = settings.new_chain(0, math, &mut rng);
 
         // Set initial position
-        sampler.set_position(&x0[..]).unwrap_or_else(|e| {
+        sampler.set_position(x0).unwrap_or_else(|e| {
             panic!(
                 "Failed to set initial position for NUTS sampler. \
                      This may be due to invalid parameters or boundary violations. \
@@ -225,16 +224,13 @@ impl CurveFitTrait for NutsCurveFit {
         });
 
         // Collect samples
-        let mut best_x = *x0;
+        let mut best_x = x0.to_vec();
         let mut best_lnprob = f64::NEG_INFINITY;
 
         for _ in 0..(self.num_tune + self.num_draws) {
             match sampler.expanded_draw() {
                 Ok((draw, _expanded, stats, _progress)) => {
-                    // Convert draw to array
-                    let params: [f64; NPARAMS] = Vec::from(draw)
-                        .try_into()
-                        .expect("Failed to convert draw to array");
+                    let params = Vec::from(draw);
 
                     // Use the log probability from the sampler stats
                     let lnprob = stats.point.logp;
@@ -262,7 +258,7 @@ impl CurveFitTrait for NutsCurveFit {
                     .for_each(|&t, &m, &inv_err| {
                         residual += (inv_err * (model(t, &best_x) - m)).powi(2);
                     });
-                let reduced_chi2 = residual / ((nsamples - NPARAMS) as f64);
+                let reduced_chi2 = residual / ((nsamples - nparams) as f64);
 
                 CurveFitResult {
                     x: best_x,
@@ -281,7 +277,7 @@ mod tests {
     use crate::nl_fit::data::NormalizedData;
     use crate::nl_fit::evaluator::{
         FitParametersInternalDimlessTrait, FitParametersInternalExternalTrait,
-        FitParametersOriginalDimLessTrait,
+        FitParametersOriginalDimLessTrait, MAX_INLINE_PARAMS,
     };
     use crate::nl_fit::prior::ln_prior::LnPrior;
     use crate::nl_fit::prior::ln_prior_1d::LnPrior1D;
@@ -298,36 +294,40 @@ mod tests {
     /// with external = dimensionless (no additional scaling).
     struct SimpleConstantModel;
 
-    impl FitParametersInternalDimlessTrait<f64, 1> for SimpleConstantModel {
-        fn dimensionless_to_internal(params: &[f64; 1]) -> [f64; 1] {
-            *params
+    impl FitParametersInternalDimlessTrait<f64> for SimpleConstantModel {
+        fn dimensionless_to_internal(
+            params: &[f64],
+        ) -> smallvec::SmallVec<[f64; MAX_INLINE_PARAMS]> {
+            smallvec::SmallVec::from_slice(params)
         }
 
-        fn internal_to_dimensionless(params: &[f64; 1]) -> [f64; 1] {
-            [params[0].abs()] // Apply abs() transformation
-        }
-    }
-
-    impl FitParametersOriginalDimLessTrait<1> for SimpleConstantModel {
-        fn orig_to_dimensionless(_norm_data: &NormalizedData<f64>, orig: &[f64; 1]) -> [f64; 1] {
-            // No scaling - external = dimensionless for this simple model
-            *orig
-        }
-
-        fn dimensionless_to_orig(_norm_data: &NormalizedData<f64>, norm: &[f64; 1]) -> [f64; 1] {
-            // No scaling - external = dimensionless for this simple model
-            *norm
+        fn internal_to_dimensionless(
+            params: &[f64],
+        ) -> smallvec::SmallVec<[f64; MAX_INLINE_PARAMS]> {
+            smallvec::smallvec![params[0].abs()] // Apply abs() transformation
         }
     }
 
-    impl FitParametersInternalExternalTrait<1> for SimpleConstantModel {
+    impl FitParametersOriginalDimLessTrait for SimpleConstantModel {
+        fn orig_to_dimensionless(_norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
+            // No scaling - external = dimensionless for this simple model
+            orig.to_vec()
+        }
+
+        fn dimensionless_to_orig(_norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
+            // No scaling - external = dimensionless for this simple model
+            norm.to_vec()
+        }
+    }
+
+    impl FitParametersInternalExternalTrait for SimpleConstantModel {
         fn jacobian_internal_to_external(
             _norm_data: &NormalizedData<f64>,
-            internal: &[f64; 1],
-        ) -> [f64; 1] {
+            internal: &[f64],
+        ) -> Vec<f64> {
             // external = |internal|
             // d(external)/d(internal) = sign(internal)
-            [internal[0].signum()]
+            vec![internal[0].signum()]
         }
     }
 
@@ -380,17 +380,18 @@ mod tests {
             posterior_var * ((N as f64) * y_target / obs_var + prior_mean / prior_var);
 
         // Create prior in external space
-        let prior: LnPrior<1> = LnPrior::ind_components([LnPrior1D::normal(prior_mean, prior_std)]);
+        let prior: LnPrior =
+            LnPrior::ind_components(vec![LnPrior1D::normal(prior_mean, prior_std)]);
 
         // Transform prior to work with internal parameters
         let transformed_prior =
             prior.with_fit_parameters_transformation::<SimpleConstantModel>(&norm_data);
 
         // Model: f(t) = |internal[0]|
-        let model = |_t: f64, params: &[f64; 1]| -> f64 { params[0].abs() };
+        let model = |_t: f64, params: &[f64]| -> f64 { params[0].abs() };
 
         // Derivatives: d(|x|)/dx = sign(x)
-        let derivatives = |_t: f64, params: &[f64; 1], jac: &mut [f64; 1]| {
+        let derivatives = |_t: f64, params: &[f64], jac: &mut [f64]| {
             jac[0] = params[0].signum();
         };
 
@@ -457,7 +458,7 @@ mod tests {
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
         // Prior in external space: N(1.0, 0.5²)
-        let prior: LnPrior<1> = LnPrior::ind_components([LnPrior1D::normal(1.0, 0.5)]);
+        let prior: LnPrior = LnPrior::ind_components(vec![LnPrior1D::normal(1.0, 0.5)]);
         let transformed_prior =
             prior.with_fit_parameters_transformation::<SimpleConstantModel>(&norm_data);
 
@@ -530,7 +531,7 @@ mod tests {
         let mut ts = TimeSeries::new(&t_vec, &m_vec, &w_vec);
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
-        let prior: LnPrior<1> = LnPrior::ind_components([LnPrior1D::normal(1.0, 0.5)]);
+        let prior: LnPrior = LnPrior::ind_components(vec![LnPrior1D::normal(1.0, 0.5)]);
         let transformed_prior =
             prior.with_fit_parameters_transformation::<SimpleConstantModel>(&norm_data);
 

--- a/src/nl_fit/nuts.rs
+++ b/src/nl_fit/nuts.rs
@@ -1,6 +1,7 @@
 use crate::nl_fit::bounds::within_bounds;
 use crate::nl_fit::curve_fit::{CurveFitAlgorithm, CurveFitResult, CurveFitTrait};
 use crate::nl_fit::data::Data;
+use crate::nl_fit::evaluator::MAX_INLINE_PARAMS;
 use crate::nl_fit::prior::ln_prior::LnPriorEvaluator;
 
 use ndarray::Zip;
@@ -9,6 +10,7 @@ use rand::SeedableRng;
 use rand::rngs::StdRng;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use smallvec::{SmallVec, smallvec};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::rc::Rc;
@@ -93,8 +95,8 @@ struct LogpFunc<F, DF, LP> {
     model: F,
     derivatives: DF,
     ln_prior: LP,
-    lower: Vec<f64>,
-    upper: Vec<f64>,
+    lower: SmallVec<[f64; MAX_INLINE_PARAMS]>,
+    upper: SmallVec<[f64; MAX_INLINE_PARAMS]>,
 }
 
 impl<F, DF, LP> HasDims for LogpFunc<F, DF, LP> {
@@ -131,10 +133,10 @@ where
 
         // Calculate log-likelihood (negative chi-squared)
         let mut residual = 0.0;
-        let mut grad_array = vec![0.0; nparams];
+        let mut grad_array: SmallVec<[f64; MAX_INLINE_PARAMS]> = smallvec![0.0; nparams];
 
         // Compute -chi^2/2 and its gradient
-        let mut model_grad = vec![0.0; nparams];
+        let mut model_grad: SmallVec<[f64; MAX_INLINE_PARAMS]> = smallvec![0.0; nparams];
         Zip::from(&self.ts.t)
             .and(&self.ts.m)
             .and(&self.ts.inv_err)
@@ -153,7 +155,7 @@ where
         let lnlike = -0.5 * residual;
 
         // Add prior and compute its gradient
-        let mut prior_grad = vec![0.0; nparams];
+        let mut prior_grad: SmallVec<[f64; MAX_INLINE_PARAMS]> = smallvec![0.0; nparams];
         let lnprior = self.ln_prior.ln_prior(params, Some(&mut prior_grad));
 
         // Gradient is d(lnlike + lnprior)/d(params)
@@ -198,8 +200,8 @@ impl CurveFitTrait for NutsCurveFit {
             model: model.clone(),
             derivatives: derivatives.clone(),
             ln_prior: ln_prior.clone(),
-            lower: bounds.0.to_vec(),
-            upper: bounds.1.to_vec(),
+            lower: SmallVec::from_slice(bounds.0),
+            upper: SmallVec::from_slice(bounds.1),
         };
 
         let math = CpuMath::new(logp_func);
@@ -309,14 +311,20 @@ mod tests {
     }
 
     impl FitParametersOriginalDimLessTrait for SimpleConstantModel {
-        fn orig_to_dimensionless(_norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
+        fn orig_to_dimensionless(
+            _norm_data: &NormalizedData<f64>,
+            orig: &[f64],
+        ) -> smallvec::SmallVec<[f64; MAX_INLINE_PARAMS]> {
             // No scaling - external = dimensionless for this simple model
-            orig.to_vec()
+            smallvec::SmallVec::from_slice(orig)
         }
 
-        fn dimensionless_to_orig(_norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
+        fn dimensionless_to_orig(
+            _norm_data: &NormalizedData<f64>,
+            norm: &[f64],
+        ) -> smallvec::SmallVec<[f64; MAX_INLINE_PARAMS]> {
             // No scaling - external = dimensionless for this simple model
-            norm.to_vec()
+            smallvec::SmallVec::from_slice(norm)
         }
     }
 
@@ -324,10 +332,10 @@ mod tests {
         fn jacobian_internal_to_external(
             _norm_data: &NormalizedData<f64>,
             internal: &[f64],
-        ) -> Vec<f64> {
+        ) -> smallvec::SmallVec<[f64; MAX_INLINE_PARAMS]> {
             // external = |internal|
             // d(external)/d(internal) = sign(internal)
-            vec![internal[0].signum()]
+            smallvec::smallvec![internal[0].signum()]
         }
     }
 

--- a/src/nl_fit/prior/ln_prior.rs
+++ b/src/nl_fit/prior/ln_prior.rs
@@ -329,11 +329,17 @@ mod tests {
     }
 
     impl crate::nl_fit::evaluator::FitParametersOriginalDimLessTrait for MockFitParameters {
-        fn orig_to_dimensionless(_norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
-            orig.to_vec()
+        fn orig_to_dimensionless(
+            _norm_data: &NormalizedData<f64>,
+            orig: &[f64],
+        ) -> smallvec::SmallVec<[f64; crate::nl_fit::evaluator::MAX_INLINE_PARAMS]> {
+            smallvec::SmallVec::from_slice(orig)
         }
 
-        fn dimensionless_to_orig(_norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
+        fn dimensionless_to_orig(
+            _norm_data: &NormalizedData<f64>,
+            norm: &[f64],
+        ) -> smallvec::SmallVec<[f64; crate::nl_fit::evaluator::MAX_INLINE_PARAMS]> {
             // Simple transformation: multiply by 2
             norm.iter().map(|&x| x * 2.0).collect()
         }
@@ -343,12 +349,12 @@ mod tests {
         fn jacobian_internal_to_external(
             _norm_data: &NormalizedData<f64>,
             internal: &[f64],
-        ) -> Vec<f64> {
+        ) -> smallvec::SmallVec<[f64; crate::nl_fit::evaluator::MAX_INLINE_PARAMS]> {
             // For MockFitParameters:
             // - internal_to_dimensionless is identity, so derivative is 1
             // - dimensionless_to_orig multiplies by 2, so derivative is 2
             // Combined: 1 * 2 = 2 for each component
-            vec![2.0; internal.len()]
+            smallvec::smallvec![2.0; internal.len()]
         }
     }
 

--- a/src/nl_fit/prior/ln_prior.rs
+++ b/src/nl_fit/prior/ln_prior.rs
@@ -12,11 +12,12 @@ use std::fmt::Debug;
 /// This trait is implemented by types that can evaluate ln(prior) for a given set of parameters.
 /// Unlike [LnPriorTrait], this trait does not require serialization, making it suitable for
 /// use with closures and other non-serializable types.
-pub trait LnPriorEvaluator<const NPARAMS: usize>: Clone {
+pub trait LnPriorEvaluator: Clone {
     /// Evaluate the natural logarithm of the prior at params
     ///
     /// If `jac` is `Some`, the jacobian (gradient) d(ln_prior)/d(params) is also computed and stored in it.
-    fn ln_prior(&self, params: &[f64; NPARAMS], jac: Option<&mut [f64; NPARAMS]>) -> f64;
+    /// `jac`, when given, must be the same length as `params`.
+    fn ln_prior(&self, params: &[f64], jac: Option<&mut [f64]>) -> f64;
 }
 
 /// Trait for serializable prior evaluators
@@ -28,22 +29,19 @@ pub trait LnPriorEvaluator<const NPARAMS: usize>: Clone {
 /// or temporary prior objects). Use this trait when you need to serialize the prior
 /// configuration.
 #[enum_dispatch]
-pub trait LnPriorTrait<const NPARAMS: usize>:
-    LnPriorEvaluator<NPARAMS> + Debug + Serialize + DeserializeOwned
-{
-}
+pub trait LnPriorTrait: LnPriorEvaluator + Debug + Serialize + DeserializeOwned {}
 
 /// Natural logarithm of prior for non-linear curve-fit problem
-#[enum_dispatch(LnPriorTrait<NPARAMS>)]
+#[enum_dispatch(LnPriorTrait)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
 #[non_exhaustive]
-pub enum LnPrior<const NPARAMS: usize> {
+pub enum LnPrior {
     None(NoneLnPrior),
-    IndComponents(IndComponentsLnPrior<NPARAMS>),
+    IndComponents(IndComponentsLnPrior),
 }
 
-impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for LnPrior<NPARAMS> {
-    fn ln_prior(&self, params: &[f64; NPARAMS], jac: Option<&mut [f64; NPARAMS]>) -> f64 {
+impl LnPriorEvaluator for LnPrior {
+    fn ln_prior(&self, params: &[f64], jac: Option<&mut [f64]>) -> f64 {
         match self {
             LnPrior::None(p) => p.ln_prior(params, jac),
             LnPrior::IndComponents(p) => p.ln_prior(params, jac),
@@ -51,39 +49,42 @@ impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for LnPrior<NPARAMS> {
     }
 }
 
-impl<const NPARAMS: usize> LnPrior<NPARAMS> {
+impl LnPrior {
     pub fn none() -> Self {
         NoneLnPrior {}.into()
     }
 
-    pub fn ind_components(components: [LnPrior1D; NPARAMS]) -> Self {
-        IndComponentsLnPrior { components }.into()
+    pub fn ind_components(components: impl Into<Vec<LnPrior1D>>) -> Self {
+        IndComponentsLnPrior {
+            components: components.into(),
+        }
+        .into()
     }
 
-    pub fn into_func(self) -> impl 'static + Clone + Fn(&[f64; NPARAMS]) -> f64 {
+    pub fn into_func(self) -> impl 'static + Clone + Fn(&[f64]) -> f64 {
         move |params| self.ln_prior(params, None)
     }
 
     pub fn into_func_with_transformation<'a, F>(
         self,
         transform: F,
-    ) -> impl 'a + Clone + Fn(&[f64; NPARAMS]) -> f64
+    ) -> impl 'a + Clone + Fn(&[f64]) -> f64
     where
-        F: 'a + Clone + Fn(&[f64; NPARAMS]) -> [f64; NPARAMS],
+        F: 'a + Clone + Fn(&[f64]) -> Vec<f64>,
     {
         move |params| self.ln_prior(&transform(params), None)
     }
 
-    pub fn as_func(&self) -> impl '_ + Fn(&[f64; NPARAMS]) -> f64 {
+    pub fn as_func(&self) -> impl '_ + Fn(&[f64]) -> f64 {
         |params| self.ln_prior(params, None)
     }
 
     pub fn as_func_with_transformation<'a, F>(
         &'a self,
         transform: F,
-    ) -> impl 'a + Clone + Fn(&[f64; NPARAMS]) -> f64
+    ) -> impl 'a + Clone + Fn(&[f64]) -> f64
     where
-        F: 'a + Clone + Fn(&[f64; NPARAMS]) -> [f64; NPARAMS],
+        F: 'a + Clone + Fn(&[f64]) -> Vec<f64>,
     {
         move |params| self.ln_prior(&transform(params), None)
     }
@@ -96,9 +97,9 @@ impl<const NPARAMS: usize> LnPrior<NPARAMS> {
     pub fn with_fit_parameters_transformation<'a, T>(
         &'a self,
         norm_data: &'a NormalizedData<f64>,
-    ) -> TransformedLnPrior<'a, T, NPARAMS>
+    ) -> TransformedLnPrior<'a, T>
     where
-        T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait<NPARAMS>,
+        T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait,
     {
         TransformedLnPrior {
             prior: self.clone(),
@@ -111,8 +112,8 @@ impl<const NPARAMS: usize> LnPrior<NPARAMS> {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
 pub struct NoneLnPrior {}
 
-impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for NoneLnPrior {
-    fn ln_prior(&self, _params: &[f64; NPARAMS], jac: Option<&mut [f64; NPARAMS]>) -> f64 {
+impl LnPriorEvaluator for NoneLnPrior {
+    fn ln_prior(&self, _params: &[f64], jac: Option<&mut [f64]>) -> f64 {
         if let Some(j) = jac {
             j.iter_mut().for_each(|x| *x = 0.0);
         }
@@ -120,19 +121,16 @@ impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for NoneLnPrior {
     }
 }
 
-impl<const NPARAMS: usize> LnPriorTrait<NPARAMS> for NoneLnPrior {}
+impl LnPriorTrait for NoneLnPrior {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(
-    into = "IndComponentsLnPriorSerde",
-    try_from = "IndComponentsLnPriorSerde"
-)]
-pub struct IndComponentsLnPrior<const NPARAMS: usize> {
-    pub components: [LnPrior1D; NPARAMS],
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
+#[serde(rename = "IndComponentsLnPrior")]
+pub struct IndComponentsLnPrior {
+    pub components: Vec<LnPrior1D>,
 }
 
-impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for IndComponentsLnPrior<NPARAMS> {
-    fn ln_prior(&self, params: &[f64; NPARAMS], jac: Option<&mut [f64; NPARAMS]>) -> f64 {
+impl LnPriorEvaluator for IndComponentsLnPrior {
+    fn ln_prior(&self, params: &[f64], jac: Option<&mut [f64]>) -> f64 {
         let mut total_ln_prior = 0.0;
 
         if let Some(jac) = jac {
@@ -156,48 +154,7 @@ impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for IndComponentsLnPrior<NP
     }
 }
 
-impl<const NPARAMS: usize> LnPriorTrait<NPARAMS> for IndComponentsLnPrior<NPARAMS> {}
-
-impl<const NPARAMS: usize> JsonSchema for IndComponentsLnPrior<NPARAMS> {
-    fn is_referenceable() -> bool {
-        false
-    }
-
-    fn schema_name() -> String {
-        IndComponentsLnPriorSerde::schema_name()
-    }
-
-    fn json_schema(r#gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
-        IndComponentsLnPriorSerde::json_schema(r#gen)
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename = "IndComponentsLnPrior")]
-struct IndComponentsLnPriorSerde {
-    components: Vec<LnPrior1D>,
-}
-
-impl<const NPARAMS: usize> From<IndComponentsLnPrior<NPARAMS>> for IndComponentsLnPriorSerde {
-    fn from(value: IndComponentsLnPrior<NPARAMS>) -> Self {
-        Self {
-            components: value.components.into(),
-        }
-    }
-}
-
-impl<const NPARAMS: usize> TryFrom<IndComponentsLnPriorSerde> for IndComponentsLnPrior<NPARAMS> {
-    type Error = &'static str;
-
-    fn try_from(value: IndComponentsLnPriorSerde) -> Result<Self, Self::Error> {
-        Ok(Self {
-            components: value
-                .components
-                .try_into()
-                .map_err(|_| "wrong size of the IndComponentsLnPrior.components")?,
-        })
-    }
-}
+impl LnPriorTrait for IndComponentsLnPrior {}
 
 /// A prior with parameter transformation using FitParametersInternalExternalTrait
 ///
@@ -209,18 +166,18 @@ impl<const NPARAMS: usize> TryFrom<IndComponentsLnPriorSerde> for IndComponentsL
 /// Note: This type stores a reference to `NormalizedData` which is runtime data, so it cannot
 /// be serialized. However, the prior itself can be serialized separately.
 #[derive(Debug)]
-pub struct TransformedLnPrior<'a, T, const NPARAMS: usize>
+pub struct TransformedLnPrior<'a, T>
 where
-    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait<NPARAMS>,
+    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait,
 {
-    prior: LnPrior<NPARAMS>,
+    prior: LnPrior,
     norm_data: &'a NormalizedData<f64>,
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<'a, T, const NPARAMS: usize> Clone for TransformedLnPrior<'a, T, NPARAMS>
+impl<'a, T> Clone for TransformedLnPrior<'a, T>
 where
-    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait<NPARAMS>,
+    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait,
 {
     fn clone(&self) -> Self {
         Self {
@@ -231,11 +188,11 @@ where
     }
 }
 
-impl<'a, T, const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for TransformedLnPrior<'a, T, NPARAMS>
+impl<'a, T> LnPriorEvaluator for TransformedLnPrior<'a, T>
 where
-    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait<NPARAMS>,
+    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait,
 {
-    fn ln_prior(&self, params: &[f64; NPARAMS], jac: Option<&mut [f64; NPARAMS]>) -> f64 {
+    fn ln_prior(&self, params: &[f64], jac: Option<&mut [f64]>) -> f64 {
         let transformed = T::convert_to_external(self.norm_data, params);
 
         match jac {
@@ -264,19 +221,19 @@ mod tests {
 
     #[test]
     fn test_ln_prior_evaluator_trait_none() {
-        let prior: LnPrior<3> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let params = [1.0, 2.0, 3.0];
         assert_eq!(prior.ln_prior(&params, None), 0.0);
     }
 
     #[test]
     fn test_ln_prior_evaluator_trait_ind_components() {
-        let components = [
+        let components = vec![
             LnPrior1D::uniform(0.0, 10.0),
             LnPrior1D::uniform(0.0, 10.0),
             LnPrior1D::uniform(0.0, 10.0),
         ];
-        let prior: LnPrior<3> = LnPrior::ind_components(components);
+        let prior: LnPrior = LnPrior::ind_components(components);
 
         // Test with valid parameters
         let params_valid = [5.0, 5.0, 5.0];
@@ -297,7 +254,7 @@ mod tests {
 
     #[test]
     fn test_ind_components_ln_prior() {
-        let components = [LnPrior1D::uniform(0.0, 1.0), LnPrior1D::uniform(0.0, 2.0)];
+        let components = vec![LnPrior1D::uniform(0.0, 1.0), LnPrior1D::uniform(0.0, 2.0)];
         let prior = IndComponentsLnPrior { components };
 
         // Both within bounds
@@ -311,7 +268,7 @@ mod tests {
 
     #[test]
     fn test_ln_prior_clone() {
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let cloned = prior.clone();
         let params = [1.0, 2.0];
         assert_eq!(
@@ -322,14 +279,14 @@ mod tests {
 
     #[test]
     fn test_ln_prior_debug() {
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let debug_str = format!("{:?}", prior);
         assert!(debug_str.contains("None"));
     }
 
     #[test]
     fn test_ln_prior_into_func() {
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let func = prior.into_func();
         let params = [1.0, 2.0];
         assert_eq!(func(&params), 0.0);
@@ -337,8 +294,8 @@ mod tests {
 
     #[test]
     fn test_ln_prior_into_func_with_transformation() {
-        let prior: LnPrior<2> = LnPrior::none();
-        let transform = |params: &[f64; 2]| [params[0] * 2.0, params[1] * 2.0];
+        let prior: LnPrior = LnPrior::none();
+        let transform = |params: &[f64]| vec![params[0] * 2.0, params[1] * 2.0];
         let func = prior.into_func_with_transformation(transform);
         let params = [1.0, 2.0];
         // Since NoneLnPrior always returns 0, transformation doesn't affect result
@@ -347,7 +304,7 @@ mod tests {
 
     #[test]
     fn test_ln_prior_as_func() {
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let func = prior.as_func();
         let params = [1.0, 2.0];
         assert_eq!(func(&params), 0.0);
@@ -357,37 +314,41 @@ mod tests {
     #[derive(Debug)]
     struct MockFitParameters;
 
-    impl crate::nl_fit::evaluator::FitParametersInternalDimlessTrait<f64, 2> for MockFitParameters {
-        fn dimensionless_to_internal(params: &[f64; 2]) -> [f64; 2] {
-            *params
+    impl crate::nl_fit::evaluator::FitParametersInternalDimlessTrait<f64> for MockFitParameters {
+        fn dimensionless_to_internal(
+            params: &[f64],
+        ) -> smallvec::SmallVec<[f64; crate::nl_fit::evaluator::MAX_INLINE_PARAMS]> {
+            smallvec::SmallVec::from_slice(params)
         }
 
-        fn internal_to_dimensionless(params: &[f64; 2]) -> [f64; 2] {
-            *params
+        fn internal_to_dimensionless(
+            params: &[f64],
+        ) -> smallvec::SmallVec<[f64; crate::nl_fit::evaluator::MAX_INLINE_PARAMS]> {
+            smallvec::SmallVec::from_slice(params)
         }
     }
 
-    impl crate::nl_fit::evaluator::FitParametersOriginalDimLessTrait<2> for MockFitParameters {
-        fn orig_to_dimensionless(_norm_data: &NormalizedData<f64>, orig: &[f64; 2]) -> [f64; 2] {
-            *orig
+    impl crate::nl_fit::evaluator::FitParametersOriginalDimLessTrait for MockFitParameters {
+        fn orig_to_dimensionless(_norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
+            orig.to_vec()
         }
 
-        fn dimensionless_to_orig(_norm_data: &NormalizedData<f64>, norm: &[f64; 2]) -> [f64; 2] {
+        fn dimensionless_to_orig(_norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
             // Simple transformation: multiply by 2
-            [norm[0] * 2.0, norm[1] * 2.0]
+            norm.iter().map(|&x| x * 2.0).collect()
         }
     }
 
-    impl crate::nl_fit::evaluator::FitParametersInternalExternalTrait<2> for MockFitParameters {
+    impl crate::nl_fit::evaluator::FitParametersInternalExternalTrait for MockFitParameters {
         fn jacobian_internal_to_external(
             _norm_data: &NormalizedData<f64>,
-            _internal: &[f64; 2],
-        ) -> [f64; 2] {
+            internal: &[f64],
+        ) -> Vec<f64> {
             // For MockFitParameters:
             // - internal_to_dimensionless is identity, so derivative is 1
             // - dimensionless_to_orig multiplies by 2, so derivative is 2
             // Combined: 1 * 2 = 2 for each component
-            [2.0, 2.0]
+            vec![2.0; internal.len()]
         }
     }
 
@@ -398,8 +359,8 @@ mod tests {
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
         // Create a prior with bounds [0, 2] for each parameter
-        let components = [LnPrior1D::uniform(0.0, 2.0), LnPrior1D::uniform(0.0, 2.0)];
-        let prior: LnPrior<2> = LnPrior::ind_components(components);
+        let components = vec![LnPrior1D::uniform(0.0, 2.0), LnPrior1D::uniform(0.0, 2.0)];
+        let prior: LnPrior = LnPrior::ind_components(components);
 
         // Create transformed prior
         let transformed_prior =
@@ -424,7 +385,7 @@ mod tests {
         let mut ts = TimeSeries::new_without_weight(vec![1.0, 2.0, 3.0], vec![1.0, 2.0, 3.0]);
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let transformed_prior =
             prior.with_fit_parameters_transformation::<MockFitParameters>(&norm_data);
         let cloned = transformed_prior.clone();
@@ -441,7 +402,7 @@ mod tests {
         let mut ts = TimeSeries::new_without_weight(vec![1.0, 2.0, 3.0], vec![1.0, 2.0, 3.0]);
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let transformed_prior =
             prior.with_fit_parameters_transformation::<MockFitParameters>(&norm_data);
 
@@ -451,9 +412,9 @@ mod tests {
 
     #[test]
     fn test_ln_prior_serialization() {
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let serialized = serde_json::to_string(&prior).unwrap();
-        let deserialized: LnPrior<2> = serde_json::from_str(&serialized).unwrap();
+        let deserialized: LnPrior = serde_json::from_str(&serialized).unwrap();
 
         let params = [1.0, 2.0];
         assert_eq!(
@@ -464,11 +425,11 @@ mod tests {
 
     #[test]
     fn test_ind_components_serialization() {
-        let components = [LnPrior1D::uniform(0.0, 10.0), LnPrior1D::uniform(-5.0, 5.0)];
-        let prior: LnPrior<2> = LnPrior::ind_components(components);
+        let components = vec![LnPrior1D::uniform(0.0, 10.0), LnPrior1D::uniform(-5.0, 5.0)];
+        let prior: LnPrior = LnPrior::ind_components(components);
 
         let serialized = serde_json::to_string(&prior).unwrap();
-        let deserialized: LnPrior<2> = serde_json::from_str(&serialized).unwrap();
+        let deserialized: LnPrior = serde_json::from_str(&serialized).unwrap();
 
         let params = [5.0, 0.0];
         assert_eq!(
@@ -481,8 +442,8 @@ mod tests {
     fn test_ind_components_gradient() {
         use approx::assert_relative_eq;
 
-        let components = [LnPrior1D::normal(5.0, 2.0), LnPrior1D::normal(10.0, 3.0)];
-        let prior: LnPrior<2> = LnPrior::ind_components(components.clone());
+        let components = vec![LnPrior1D::normal(5.0, 2.0), LnPrior1D::normal(10.0, 3.0)];
+        let prior: LnPrior = LnPrior::ind_components(components.clone());
 
         let params = [6.0, 11.0];
         let mut jac = [0.0; 2];
@@ -506,7 +467,7 @@ mod tests {
 
     #[test]
     fn test_none_ln_prior_gradient() {
-        let prior: LnPrior<3> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let params = [1.0, 2.0, 3.0];
         let mut jac = [0.0; 3];
         let ln_p = prior.ln_prior(&params, Some(&mut jac));
@@ -524,8 +485,8 @@ mod tests {
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
         // Create a prior with normal distribution in external space
-        let components = [LnPrior1D::normal(1.0, 0.5), LnPrior1D::normal(2.0, 0.5)];
-        let prior: LnPrior<2> = LnPrior::ind_components(components);
+        let components = vec![LnPrior1D::normal(1.0, 0.5), LnPrior1D::normal(2.0, 0.5)];
+        let prior: LnPrior = LnPrior::ind_components(components);
 
         // Create transformed prior
         let transformed_prior =


### PR DESCRIPTION
Removes const NPARAMS: usize as a compile-time generic from nl_fit's shared trait hierarchy and all four CurveFitAlgorithm backends (GSL, Ceres, MCMC, NUTS), per your review comment on the RainbowFit PR -- this lands separately, ahead of that PR, so it can be reviewed on its own.

BazinFit/LinexpFit/VillarFit keep their own NPARAMS as a private local constant (they're still genuinely fixed-size); only the shared interface they plug into is now parameter-count-agnostic.

Tried two options :

Plain Vec first. GSL/Ceres's underlying C/C++ libraries already take runtime-sized buffers, so this was mostly mechanical. Found and fixed a real bug along the way: Ceres calls its callback once per data point (unlike GSL, which loops over all points inside a single call), and my first pass allocated a fresh derivative buffer per point instead of once, causing a genuine +22% regression -- root cause, not just measurement noise.
SmallVec<[T; 8]> for the hottest specific path (the per-point internal_to_dimensionless/ dimensionless_to_internal transforms) brought Ceres down to ~5-8% over baseline; Lmsder is flat. Didn't chase it further into a third, separate dynamic/fixed interface -- the remaining gap is small and Ceres-specific.
Verification: all existing tests pass unmodified (real SN Ia fit-recovery tests across every algorithm x prior combination) -- zero correctness regressions. clippy -D warnings and fmt --check clean.

Not verified: MSRV (1.88) build -- that toolchain isn't installed in my environment; smallvec is an extremely common, low-MSRV crate, so I'd be surprised if this is an issue, but worth a real check before this is considered final.