### PR TITLE
Add RainbowFit: multi-band Rainbow model fit (on top of #317)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   counts) and `Rejection` (i.i.d. resampling with bounded rejection of resamples that fail the
   wrapped features' per-band requirements)
   https://github.com/light-curve/light-curve-feature/issues/285
+- Add `RainbowFit` multi-color feature: joint multi-band fit of a bolometric envelope times a
+  temperature-dependent spectral energy distribution ("Rainbow" model, Russeil et al. 2023,
+  https://arxiv.org/abs/2310.02916), with pluggable bolometric/temperature/spectral terms and an
+  optional per-band baseline. Runs through the existing `CurveFitAlgorithm` infrastructure
+  (Ceres/MCMC/NUTS)
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ paste = "1"
 rand = { version = "0.10" }
 schemars = "^0.8"
 serde = { version = "1", features = ["derive"] }
+smallvec = "1"
 special = "0.13"
 take_mut = "0.2.2"
 thiserror = "2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,9 @@ pub enum EvaluatorError {
         "too few valid bootstrap resamples: {actual} obtained, at least {minimum} required to estimate the uncertainty"
     )]
     InsufficientResamples { actual: usize, minimum: usize },
+
+    #[error("non-linear fit did not converge")]
+    FitDidNotConverge,
 }
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]

--- a/src/features/bazin_fit.rs
+++ b/src/features/bazin_fit.rs
@@ -5,6 +5,7 @@ use crate::nl_fit::{
 };
 
 use conv::ConvUtil;
+use smallvec::{SmallVec, smallvec};
 
 const NPARAMS: usize = 5;
 
@@ -113,8 +114,8 @@ lazy_info!(
 );
 
 struct Params<'a, T> {
-    internal: &'a [T; NPARAMS],
-    external: [T; NPARAMS],
+    internal: &'a [T],
+    external: SmallVec<[T; MAX_INLINE_PARAMS]>,
 }
 
 impl<T> Params<'_, T>
@@ -162,12 +163,12 @@ where
     }
 }
 
-impl<T, U> FitModelTrait<T, U, NPARAMS> for BazinFit
+impl<T, U> FitModelTrait<T, U> for BazinFit
 where
     T: Float + Into<U>,
     U: LikeFloat,
 {
-    fn model(t: T, param: &[U; NPARAMS]) -> U
+    fn model(t: T, param: &[U]) -> U
     where
         T: Float + Into<U>,
         U: LikeFloat,
@@ -183,13 +184,13 @@ where
     }
 }
 
-impl<T> FitFunctionTrait<T, NPARAMS> for BazinFit where T: Float {}
+impl<T> FitFunctionTrait<T> for BazinFit where T: Float {}
 
-impl<T> FitDerivalivesTrait<T, NPARAMS> for BazinFit
+impl<T> FitDerivalivesTrait<T> for BazinFit
 where
     T: Float,
 {
-    fn derivatives(t: T, param: &[T; NPARAMS], jac: &mut [T; NPARAMS]) {
+    fn derivatives(t: T, param: &[T], jac: &mut [T]) {
         let x = Params {
             internal: param,
             external: Self::internal_to_dimensionless(param),
@@ -212,11 +213,11 @@ where
     }
 }
 
-impl<T> FitInitsBoundsTrait<T, NPARAMS> for BazinFit
+impl<T> FitInitsBoundsTrait<T> for BazinFit
 where
     T: Float,
 {
-    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         match &self.inits_bounds {
             BazinInitsBounds::Default => BazinInitsBounds::default_from_ts(ts),
             BazinInitsBounds::Arrays(arrays) => arrays.as_ref().clone(),
@@ -227,12 +228,9 @@ where
     }
 }
 
-impl FitParametersOriginalDimLessTrait<NPARAMS> for BazinFit {
-    fn orig_to_dimensionless(
-        norm_data: &NormalizedData<f64>,
-        orig: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
-        [
+impl FitParametersOriginalDimLessTrait for BazinFit {
+    fn orig_to_dimensionless(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
+        vec![
             norm_data.m_to_norm_scale(orig[0]), // A amplitude
             norm_data.m_to_norm(orig[1]),       // c baseline
             norm_data.t_to_norm(orig[2]),       // t_0 reference_time
@@ -241,11 +239,8 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for BazinFit {
         ]
     }
 
-    fn dimensionless_to_orig(
-        norm_data: &NormalizedData<f64>,
-        norm: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
-        [
+    fn dimensionless_to_orig(norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
+        vec![
             norm_data.m_to_orig_scale(norm[0]), // A amplitude
             norm_data.m_to_orig(norm[1]),       // c baseline
             norm_data.t_to_orig(norm[2]),       // t_0 reference_time
@@ -255,16 +250,16 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for BazinFit {
     }
 }
 
-impl<U> FitParametersInternalDimlessTrait<U, NPARAMS> for BazinFit
+impl<U> FitParametersInternalDimlessTrait<U> for BazinFit
 where
     U: LikeFloat,
 {
-    fn dimensionless_to_internal(params: &[U; NPARAMS]) -> [U; NPARAMS] {
-        *params
+    fn dimensionless_to_internal(params: &[U]) -> SmallVec<[U; MAX_INLINE_PARAMS]> {
+        SmallVec::from_slice(params)
     }
 
-    fn internal_to_dimensionless(params: &[U; NPARAMS]) -> [U; NPARAMS] {
-        [
+    fn internal_to_dimensionless(params: &[U]) -> SmallVec<[U; MAX_INLINE_PARAMS]> {
+        smallvec![
             params[0].abs(),
             params[1],
             params[2],
@@ -274,11 +269,11 @@ where
     }
 }
 
-impl FitParametersInternalExternalTrait<NPARAMS> for BazinFit {
+impl FitParametersInternalExternalTrait for BazinFit {
     fn jacobian_internal_to_external(
         norm_data: &NormalizedData<f64>,
-        internal: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
+        internal: &[f64],
+    ) -> Vec<f64> {
         // The full transformation is: external = dimensionless_to_orig(internal_to_dimensionless(internal))
         // internal_to_dimensionless applies abs() to params[0], [3], [4]
         // dimensionless_to_orig scales by m_std (params 0,1) and t_std (params 2,3,4)
@@ -286,7 +281,7 @@ impl FitParametersInternalExternalTrait<NPARAMS> for BazinFit {
         // ∂|x|/∂x = sign(x), so the Jacobian is:
         let m_std = norm_data.m_std();
         let t_std = norm_data.t_std();
-        [
+        vec![
             internal[0].signum() * m_std, // A amplitude: |internal[0]| * m_std
             m_std,                        // B baseline: internal[1] * m_std + m_mean
             t_std,                        // t0: internal[2] * t_std + t_mean
@@ -296,12 +291,12 @@ impl FitParametersInternalExternalTrait<NPARAMS> for BazinFit {
     }
 }
 
-impl FitFeatureEvaluatorGettersTrait<NPARAMS> for BazinFit {
+impl FitFeatureEvaluatorGettersTrait for BazinFit {
     fn get_algorithm(&self) -> &CurveFitAlgorithm {
         &self.algorithm
     }
 
-    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior {
         self.ln_prior.ln_prior_from_ts(ts)
     }
 }
@@ -342,13 +337,13 @@ where
 pub enum BazinInitsBounds {
     #[default]
     Default,
-    Arrays(Box<FitInitsBoundsArrays<NPARAMS>>),
-    OptionArrays(Box<OptionFitInitsBoundsArrays<NPARAMS>>),
+    Arrays(Box<FitInitsBoundsArrays>),
+    OptionArrays(Box<OptionFitInitsBoundsArrays>),
 }
 
 impl BazinInitsBounds {
     pub fn arrays(init: [f64; NPARAMS], lower: [f64; NPARAMS], upper: [f64; NPARAMS]) -> Self {
-        Self::Arrays(FitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::Arrays(FitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into())
     }
 
     pub fn option_arrays(
@@ -356,10 +351,12 @@ impl BazinInitsBounds {
         lower: [Option<f64>; NPARAMS],
         upper: [Option<f64>; NPARAMS],
     ) -> Self {
-        Self::OptionArrays(OptionFitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::OptionArrays(
+            OptionFitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into(),
+        )
     }
 
-    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         let t_min: f64 = ts.t.get_min().value_into().unwrap();
         let t_max: f64 = ts.t.get_max().value_into().unwrap();
         let t_amplitude = t_max - t_min;
@@ -384,9 +381,9 @@ impl BazinInitsBounds {
         let (fall_lower, fall_upper) = (0.0, 10.0 * t_amplitude);
 
         FitInitsBoundsArrays {
-            init: [a_init, c_init, t0_init, rise_init, fall_init].into(),
-            lower: [a_lower, c_lower, t0_lower, rise_lower, fall_lower].into(),
-            upper: [a_upper, c_upper, t0_upper, rise_upper, fall_upper].into(),
+            init: vec![a_init, c_init, t0_init, rise_init, fall_init],
+            lower: vec![a_lower, c_lower, t0_lower, rise_lower, fall_lower],
+            upper: vec![a_upper, c_upper, t0_upper, rise_upper, fall_upper],
         }
     }
 }
@@ -394,23 +391,23 @@ impl BazinInitsBounds {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum BazinLnPrior {
-    Fixed(Box<LnPrior<NPARAMS>>),
+    Fixed(Box<LnPrior>),
 }
 
 impl BazinLnPrior {
-    pub fn fixed(ln_prior: LnPrior<NPARAMS>) -> Self {
+    pub fn fixed(ln_prior: LnPrior) -> Self {
         Self::Fixed(ln_prior.into())
     }
 
-    pub fn ln_prior_from_ts<T: Float>(&self, _ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    pub fn ln_prior_from_ts<T: Float>(&self, _ts: &mut TimeSeries<T>) -> LnPrior {
         match self {
             Self::Fixed(ln_prior) => ln_prior.as_ref().clone(),
         }
     }
 }
 
-impl From<LnPrior<NPARAMS>> for BazinLnPrior {
-    fn from(item: LnPrior<NPARAMS>) -> Self {
+impl From<LnPrior> for BazinLnPrior {
+    fn from(item: LnPrior) -> Self {
         Self::fixed(item)
     }
 }
@@ -515,7 +512,7 @@ mod tests {
     //     let lmsder = CeresCurveFit::new();
     //     let mcmc = McmcCurveFit::new(512, Some(lmsder.into()));
     //     bazin_fit_noisy(BazinFit::new(
-    //         CeresCurveFit::new().into(),
+    //         mcmc.into(),
     //         LnPrior::none(),
     //         BazinInitsBounds::option_arrays(
     //             [None; 5],
@@ -614,8 +611,7 @@ mod tests {
                 let result = bazin.eval(&mut ts).unwrap();
 
                 let t_model = Array1::linspace(t[0] - 1.0, t[t.len() - 1] + 1.0, 100);
-                let flux_model =
-                    t_model.mapv(|x| BazinFit::model(x, &result[..NPARAMS].try_into().unwrap()));
+                let flux_model = t_model.mapv(|x| BazinFit::model(x, &result[..NPARAMS]));
                 flux_model.mapv(|y| -2.5 * f64::log10(y / f0))
             })
             .collect();

--- a/src/features/bazin_fit.rs
+++ b/src/features/bazin_fit.rs
@@ -229,8 +229,11 @@ where
 }
 
 impl FitParametersOriginalDimLessTrait for BazinFit {
-    fn orig_to_dimensionless(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
-        vec![
+    fn orig_to_dimensionless(
+        norm_data: &NormalizedData<f64>,
+        orig: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
+        smallvec![
             norm_data.m_to_norm_scale(orig[0]), // A amplitude
             norm_data.m_to_norm(orig[1]),       // c baseline
             norm_data.t_to_norm(orig[2]),       // t_0 reference_time
@@ -239,8 +242,11 @@ impl FitParametersOriginalDimLessTrait for BazinFit {
         ]
     }
 
-    fn dimensionless_to_orig(norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
-        vec![
+    fn dimensionless_to_orig(
+        norm_data: &NormalizedData<f64>,
+        norm: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
+        smallvec![
             norm_data.m_to_orig_scale(norm[0]), // A amplitude
             norm_data.m_to_orig(norm[1]),       // c baseline
             norm_data.t_to_orig(norm[2]),       // t_0 reference_time
@@ -273,7 +279,7 @@ impl FitParametersInternalExternalTrait for BazinFit {
     fn jacobian_internal_to_external(
         norm_data: &NormalizedData<f64>,
         internal: &[f64],
-    ) -> Vec<f64> {
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
         // The full transformation is: external = dimensionless_to_orig(internal_to_dimensionless(internal))
         // internal_to_dimensionless applies abs() to params[0], [3], [4]
         // dimensionless_to_orig scales by m_std (params 0,1) and t_std (params 2,3,4)
@@ -281,7 +287,7 @@ impl FitParametersInternalExternalTrait for BazinFit {
         // ∂|x|/∂x = sign(x), so the Jacobian is:
         let m_std = norm_data.m_std();
         let t_std = norm_data.t_std();
-        vec![
+        smallvec![
             internal[0].signum() * m_std, // A amplitude: |internal[0]| * m_std
             m_std,                        // B baseline: internal[1] * m_std + m_mean
             t_std,                        // t0: internal[2] * t_std + t_mean

--- a/src/features/linexp_fit.rs
+++ b/src/features/linexp_fit.rs
@@ -212,8 +212,11 @@ where
 }
 
 impl FitParametersOriginalDimLessTrait for LinexpFit {
-    fn orig_to_dimensionless(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
-        vec![
+    fn orig_to_dimensionless(
+        norm_data: &NormalizedData<f64>,
+        orig: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
+        smallvec![
             norm_data.m_to_norm_scale(orig[0]), // A amplitude
             norm_data.t_to_norm(orig[1]),       // t_0 reference_time
             norm_data.t_to_norm_scale(orig[2]), // tau fall time
@@ -221,8 +224,11 @@ impl FitParametersOriginalDimLessTrait for LinexpFit {
         ]
     }
 
-    fn dimensionless_to_orig(norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
-        vec![
+    fn dimensionless_to_orig(
+        norm_data: &NormalizedData<f64>,
+        norm: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
+        smallvec![
             norm_data.m_to_orig_scale(norm[0]), // A amplitude
             norm_data.t_to_orig(norm[1]),       // t_0 reference_time
             norm_data.t_to_orig_scale(norm[2]), // tau fall time
@@ -248,7 +254,7 @@ impl FitParametersInternalExternalTrait for LinexpFit {
     fn jacobian_internal_to_external(
         norm_data: &NormalizedData<f64>,
         internal: &[f64],
-    ) -> Vec<f64> {
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
         // The full transformation is: external = dimensionless_to_orig(internal_to_dimensionless(internal))
         // internal_to_dimensionless applies abs() to params[0], [2]
         // dimensionless_to_orig scales by m_std (params 0,3) and t_std (params 1,2)
@@ -256,7 +262,7 @@ impl FitParametersInternalExternalTrait for LinexpFit {
         // ∂|x|/∂x = sign(x), so the Jacobian is:
         let m_std = norm_data.m_std();
         let t_std = norm_data.t_std();
-        vec![
+        smallvec![
             internal[0].signum() * m_std, // A amplitude: |internal[0]| * m_std
             t_std,                        // t0: internal[1] * t_std + t_mean
             internal[2].signum() * t_std, // tau: |internal[2]| * t_std

--- a/src/features/linexp_fit.rs
+++ b/src/features/linexp_fit.rs
@@ -5,6 +5,7 @@ use crate::nl_fit::{
 };
 
 use conv::ConvUtil;
+use smallvec::{SmallVec, smallvec};
 
 const NPARAMS: usize = 4;
 
@@ -111,8 +112,8 @@ lazy_info!(
 );
 
 struct Params<'a, T> {
-    internal: &'a [T; NPARAMS],
-    external: [T; NPARAMS],
+    internal: &'a [T],
+    external: SmallVec<[T; MAX_INLINE_PARAMS]>,
 }
 
 impl<T> Params<'_, T>
@@ -150,12 +151,12 @@ where
     }
 }
 
-impl<T, U> FitModelTrait<T, U, NPARAMS> for LinexpFit
+impl<T, U> FitModelTrait<T, U> for LinexpFit
 where
     T: Float + Into<U>,
     U: LikeFloat,
 {
-    fn model(t: T, param: &[U; NPARAMS]) -> U
+    fn model(t: T, param: &[U]) -> U
     where
         T: Float + Into<U>,
         U: LikeFloat,
@@ -170,13 +171,13 @@ where
     }
 }
 
-impl<T> FitFunctionTrait<T, NPARAMS> for LinexpFit where T: Float {}
+impl<T> FitFunctionTrait<T> for LinexpFit where T: Float {}
 
-impl<T> FitDerivalivesTrait<T, NPARAMS> for LinexpFit
+impl<T> FitDerivalivesTrait<T> for LinexpFit
 where
     T: Float,
 {
-    fn derivatives(t: T, param: &[T; NPARAMS], jac: &mut [T; NPARAMS]) {
+    fn derivatives(t: T, param: &[T], jac: &mut [T]) {
         let x = Params {
             internal: param,
             external: Self::internal_to_dimensionless(param),
@@ -195,11 +196,11 @@ where
     }
 }
 
-impl<T> FitInitsBoundsTrait<T, NPARAMS> for LinexpFit
+impl<T> FitInitsBoundsTrait<T> for LinexpFit
 where
     T: Float,
 {
-    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         match &self.inits_bounds {
             LinexpInitsBounds::Default => LinexpInitsBounds::default_from_ts(ts),
             LinexpInitsBounds::Arrays(arrays) => arrays.as_ref().clone(),
@@ -210,12 +211,9 @@ where
     }
 }
 
-impl FitParametersOriginalDimLessTrait<NPARAMS> for LinexpFit {
-    fn orig_to_dimensionless(
-        norm_data: &NormalizedData<f64>,
-        orig: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
-        [
+impl FitParametersOriginalDimLessTrait for LinexpFit {
+    fn orig_to_dimensionless(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
+        vec![
             norm_data.m_to_norm_scale(orig[0]), // A amplitude
             norm_data.t_to_norm(orig[1]),       // t_0 reference_time
             norm_data.t_to_norm_scale(orig[2]), // tau fall time
@@ -223,11 +221,8 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for LinexpFit {
         ]
     }
 
-    fn dimensionless_to_orig(
-        norm_data: &NormalizedData<f64>,
-        norm: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
-        [
+    fn dimensionless_to_orig(norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
+        vec![
             norm_data.m_to_orig_scale(norm[0]), // A amplitude
             norm_data.t_to_orig(norm[1]),       // t_0 reference_time
             norm_data.t_to_orig_scale(norm[2]), // tau fall time
@@ -236,24 +231,24 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for LinexpFit {
     }
 }
 
-impl<U> FitParametersInternalDimlessTrait<U, NPARAMS> for LinexpFit
+impl<U> FitParametersInternalDimlessTrait<U> for LinexpFit
 where
     U: LikeFloat,
 {
-    fn dimensionless_to_internal(params: &[U; NPARAMS]) -> [U; NPARAMS] {
-        *params
+    fn dimensionless_to_internal(params: &[U]) -> SmallVec<[U; MAX_INLINE_PARAMS]> {
+        SmallVec::from_slice(params)
     }
 
-    fn internal_to_dimensionless(params: &[U; NPARAMS]) -> [U; NPARAMS] {
-        [params[0].abs(), params[1], params[2].abs(), params[3]]
+    fn internal_to_dimensionless(params: &[U]) -> SmallVec<[U; MAX_INLINE_PARAMS]> {
+        smallvec![params[0].abs(), params[1], params[2].abs(), params[3]]
     }
 }
 
-impl FitParametersInternalExternalTrait<NPARAMS> for LinexpFit {
+impl FitParametersInternalExternalTrait for LinexpFit {
     fn jacobian_internal_to_external(
         norm_data: &NormalizedData<f64>,
-        internal: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
+        internal: &[f64],
+    ) -> Vec<f64> {
         // The full transformation is: external = dimensionless_to_orig(internal_to_dimensionless(internal))
         // internal_to_dimensionless applies abs() to params[0], [2]
         // dimensionless_to_orig scales by m_std (params 0,3) and t_std (params 1,2)
@@ -261,7 +256,7 @@ impl FitParametersInternalExternalTrait<NPARAMS> for LinexpFit {
         // ∂|x|/∂x = sign(x), so the Jacobian is:
         let m_std = norm_data.m_std();
         let t_std = norm_data.t_std();
-        [
+        vec![
             internal[0].signum() * m_std, // A amplitude: |internal[0]| * m_std
             t_std,                        // t0: internal[1] * t_std + t_mean
             internal[2].signum() * t_std, // tau: |internal[2]| * t_std
@@ -270,12 +265,12 @@ impl FitParametersInternalExternalTrait<NPARAMS> for LinexpFit {
     }
 }
 
-impl FitFeatureEvaluatorGettersTrait<NPARAMS> for LinexpFit {
+impl FitFeatureEvaluatorGettersTrait for LinexpFit {
     fn get_algorithm(&self) -> &CurveFitAlgorithm {
         &self.algorithm
     }
 
-    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior {
         self.ln_prior.ln_prior_from_ts(ts)
     }
 }
@@ -314,13 +309,13 @@ where
 pub enum LinexpInitsBounds {
     #[default]
     Default,
-    Arrays(Box<FitInitsBoundsArrays<NPARAMS>>),
-    OptionArrays(Box<OptionFitInitsBoundsArrays<NPARAMS>>),
+    Arrays(Box<FitInitsBoundsArrays>),
+    OptionArrays(Box<OptionFitInitsBoundsArrays>),
 }
 
 impl LinexpInitsBounds {
     pub fn arrays(init: [f64; NPARAMS], lower: [f64; NPARAMS], upper: [f64; NPARAMS]) -> Self {
-        Self::Arrays(FitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::Arrays(FitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into())
     }
 
     pub fn option_arrays(
@@ -328,10 +323,12 @@ impl LinexpInitsBounds {
         lower: [Option<f64>; NPARAMS],
         upper: [Option<f64>; NPARAMS],
     ) -> Self {
-        Self::OptionArrays(OptionFitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::OptionArrays(
+            OptionFitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into(),
+        )
     }
 
-    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         let t_min: f64 = ts.t.get_min().value_into().unwrap();
         let t_max: f64 = ts.t.get_max().value_into().unwrap();
         let t_amplitude = t_max - t_min;
@@ -358,9 +355,9 @@ impl LinexpInitsBounds {
         let (b_lower, b_upper) = (m_min - 100.0 * m_amplitude, m_max + 100.0 * m_amplitude);
 
         FitInitsBoundsArrays {
-            init: [a_init, t0_init, tau_init, b_init].into(),
-            lower: [a_lower, t0_lower, tau_lower, b_lower].into(),
-            upper: [a_upper, t0_upper, tau_upper, b_upper].into(),
+            init: vec![a_init, t0_init, tau_init, b_init],
+            lower: vec![a_lower, t0_lower, tau_lower, b_lower],
+            upper: vec![a_upper, t0_upper, tau_upper, b_upper],
         }
     }
 }
@@ -368,23 +365,23 @@ impl LinexpInitsBounds {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[non_exhaustive]
 pub enum LinexpLnPrior {
-    Fixed(Box<LnPrior<NPARAMS>>),
+    Fixed(Box<LnPrior>),
 }
 
 impl LinexpLnPrior {
-    pub fn fixed(ln_prior: LnPrior<NPARAMS>) -> Self {
+    pub fn fixed(ln_prior: LnPrior) -> Self {
         Self::Fixed(ln_prior.into())
     }
 
-    pub fn ln_prior_from_ts<T: Float>(&self, _ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    pub fn ln_prior_from_ts<T: Float>(&self, _ts: &mut TimeSeries<T>) -> LnPrior {
         match self {
             Self::Fixed(ln_prior) => ln_prior.as_ref().clone(),
         }
     }
 }
 
-impl From<LnPrior<NPARAMS>> for LinexpLnPrior {
-    fn from(item: LnPrior<NPARAMS>) -> Self {
+impl From<LnPrior> for LinexpLnPrior {
+    fn from(item: LnPrior) -> Self {
         Self::fixed(item)
     }
 }

--- a/src/features/villar_fit.rs
+++ b/src/features/villar_fit.rs
@@ -6,6 +6,7 @@ use crate::nl_fit::{
 
 use conv::ConvUtil;
 use ordered_float::NotNan;
+use smallvec::{SmallVec, smallvec};
 
 const NPARAMS: usize = 7;
 
@@ -131,12 +132,12 @@ lazy_info!(
     variability_required: true,
 );
 
-impl<T, U> FitModelTrait<T, U, NPARAMS> for VillarFit
+impl<T, U> FitModelTrait<T, U> for VillarFit
 where
     T: Float + Into<U>,
     U: LikeFloat,
 {
-    fn model(t: T, param: &[U; NPARAMS]) -> U {
+    fn model(t: T, param: &[U]) -> U {
         let t: U = t.into();
         let x = Params {
             internal: param,
@@ -146,13 +147,13 @@ where
     }
 }
 
-impl<T> FitFunctionTrait<T, NPARAMS> for VillarFit where T: Float {}
+impl<T> FitFunctionTrait<T> for VillarFit where T: Float {}
 
-impl<T> FitDerivalivesTrait<T, NPARAMS> for VillarFit
+impl<T> FitDerivalivesTrait<T> for VillarFit
 where
     T: Float,
 {
-    fn derivatives(t: T, param: &[T; NPARAMS], jac: &mut [T; NPARAMS]) {
+    fn derivatives(t: T, param: &[T], jac: &mut [T]) {
         let x = Params {
             internal: param,
             external: Self::internal_to_dimensionless(param),
@@ -206,11 +207,11 @@ where
     }
 }
 
-impl<T> FitInitsBoundsTrait<T, NPARAMS> for VillarFit
+impl<T> FitInitsBoundsTrait<T> for VillarFit
 where
     T: Float,
 {
-    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         match &self.inits_bounds {
             VillarInitsBounds::Default => VillarInitsBounds::default_from_ts(ts),
             VillarInitsBounds::Arrays(arrays) => arrays.as_ref().clone(),
@@ -221,12 +222,9 @@ where
     }
 }
 
-impl FitParametersOriginalDimLessTrait<NPARAMS> for VillarFit {
-    fn orig_to_dimensionless(
-        norm_data: &NormalizedData<f64>,
-        orig: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
-        [
+impl FitParametersOriginalDimLessTrait for VillarFit {
+    fn orig_to_dimensionless(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
+        vec![
             norm_data.m_to_norm_scale(orig[0]), // A amplitude
             norm_data.m_to_norm(orig[1]),       // c baseline
             norm_data.t_to_norm(orig[2]),       // t_0 reference time
@@ -237,11 +235,8 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for VillarFit {
         ]
     }
 
-    fn dimensionless_to_orig(
-        norm_data: &NormalizedData<f64>,
-        norm: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
-        [
+    fn dimensionless_to_orig(norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
+        vec![
             norm_data.m_to_orig_scale(norm[0]), // A amplitude
             norm_data.m_to_orig(norm[1]),       // c baseline
             norm_data.t_to_orig(norm[2]),       // t_0 reference time
@@ -253,12 +248,12 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for VillarFit {
     }
 }
 
-impl<U> FitParametersInternalDimlessTrait<U, NPARAMS> for VillarFit
+impl<U> FitParametersInternalDimlessTrait<U> for VillarFit
 where
     U: LikeFloat,
 {
-    fn dimensionless_to_internal(params: &[U; NPARAMS]) -> [U; NPARAMS] {
-        [
+    fn dimensionless_to_internal(params: &[U]) -> SmallVec<[U; MAX_INLINE_PARAMS]> {
+        smallvec![
             params[0],
             params[1],
             params[2],
@@ -269,8 +264,8 @@ where
         ]
     }
 
-    fn internal_to_dimensionless(params: &[U; NPARAMS]) -> [U; NPARAMS] {
-        [
+    fn internal_to_dimensionless(params: &[U]) -> SmallVec<[U; MAX_INLINE_PARAMS]> {
+        smallvec![
             params[0].abs(),
             params[1],
             params[2],
@@ -282,11 +277,11 @@ where
     }
 }
 
-impl FitParametersInternalExternalTrait<NPARAMS> for VillarFit {
+impl FitParametersInternalExternalTrait for VillarFit {
     fn jacobian_internal_to_external(
         norm_data: &NormalizedData<f64>,
-        internal: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
+        internal: &[f64],
+    ) -> Vec<f64> {
         // The full transformation is: external = dimensionless_to_orig(internal_to_dimensionless(internal))
         //
         // internal_to_dimensionless:
@@ -305,7 +300,7 @@ impl FitParametersInternalExternalTrait<NPARAMS> for VillarFit {
         let nu = Self::b_to_nu(internal[5]);
         let d_nu_d_b = (1.0 - nu.powi(2)) * internal[5].signum();
 
-        [
+        vec![
             internal[0].signum() * m_std, // A amplitude: |internal[0]| * m_std
             m_std,                        // c baseline: internal[1] * m_std + m_mean
             t_std,                        // t0: internal[2] * t_std + t_mean
@@ -317,12 +312,12 @@ impl FitParametersInternalExternalTrait<NPARAMS> for VillarFit {
     }
 }
 
-impl FitFeatureEvaluatorGettersTrait<NPARAMS> for VillarFit {
+impl FitFeatureEvaluatorGettersTrait for VillarFit {
     fn get_algorithm(&self) -> &CurveFitAlgorithm {
         &self.algorithm
     }
 
-    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior {
         self.ln_prior.ln_prior_from_ts(ts)
     }
 }
@@ -363,8 +358,8 @@ where
 }
 
 struct Params<'a, T> {
-    internal: &'a [T; NPARAMS],
-    external: [T; NPARAMS],
+    internal: &'a [T],
+    external: SmallVec<[T; MAX_INLINE_PARAMS]>,
 }
 
 impl<T> Params<'_, T>
@@ -472,13 +467,13 @@ where
 pub enum VillarInitsBounds {
     #[default]
     Default,
-    Arrays(Box<FitInitsBoundsArrays<NPARAMS>>),
-    OptionArrays(Box<OptionFitInitsBoundsArrays<NPARAMS>>),
+    Arrays(Box<FitInitsBoundsArrays>),
+    OptionArrays(Box<OptionFitInitsBoundsArrays>),
 }
 
 impl VillarInitsBounds {
     pub fn arrays(init: [f64; NPARAMS], lower: [f64; NPARAMS], upper: [f64; NPARAMS]) -> Self {
-        Self::Arrays(FitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::Arrays(FitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into())
     }
 
     pub fn option_arrays(
@@ -486,10 +481,12 @@ impl VillarInitsBounds {
         lower: [Option<f64>; NPARAMS],
         upper: [Option<f64>; NPARAMS],
     ) -> Self {
-        Self::OptionArrays(OptionFitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::OptionArrays(
+            OptionFitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into(),
+        )
     }
 
-    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         let t_min: f64 = ts.t.get_min().value_into().unwrap();
         let t_max: f64 = ts.t.get_max().value_into().unwrap();
         let t_amplitude = t_max - t_min;
@@ -521,7 +518,7 @@ impl VillarInitsBounds {
         let (gamma_lower, gamma_upper) = (0.0, 10.0 * t_amplitude);
 
         FitInitsBoundsArrays {
-            init: [
+            init: vec![
                 a_init,
                 c_init,
                 t0_init,
@@ -529,9 +526,8 @@ impl VillarInitsBounds {
                 tau_fall_init,
                 nu_init,
                 gamma_init,
-            ]
-            .into(),
-            lower: [
+            ],
+            lower: vec![
                 a_lower,
                 c_lower,
                 t0_lower,
@@ -539,9 +535,8 @@ impl VillarInitsBounds {
                 tau_fall_lower,
                 nu_lower,
                 gamma_lower,
-            ]
-            .into(),
-            upper: [
+            ],
+            upper: vec![
                 a_upper,
                 c_upper,
                 t0_upper,
@@ -549,8 +544,7 @@ impl VillarInitsBounds {
                 tau_fall_upper,
                 nu_upper,
                 gamma_upper,
-            ]
-            .into(),
+            ],
         }
     }
 }
@@ -559,7 +553,7 @@ impl VillarInitsBounds {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[non_exhaustive]
 pub enum VillarLnPrior {
-    Fixed(Box<LnPrior<NPARAMS>>),
+    Fixed(Box<LnPrior>),
     /// Adopted from Hosseinzadeh, et al. 2020, table 2
     ///
     /// `time_units_in_day` specifies the units of time you use in yout `TimeSeries` object, it
@@ -572,7 +566,7 @@ pub enum VillarLnPrior {
 }
 
 impl VillarLnPrior {
-    pub fn fixed(ln_prior: LnPrior<NPARAMS>) -> Self {
+    pub fn fixed(ln_prior: LnPrior) -> Self {
         Self::Fixed(ln_prior.into())
     }
 
@@ -584,7 +578,7 @@ impl VillarLnPrior {
         }
     }
 
-    pub fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    pub fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior {
         match self {
             Self::Fixed(ln_prior) => ln_prior.as_ref().clone(),
             Self::Hosseinzadeh2020 {
@@ -598,7 +592,7 @@ impl VillarLnPrior {
                 let day = day.into_inner();
                 let min_amplitude = min_amplitude.into_inner();
 
-                LnPrior::ind_components([
+                LnPrior::ind_components(vec![
                     LnPrior1D::log_uniform(min_amplitude, 100.0 * m_amplitude), // amplitude
                     LnPrior1D::none(), // offset, not used in the original paper
                     LnPrior1D::uniform(t_peak - 50.0 * day, t_peak + 300.0 * day), // reference time
@@ -615,8 +609,8 @@ impl VillarLnPrior {
     }
 }
 
-impl From<LnPrior<NPARAMS>> for VillarLnPrior {
-    fn from(item: LnPrior<NPARAMS>) -> Self {
+impl From<LnPrior> for VillarLnPrior {
+    fn from(item: LnPrior) -> Self {
         Self::fixed(item)
     }
 }

--- a/src/features/villar_fit.rs
+++ b/src/features/villar_fit.rs
@@ -223,8 +223,11 @@ where
 }
 
 impl FitParametersOriginalDimLessTrait for VillarFit {
-    fn orig_to_dimensionless(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
-        vec![
+    fn orig_to_dimensionless(
+        norm_data: &NormalizedData<f64>,
+        orig: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
+        smallvec![
             norm_data.m_to_norm_scale(orig[0]), // A amplitude
             norm_data.m_to_norm(orig[1]),       // c baseline
             norm_data.t_to_norm(orig[2]),       // t_0 reference time
@@ -235,8 +238,11 @@ impl FitParametersOriginalDimLessTrait for VillarFit {
         ]
     }
 
-    fn dimensionless_to_orig(norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
-        vec![
+    fn dimensionless_to_orig(
+        norm_data: &NormalizedData<f64>,
+        norm: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
+        smallvec![
             norm_data.m_to_orig_scale(norm[0]), // A amplitude
             norm_data.m_to_orig(norm[1]),       // c baseline
             norm_data.t_to_orig(norm[2]),       // t_0 reference time
@@ -281,7 +287,7 @@ impl FitParametersInternalExternalTrait for VillarFit {
     fn jacobian_internal_to_external(
         norm_data: &NormalizedData<f64>,
         internal: &[f64],
-    ) -> Vec<f64> {
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
         // The full transformation is: external = dimensionless_to_orig(internal_to_dimensionless(internal))
         //
         // internal_to_dimensionless:
@@ -300,7 +306,7 @@ impl FitParametersInternalExternalTrait for VillarFit {
         let nu = Self::b_to_nu(internal[5]);
         let d_nu_d_b = (1.0 - nu.powi(2)) * internal[5].signum();
 
-        vec![
+        smallvec![
             internal[0].signum() * m_std, // A amplitude: |internal[0]| * m_std
             m_std,                        // c baseline: internal[1] * m_std + m_mean
             t_std,                        // t0: internal[2] * t_std + t_mean

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -132,9 +132,9 @@ macro_rules! fit_eval {
 
             let (x0, lower, upper) = {
                 let FitInitsBoundsArrays {
-                    init: FitArray(mut x0),
-                    lower: FitArray(mut lower),
-                    upper: FitArray(mut upper),
+                    init: mut x0,
+                    lower: mut lower,
+                    upper: mut upper,
                 } = self.init_and_bounds_from_ts(ts);
                 x0 = Self::convert_to_internal(&norm_data, &x0);
                 lower = Self::convert_to_internal(&norm_data, &lower);
@@ -154,8 +154,7 @@ macro_rules! fit_eval {
                     self.ln_prior_from_ts(ts)
                         .with_fit_parameters_transformation::<Self>(&norm_data),
                 );
-                let result =
-                    Self::convert_to_external(&norm_data, (&x as &[_]).try_into().unwrap());
+                let result = Self::convert_to_external(&norm_data, &x);
                 result
                     .into_iter()
                     .chain(std::iter::once(reduced_chi2))

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -131,14 +131,10 @@ macro_rules! fit_eval {
             let norm_data = NormalizedData::<f64>::from_ts(ts);
 
             let (x0, lower, upper) = {
-                let FitInitsBoundsArrays {
-                    init: mut x0,
-                    lower: mut lower,
-                    upper: mut upper,
-                } = self.init_and_bounds_from_ts(ts);
-                x0 = Self::convert_to_internal(&norm_data, &x0);
-                lower = Self::convert_to_internal(&norm_data, &lower);
-                upper = Self::convert_to_internal(&norm_data, &upper);
+                let FitInitsBoundsArrays { init, lower, upper } = self.init_and_bounds_from_ts(ts);
+                let x0 = Self::convert_to_internal(&norm_data, &init);
+                let lower = Self::convert_to_internal(&norm_data, &lower);
+                let upper = Self::convert_to_internal(&norm_data, &upper);
                 (x0, lower, upper)
             };
 

--- a/src/multicolor/mod.rs
+++ b/src/multicolor/mod.rs
@@ -20,3 +20,6 @@ pub use multicolor_feature::MultiColorFeature;
 
 mod passband;
 pub use passband::*;
+
+mod rainbow;
+pub use rainbow::{Bolometric, RainbowFit, RainbowFitError, Spectral, Temperature};

--- a/src/multicolor/multicolor_feature.rs
+++ b/src/multicolor/multicolor_feature.rs
@@ -6,7 +6,9 @@ use crate::multicolor::features::{
     ColorOfMaximum, ColorOfMedian, ColorOfMinimum, ColorSpread, MultiColorPeriodogram,
 };
 use crate::multicolor::multicolor_evaluator::*;
-use crate::multicolor::{MultiColorBins, MultiColorBootstrap, MultiColorExtractor, PerBandFeature};
+use crate::multicolor::{
+    MultiColorBins, MultiColorBootstrap, MultiColorExtractor, PerBandFeature, RainbowFit,
+};
 
 use enum_dispatch::enum_dispatch;
 use schemars::JsonSchema;
@@ -34,6 +36,7 @@ where
     MultiColorPeriodogram(MultiColorPeriodogram<P, T, Feature<T>>),
     MultiColorBins(MultiColorBins<P, T>),
     MultiColorBootstrap(MultiColorBootstrap<P, T>),
+    RainbowFit(RainbowFit<P, T>),
 }
 
 impl<P, T> MultiColorFeature<P, T>

--- a/src/multicolor/rainbow/constants.rs
+++ b/src/multicolor/rainbow/constants.rs
@@ -1,0 +1,10 @@
+//! CGS physical constants (CODATA 2018) used by [super::terms::spectral]'s blackbody-family SEDs.
+
+/// Planck constant, erg*s
+pub const PLANCK_H: f64 = 6.62607004e-27;
+/// Speed of light, cm/s
+pub const SPEED_OF_LIGHT: f64 = 2.99792458e10;
+/// Boltzmann constant, erg/K
+pub const BOLTZMANN_K: f64 = 1.380649e-16;
+/// Stefan-Boltzmann constant, erg/(cm^2 s K^4)
+pub const SIGMA_SB: f64 = 5.6703744191844314e-05;

--- a/src/multicolor/rainbow/fit.rs
+++ b/src/multicolor/rainbow/fit.rs
@@ -1,0 +1,212 @@
+//! Drives [`RainbowModel`] through this crate's shared [`CurveFitAlgorithm`] (Ceres/MCMC/NUTS),
+//! the same optimizer infrastructure every other `*Fit` feature uses.
+//!
+//! # Band tagging
+//!
+//! Every [`CurveFitAlgorithm`] backend calls its model/derivatives closures with a bare scalar
+//! `t` per data point -- there's no side channel for "which band is this point from". Rather than
+//! extend [`Data`]/[`CurveFitTrait`] with a new per-point-tag channel across all four backends
+//! (GSL FFI, Ceres FFI, MCMC, NUTS), band index is folded into `t` itself before the point ever
+//! reaches the optimizer: each band gets a disjoint offset range,
+//! `t_encoded = (t - t_min) + band_idx * stride` with `stride` chosen wider than the full time
+//! span, so `band_idx = floor(t_encoded / stride)` and the real `t` recover exactly. This is the
+//! same trick used for "global" / simultaneous multi-dataset fits in `lmfit`/`scipy` tutorials
+//! (concatenate independent variables into non-overlapping ranges); it's entirely local to this
+//! function and touches none of `nl_fit`'s shared types.
+//!
+//! `t` is fixed input data to every backend (never perturbed by the optimizer), so the encoding
+//! is stable across iterations.
+//!
+//! # Bounds and physical units
+//!
+//! Unlike [`crate::nl_fit::fit_eval!`]-based features, this skips [`NormalizedData`]: Rainbow's
+//! model already works in raw physical units (matching the Python reference), and box bounds are
+//! passed straight through in those units to whichever algorithm was chosen -- Ceres/MCMC/NUTS
+//! all honor them (Ceres via native box constraints, MCMC/NUTS by rejecting proposals outside
+//! `bounds`). See [`super::algorithm_supports_bounds`] for why Lmsder isn't offered here: it
+//! ignores the `bounds` argument entirely, and Rainbow has no equivalent of `BazinFit`'s
+//! `abs()`-based unconstrained conditioning to fall back on.
+//!
+//! [`NormalizedData`]: crate::nl_fit::data::NormalizedData
+
+use std::rc::Rc;
+
+use ndarray::Array1;
+
+use crate::nl_fit::{CurveFitAlgorithm, CurveFitResult, CurveFitTrait, LnPrior, data::Data};
+
+use super::model::RainbowModel;
+
+/// Result of fitting [`RainbowModel`] to a light curve.
+pub(crate) struct FitResult {
+    /// Fitted physical parameters, in [`RainbowModel::param_names`] order.
+    pub(crate) params: Vec<f64>,
+    pub(crate) reduced_chi2: f64,
+    pub(crate) success: bool,
+}
+
+/// Encodes `(t, band_idx)` into a single `f64` `t_encoded` such that `decode(encode(t, b)) ==
+/// (t, b)` exactly, by giving each band a disjoint offset range. See the module docs.
+#[derive(Clone, Copy)]
+struct BandTimeCode {
+    t_min: f64,
+    stride: f64,
+}
+
+impl BandTimeCode {
+    fn new(t: &[f64]) -> Self {
+        let t_min = t.iter().copied().fold(f64::INFINITY, f64::min);
+        let t_max = t.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        let span = (t_max - t_min).max(1e-6);
+        // Generous margin: encoded offsets never approach the stride boundary, so floor() below
+        // is robust to floating-point rounding.
+        let stride = 4.0 * span + 1.0;
+        Self { t_min, stride }
+    }
+
+    fn encode(&self, t: f64, band_idx: usize) -> f64 {
+        (t - self.t_min) + band_idx as f64 * self.stride
+    }
+
+    fn decode(&self, t_encoded: f64) -> (f64, usize) {
+        let band_idx = (t_encoded / self.stride).floor();
+        let t = t_encoded - band_idx * self.stride + self.t_min;
+        (t, band_idx as usize)
+    }
+}
+
+/// Jointly fits all bands' `(t, flux, flux_err, band_idx)` to `model` using `algorithm`.
+///
+/// Too few points to constrain the model returns `success: false` with NaN outputs rather than
+/// panicking -- sparse real light curves are a normal data-quality issue, not a bug.
+pub(crate) fn fit(
+    model: &RainbowModel,
+    algorithm: &CurveFitAlgorithm,
+    t: &[f64],
+    flux: &[f64],
+    flux_err: &[f64],
+    band_idx: &[usize],
+) -> FitResult {
+    assert_eq!(t.len(), flux.len());
+    assert_eq!(t.len(), flux_err.len());
+    assert_eq!(t.len(), band_idx.len());
+
+    let n_params = model.n_params();
+    if t.len() <= n_params {
+        return FitResult {
+            params: vec![f64::NAN; n_params],
+            reduced_chi2: f64::NAN,
+            success: false,
+        };
+    }
+
+    let bounds = model.bounds(t, flux, flux_err, band_idx);
+    let (lower, upper): (Vec<f64>, Vec<f64>) = bounds.into_iter().unzip();
+    let guess = model.initial_guess(t, flux, flux_err, band_idx);
+
+    let code = BandTimeCode::new(t);
+    let t_encoded: Vec<f64> = t
+        .iter()
+        .zip(band_idx)
+        .map(|(&ti, &b)| code.encode(ti, b))
+        .collect();
+    let inv_err: Vec<f64> = flux_err.iter().map(|e| e.recip()).collect();
+
+    let data = Rc::new(Data {
+        t: Array1::from(t_encoded),
+        m: Array1::from(flux.to_vec()),
+        inv_err: Array1::from(inv_err),
+    });
+
+    let model_fn = {
+        let model = model.clone();
+        move |t_encoded: f64, params: &[f64]| -> f64 {
+            let (t, b) = code.decode(t_encoded);
+            model.model(t, b, params)
+        }
+    };
+    let derivatives_fn = {
+        let model = model.clone();
+        move |t_encoded: f64, params: &[f64], jac: &mut [f64]| {
+            let (t, b) = code.decode(t_encoded);
+            let (_, grad) = model.model_and_gradient(t, b, params);
+            jac.copy_from_slice(&grad);
+        }
+    };
+
+    let CurveFitResult {
+        x: params,
+        reduced_chi2,
+        success,
+    } = algorithm.curve_fit(
+        data,
+        &guess,
+        (&lower, &upper),
+        model_fn,
+        derivatives_fn,
+        LnPrior::none(),
+    );
+
+    FitResult {
+        params,
+        reduced_chi2,
+        success,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::model::Band;
+    use super::super::terms::{Bolometric, Spectral, Temperature};
+    use super::*;
+    use crate::nl_fit::McmcCurveFit;
+
+    #[test]
+    fn band_time_code_roundtrips() {
+        let t = [0.0, 12.5, 37.0, -5.0, 100.0];
+        let code = BandTimeCode::new(&t);
+        for &ti in &t {
+            for b in 0..5usize {
+                let encoded = code.encode(ti, b);
+                let (decoded_t, decoded_b) = code.decode(encoded);
+                assert!((decoded_t - ti).abs() < 1e-9, "t: {ti} -> {decoded_t}");
+                assert_eq!(decoded_b, b);
+            }
+        }
+    }
+
+    #[test]
+    fn too_few_points_returns_failure_instead_of_panicking() {
+        let bands = vec![
+            Band {
+                name: "g".to_string(),
+                wavelength_cm: 4770.0e-8,
+            },
+            Band {
+                name: "r".to_string(),
+                wavelength_cm: 6231.0e-8,
+            },
+            Band {
+                name: "i".to_string(),
+                wavelength_cm: 7625.0e-8,
+            },
+        ];
+        let model = RainbowModel::new(
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            bands,
+            false,
+        );
+
+        let t = vec![0.0, 1.0, 2.0];
+        let flux = vec![1.0, 2.0, 1.5];
+        let flux_err = vec![0.1, 0.1, 0.1];
+        let band_idx = vec![0, 1, 2];
+        let algorithm: CurveFitAlgorithm = McmcCurveFit::new(64, None).into();
+        let result = fit(&model, &algorithm, &t, &flux, &flux_err, &band_idx);
+        assert!(!result.success);
+        assert!(result.params.iter().all(|p| p.is_nan()));
+        assert!(result.reduced_chi2.is_nan());
+    }
+}

--- a/src/multicolor/rainbow/fit.rs
+++ b/src/multicolor/rainbow/fit.rs
@@ -1,31 +1,30 @@
-//! Drives [`RainbowModel`] through this crate's shared [`CurveFitAlgorithm`] (Ceres/MCMC/NUTS),
-//! the same optimizer infrastructure every other `*Fit` feature uses.
+//! Drives [`RainbowModel`] through this crate's shared [`CurveFitAlgorithm`] (Ceres/MCMC/NUTS).
 //!
-//! # Band tagging
+//! **Band tagging**: every backend's model/derivatives closures take a single scalar `t` per
+//! point, with no channel for "which band". Band index is folded into `t` before it reaches the
+//! optimizer -- each band gets a disjoint offset range, `t_encoded = (t - t_min) + band_idx *
+//! stride`, decoded inside the closures. Standard technique for simultaneous multi-dataset fits
+//! (concatenate independent variables into non-overlapping ranges); entirely local to this
+//! function, doesn't touch `nl_fit`'s shared types.
 //!
-//! Every [`CurveFitAlgorithm`] backend calls its model/derivatives closures with a bare scalar
-//! `t` per data point -- there's no side channel for "which band is this point from". Rather than
-//! extend [`Data`]/[`CurveFitTrait`] with a new per-point-tag channel across all four backends
-//! (GSL FFI, Ceres FFI, MCMC, NUTS), band index is folded into `t` itself before the point ever
-//! reaches the optimizer: each band gets a disjoint offset range,
-//! `t_encoded = (t - t_min) + band_idx * stride` with `stride` chosen wider than the full time
-//! span, so `band_idx = floor(t_encoded / stride)` and the real `t` recover exactly. This is the
-//! same trick used for "global" / simultaneous multi-dataset fits in `lmfit`/`scipy` tutorials
-//! (concatenate independent variables into non-overlapping ranges); it's entirely local to this
-//! function and touches none of `nl_fit`'s shared types.
+//! **Bounds**: `ceres-solver` 0.5.1 silently ignores upper bounds (`CurveFitProblem1DBuilder`
+//! wires up `lower_bounds` but has a literal `// TODO: upper bounds`; confirmed with an isolated
+//! repro outside this crate). So bounds are enforced by reparametrization rather than delegated
+//! to the backend: each parameter is mapped through a logistic transform from an unconstrained
+//! `u` into its `(lower, upper)` interval before the model ever sees it, and the optimizer is
+//! handed effectively unconstrained bounds (`+-inf`). Holds regardless of which backend's bound
+//! support is broken or missing (Lmsder's is nonexistent, see
+//! [`algorithm_supports_bounds`](super::algorithm_supports_bounds)).
 //!
-//! `t` is fixed input data to every backend (never perturbed by the optimizer), so the encoding
-//! is stable across iterations.
+//! **Iterations**: `CeresCurveFit::default_niterations()` (10) is tuned for simpler single-band
+//! features; Rainbow's larger multi-band parameter space needs more (checked against 90 real
+//! light curves vs. the Python reference: ~28% converged close at 10 iterations, ~91% at 200) --
+//! see the Python bindings' Rainbow-specific Ceres default. Even at 200, a handful of light
+//! curves converge to a real but suboptimal local minimum (same failure under Ceres and MCMC
+//! alike, so not a backend quirk) -- a known, accepted gap for now.
 //!
-//! # Bounds and physical units
-//!
-//! Unlike [`crate::nl_fit::fit_eval!`]-based features, this skips [`NormalizedData`]: Rainbow's
-//! model already works in raw physical units (matching the Python reference), and box bounds are
-//! passed straight through in those units to whichever algorithm was chosen -- Ceres/MCMC/NUTS
-//! all honor them (Ceres via native box constraints, MCMC/NUTS by rejecting proposals outside
-//! `bounds`). See [`super::algorithm_supports_bounds`] for why Lmsder isn't offered here: it
-//! ignores the `bounds` argument entirely, and Rainbow has no equivalent of `BazinFit`'s
-//! `abs()`-based unconstrained conditioning to fall back on.
+//! Skips [`NormalizedData`] (unlike [`crate::nl_fit::fit_eval!`] features): the model already
+//! works in physical units, matching the Python reference's public API.
 //!
 //! [`NormalizedData`]: crate::nl_fit::data::NormalizedData
 
@@ -45,8 +44,8 @@ pub(crate) struct FitResult {
     pub(crate) success: bool,
 }
 
-/// Encodes `(t, band_idx)` into a single `f64` `t_encoded` such that `decode(encode(t, b)) ==
-/// (t, b)` exactly, by giving each band a disjoint offset range. See the module docs.
+/// Encodes `(t, band_idx)` into one `f64` such that `decode(encode(t, b)) == (t, b)` exactly, by
+/// giving each band a disjoint offset range. See the module docs.
 #[derive(Clone, Copy)]
 struct BandTimeCode {
     t_min: f64,
@@ -58,8 +57,8 @@ impl BandTimeCode {
         let t_min = t.iter().copied().fold(f64::INFINITY, f64::min);
         let t_max = t.iter().copied().fold(f64::NEG_INFINITY, f64::max);
         let span = (t_max - t_min).max(1e-6);
-        // Generous margin: encoded offsets never approach the stride boundary, so floor() below
-        // is robust to floating-point rounding.
+        // Margin wide enough that encoded offsets never approach the stride boundary, so
+        // floor() below is robust to floating-point rounding.
         let stride = 4.0 * span + 1.0;
         Self { t_min, stride }
     }
@@ -73,6 +72,41 @@ impl BandTimeCode {
         let t = t_encoded - band_idx * self.stride + self.t_min;
         (t, band_idx as usize)
     }
+}
+
+/// `(external, d(external)/du)` for unconstrained `u`, logistically mapped into `(lower,
+/// upper)`. See the module docs' "Bounds" section.
+fn bounded_transform(u: f64, lower: f64, upper: f64) -> (f64, f64) {
+    let s = 1.0 / (1.0 + (-u).exp());
+    let external = lower + (upper - lower) * s;
+    let dext_du = (upper - lower) * s * (1.0 - s);
+    (external, dext_du)
+}
+
+/// Inverse of [`bounded_transform`] (the logit function), for converting a physical-unit initial
+/// guess into `u`-space. Clamped away from the exact bounds to avoid `+-inf`.
+fn inverse_bounded_transform(external: f64, lower: f64, upper: f64) -> f64 {
+    let frac = ((external - lower) / (upper - lower)).clamp(1e-9, 1.0 - 1e-9);
+    (frac / (1.0 - frac)).ln()
+}
+
+fn internal_to_external(u: &[f64], bounds: &[(f64, f64)]) -> (Vec<f64>, Vec<f64>) {
+    let mut external = Vec::with_capacity(bounds.len());
+    let mut dext_du = Vec::with_capacity(bounds.len());
+    for (&uk, &(lower, upper)) in u.iter().zip(bounds) {
+        let (e, d) = bounded_transform(uk, lower, upper);
+        external.push(e);
+        dext_du.push(d);
+    }
+    (external, dext_du)
+}
+
+fn external_to_internal(external: &[f64], bounds: &[(f64, f64)]) -> Vec<f64> {
+    external
+        .iter()
+        .zip(bounds)
+        .map(|(&e, &(lower, upper))| inverse_bounded_transform(e, lower, upper))
+        .collect()
 }
 
 /// Jointly fits all bands' `(t, flux, flux_err, band_idx)` to `model` using `algorithm`.
@@ -101,8 +135,8 @@ pub(crate) fn fit(
     }
 
     let bounds = model.bounds(t, flux, flux_err, band_idx);
-    let (lower, upper): (Vec<f64>, Vec<f64>) = bounds.into_iter().unzip();
     let guess = model.initial_guess(t, flux, flux_err, band_idx);
+    let u0 = external_to_internal(&guess, &bounds);
 
     let code = BandTimeCode::new(t);
     let t_encoded: Vec<f64> = t
@@ -120,32 +154,45 @@ pub(crate) fn fit(
 
     let model_fn = {
         let model = model.clone();
-        move |t_encoded: f64, params: &[f64]| -> f64 {
+        let bounds = bounds.clone();
+        move |t_encoded: f64, u: &[f64]| -> f64 {
             let (t, b) = code.decode(t_encoded);
-            model.model(t, b, params)
+            let (external, _) = internal_to_external(u, &bounds);
+            model.model(t, b, &external)
         }
     };
     let derivatives_fn = {
         let model = model.clone();
-        move |t_encoded: f64, params: &[f64], jac: &mut [f64]| {
+        let bounds = bounds.clone();
+        move |t_encoded: f64, u: &[f64], jac: &mut [f64]| {
             let (t, b) = code.decode(t_encoded);
-            let (_, grad) = model.model_and_gradient(t, b, params);
-            jac.copy_from_slice(&grad);
+            let (external, dext_du) = internal_to_external(u, &bounds);
+            let (_, grad) = model.model_and_gradient(t, b, &external);
+            for k in 0..jac.len() {
+                jac[k] = grad[k] * dext_du[k];
+            }
         }
     };
 
+    // `u` is unconstrained; bounds are enforced by the logistic transform above, not by the
+    // backend's own (partly broken) bound support. See the module docs.
+    let unconstrained_lower = vec![f64::NEG_INFINITY; n_params];
+    let unconstrained_upper = vec![f64::INFINITY; n_params];
+
     let CurveFitResult {
-        x: params,
+        x: u_fit,
         reduced_chi2,
         success,
     } = algorithm.curve_fit(
         data,
-        &guess,
-        (&lower, &upper),
+        &u0,
+        (&unconstrained_lower, &unconstrained_upper),
         model_fn,
         derivatives_fn,
         LnPrior::none(),
     );
+
+    let (params, _) = internal_to_external(&u_fit, &bounds);
 
     FitResult {
         params,
@@ -172,6 +219,88 @@ mod tests {
                 assert!((decoded_t - ti).abs() < 1e-9, "t: {ti} -> {decoded_t}");
                 assert_eq!(decoded_b, b);
             }
+        }
+    }
+
+    #[test]
+    fn bounded_transform_roundtrips_and_stays_within_bounds() {
+        let (lower, upper) = (-0.99, 0.99);
+        for u in [-10.0, -1.0, 0.0, 1.0, 10.0] {
+            let (external, _) = bounded_transform(u, lower, upper);
+            assert!(external > lower && external < upper);
+            let back = inverse_bounded_transform(external, lower, upper);
+            assert!(
+                (back - u).abs() < 1e-6,
+                "u={u}, external={external}, back={back}"
+            );
+        }
+    }
+
+    #[test]
+    fn full_chain_jacobian_matches_finite_difference() {
+        // Reproduces fit()'s model_fn/derivatives_fn closures (u -> external -> model) against
+        // wide, asymmetric bounds like real Rainbow bounds actually are.
+        let bands = vec![
+            Band {
+                name: "g".to_string(),
+                wavelength_cm: 4770.0e-8,
+            },
+            Band {
+                name: "r".to_string(),
+                wavelength_cm: 6231.0e-8,
+            },
+        ];
+        let model = RainbowModel::new(
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::ModifiedBlackBody,
+            bands,
+            false,
+        );
+
+        let t = [
+            61033.0, 61035.0, 61040.0, 61041.0, 61050.0, 61052.0, 61060.0, 61070.0, 61071.0,
+            61098.0,
+        ];
+        let flux = [
+            900.0, 950.0, 3000.0, 3100.0, 16000.0, 15500.0, 8000.0, 6200.0, 6100.0, 5800.0,
+        ];
+        let flux_err = [50.0; 10];
+        let band_idx = [0, 1, 0, 1, 0, 1, 0, 0, 1, 1];
+
+        let bounds = model.bounds(&t, &flux, &flux_err, &band_idx);
+        let guess = model.initial_guess(&t, &flux, &flux_err, &band_idx);
+        let u0 = external_to_internal(&guess, &bounds);
+
+        let code = BandTimeCode::new(&t);
+        let t_encoded = code.encode(t[4], band_idx[4]);
+
+        let model_fn = |u: &[f64]| -> f64 {
+            let (external, _) = internal_to_external(u, &bounds);
+            let (t, b) = code.decode(t_encoded);
+            model.model(t, b, &external)
+        };
+        let derivatives_fn = |u: &[f64]| -> Vec<f64> {
+            let (external, dext_du) = internal_to_external(u, &bounds);
+            let (t, b) = code.decode(t_encoded);
+            let (_, grad) = model.model_and_gradient(t, b, &external);
+            (0..grad.len()).map(|k| grad[k] * dext_du[k]).collect()
+        };
+
+        let analytic = derivatives_fn(&u0);
+        for k in 0..u0.len() {
+            let h = 1e-5 * u0[k].abs().max(1.0);
+            let mut plus = u0.clone();
+            let mut minus = u0.clone();
+            plus[k] += h;
+            minus[k] -= h;
+            let numeric = (model_fn(&plus) - model_fn(&minus)) / (2.0 * h);
+            assert!(
+                (analytic[k] - numeric).abs() <= 1e-3 * numeric.abs().max(1.0),
+                "param {k}: analytic={}, numeric={}",
+                analytic[k],
+                numeric
+            );
         }
     }
 

--- a/src/multicolor/rainbow/mod.rs
+++ b/src/multicolor/rainbow/mod.rs
@@ -1,0 +1,603 @@
+//! Multi-band non-linear fit of a bolometric envelope times a temperature-dependent spectral
+//! energy distribution (SED) -- the "Rainbow" model (Russeil et al. 2023,
+//! [arXiv:2310.02916](https://arxiv.org/abs/2310.02916)):
+//! $$
+//! \mathrm{flux}(t, \lambda) = \mathrm{bol}(t) \cdot \frac{B(\lambda, T(t))}{\mathrm{norm}(T(t))} \ [+ \ \mathrm{baseline}_\mathrm{band}].
+//! $$
+//! `bol(t)`, `T(t)`, and `B(lambda, T)` are independently pluggable ([`terms::Bolometric`],
+//! [`terms::Temperature`], [`terms::Spectral`] -- see [`RainbowFit::new`]). `norm(T)` is always
+//! the Planck-based normalization, so overall flux scale is carried by the bolometric term's
+//! `amplitude`.
+//!
+//! The fit itself ([`fit`]) runs through this crate's regular [`CurveFitAlgorithm`] (Ceres/MCMC/
+//! NUTS), the same infrastructure every other `*Fit` feature uses -- see [`fit`]'s module docs
+//! for how a runtime-varying, per-band parameter set is threaded through an interface built
+//! around a single scalar `t` per point.
+//!
+//! # Wavelengths are explicit constructor data, not a passband capability
+//!
+//! [`RainbowFit::new`] takes `(passband, wavelength_cm)` pairs directly rather than deriving
+//! wavelength from the passband type: [`PassbandTrait`] stays exactly as it is for every other
+//! feature, and a missing/wrong wavelength is a plain, immediate constructor argument error
+//! instead of a capability scattered across the trait.
+//!
+//! # Not yet ported from the Python reference
+//!
+//! - `bolometric = "linexp"`: Python's own docstring flags its guesses/limits as unstable
+//!   (confirmed here by a seed sweep -- about half land in a wrong local optimum).
+//! - `spectral = "blanketed"`: anchors to the temperature term's own `T` via Python's
+//!   `common_temp_spec` cross-term sharing, more involved than the other terms.
+//! - Gaussian priors anchoring some parameters (e.g. `T_amplitude`, `beta`) toward 0, and
+//!   non-detection/upper-limit support (Python's Tobit-model likelihood).
+
+mod constants;
+mod fit;
+mod model;
+pub mod terms;
+
+use std::collections::BTreeMap;
+use std::marker::PhantomData;
+
+use conv::ConvUtil;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::data::MultiColorTimeSeries;
+use crate::error::{EvaluatorError, MultiColorEvaluatorError};
+use crate::evaluator::{
+    EvaluatorInfo, EvaluatorInfoTrait, EvaluatorProperties, FeatureNamesDescriptionsTrait,
+};
+use crate::float_trait::Float;
+use crate::multicolor::multicolor_evaluator::{
+    MultiColorEvaluator, MultiColorPassbandSetTrait, PassbandSet,
+};
+use crate::multicolor::passband::PassbandTrait;
+use crate::nl_fit::{CurveFitAlgorithm, McmcCurveFit};
+
+use model::{Band, RainbowModel};
+pub use terms::{Bolometric, Spectral, Temperature};
+
+/// Error constructing a [`RainbowFit`].
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum RainbowFitError {
+    #[error("RainbowFit requires at least one (passband, wavelength) pair")]
+    NoPassbands,
+
+    #[error("wavelength_cm must be a positive, finite number, got {0:?} for passband {1:?}")]
+    InvalidWavelength(f64, String),
+
+    #[error(
+        "algorithm {0:?} does not support box bounds, which RainbowFit relies on to keep \
+         parameters physical (e.g. positive rise_time); use Ceres, Mcmc, or Nuts instead"
+    )]
+    UnsupportedAlgorithm(CurveFitAlgorithm),
+}
+
+/// Returns `false` for an algorithm that ignores the `bounds` argument passed to
+/// [`CurveFitTrait::curve_fit`](crate::nl_fit::CurveFitTrait::curve_fit) (currently just Lmsder),
+/// recursing into `Mcmc`/`Nuts`'s optional `fine_tuning_algorithm`, since that sub-algorithm gets
+/// the same bounds and is just as capable of silently ignoring them.
+fn algorithm_supports_bounds(algorithm: &CurveFitAlgorithm) -> bool {
+    match algorithm {
+        #[cfg(any(feature = "ceres-source", feature = "ceres-system"))]
+        CurveFitAlgorithm::Ceres(_) => true,
+        #[cfg(feature = "gsl")]
+        CurveFitAlgorithm::Lmsder(_) => false,
+        CurveFitAlgorithm::Mcmc(a) => a
+            .fine_tuning_algorithm
+            .as_deref()
+            .is_none_or(algorithm_supports_bounds),
+        CurveFitAlgorithm::Nuts(a) => a
+            .fine_tuning_algorithm
+            .as_deref()
+            .is_none_or(algorithm_supports_bounds),
+    }
+}
+
+/// Multi-band fit of the Rainbow model (see the [module-level documentation](self) for the
+/// model and design notes).
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(
+    into = "RainbowFitParameters<P, T>",
+    try_from = "RainbowFitParameters<P, T>",
+    bound(
+        serialize = "P: PassbandTrait + Serialize, T: Float",
+        deserialize = "P: PassbandTrait + Deserialize<'de>, T: Float"
+    )
+)]
+pub struct RainbowFit<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    bolometric: Bolometric,
+    temperature: Temperature,
+    spectral: Spectral,
+    with_baseline: bool,
+    algorithm: CurveFitAlgorithm,
+    passband_set: PassbandSet<P>,
+    /// Band indices match `passband_set`'s sorted order (relied on by
+    /// `eval_multicolor_no_mcts_check`).
+    model: RainbowModel,
+    properties: Box<EvaluatorProperties>,
+    _marker: PhantomData<T>,
+}
+
+impl<P, T> std::fmt::Debug for RainbowFit<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RainbowFit")
+            .field("bolometric", &self.bolometric)
+            .field("temperature", &self.temperature)
+            .field("spectral", &self.spectral)
+            .field("with_baseline", &self.with_baseline)
+            .field("algorithm", &self.algorithm)
+            .field("passband_set", &self.passband_set)
+            .finish()
+    }
+}
+
+impl<P, T> RainbowFit<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    /// Constructs a `RainbowFit` for the given `(passband, wavelength_cm)` pairs and term
+    /// choices.
+    ///
+    /// # Errors
+    /// [`RainbowFitError::NoPassbands`] if `bands` is empty,
+    /// [`RainbowFitError::InvalidWavelength`] if any wavelength isn't a positive finite number,
+    /// or [`RainbowFitError::UnsupportedAlgorithm`] if `algorithm` doesn't honor box bounds (see
+    /// [`algorithm_supports_bounds`]).
+    pub fn new(
+        bands: impl IntoIterator<Item = (P, f64)>,
+        bolometric: Bolometric,
+        temperature: Temperature,
+        spectral: Spectral,
+        with_baseline: bool,
+        algorithm: CurveFitAlgorithm,
+    ) -> Result<Self, RainbowFitError> {
+        if !algorithm_supports_bounds(&algorithm) {
+            return Err(RainbowFitError::UnsupportedAlgorithm(algorithm));
+        }
+
+        let passband_wavelengths: BTreeMap<P, f64> = bands.into_iter().collect();
+        if passband_wavelengths.is_empty() {
+            return Err(RainbowFitError::NoPassbands);
+        }
+        for (p, &wavelength_cm) in &passband_wavelengths {
+            if !(wavelength_cm.is_finite() && wavelength_cm > 0.0) {
+                return Err(RainbowFitError::InvalidWavelength(
+                    wavelength_cm,
+                    p.name().into(),
+                ));
+            }
+        }
+
+        // `passband_wavelengths` and `passband_set` share the same BTreeMap/BTreeSet ordering
+        // over `P`, so `bands` below lines up with `passband_set`'s iteration order.
+        let bands: Vec<Band> = passband_wavelengths
+            .iter()
+            .map(|(p, &wavelength_cm)| Band {
+                name: p.name().into(),
+                wavelength_cm,
+            })
+            .collect();
+        let passband_set = PassbandSet(passband_wavelengths.into_keys().collect());
+
+        let model = RainbowModel::new(bolometric, temperature, spectral, bands, with_baseline);
+        let properties = Box::new(Self::build_properties(&model));
+
+        Ok(Self {
+            bolometric,
+            temperature,
+            spectral,
+            with_baseline,
+            algorithm,
+            passband_set,
+            model,
+            properties,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Default [`CurveFitAlgorithm`] for [`RainbowFit`]: [`McmcCurveFit`], available without any
+    /// optional Cargo feature. Ceres/NUTS are usually a better choice when available; Lmsder
+    /// isn't offered at all (see [`algorithm_supports_bounds`]).
+    #[inline]
+    pub fn default_algorithm() -> CurveFitAlgorithm {
+        McmcCurveFit::default().into()
+    }
+
+    /// Output layout: fitted parameters, then the reduced chi2 -- `n_params + 1` values in
+    /// total, matching `light_curve_py.RainbowFit.__call__`'s own convention.
+    fn build_properties(model: &RainbowModel) -> EvaluatorProperties {
+        let param_names = model.param_names();
+        let mut names = Vec::with_capacity(param_names.len() + 1);
+        let mut descriptions = Vec::with_capacity(param_names.len() + 1);
+
+        for name in param_names {
+            names.push(format!("rainbow_{name}"));
+            descriptions.push(format!("Rainbow fit parameter: {name}"));
+        }
+        names.push("rainbow_reduced_chi2".to_owned());
+        descriptions.push("Reduced chi^2 of the Rainbow fit".to_owned());
+
+        EvaluatorProperties {
+            info: EvaluatorInfo {
+                size: names.len(),
+                // Per-band minimums aren't meaningful for a joint multi-band fit; the real
+                // total-vs-parameter-count check happens inside `fit::fit`.
+                min_ts_length: 1,
+                t_required: true,
+                m_required: true,
+                w_required: true,
+                sorting_required: false,
+                // A light curve flat in every band isn't rejected today; it just produces a
+                // poorly-constrained fit (known gap, see module docs).
+                variability_required: false,
+            },
+            names,
+            descriptions,
+        }
+    }
+
+    /// Analytic bolometric peak time, if defined for the chosen [`Bolometric`] term. `params`
+    /// must be just the fitted parameters (the first `n_params` values of this feature's
+    /// output, not the trailing `reduced_chi2`).
+    pub fn peak_time(&self, params: &[T]) -> Option<T> {
+        let params_f64: Vec<f64> = params.iter().map(|&x| x.value_into().unwrap()).collect();
+        self.model.peak_time(&params_f64).map(|t| {
+            t.approx_as::<T>().unwrap_or_else(|_| {
+                if t.is_sign_negative() {
+                    T::min_value()
+                } else {
+                    T::max_value()
+                }
+            })
+        })
+    }
+}
+
+impl<P, T> EvaluatorInfoTrait for RainbowFit<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn get_info(&self) -> &EvaluatorInfo {
+        &self.properties.info
+    }
+}
+
+impl<P, T> FeatureNamesDescriptionsTrait for RainbowFit<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn get_names(&self) -> Vec<&str> {
+        self.properties.names.iter().map(String::as_str).collect()
+    }
+
+    fn get_descriptions(&self) -> Vec<&str> {
+        self.properties
+            .descriptions
+            .iter()
+            .map(String::as_str)
+            .collect()
+    }
+}
+
+impl<P, T> MultiColorPassbandSetTrait<P> for RainbowFit<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn get_passband_set(&self) -> &PassbandSet<P> {
+        &self.passband_set
+    }
+}
+
+impl<P, T> MultiColorEvaluator<P, T> for RainbowFit<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn eval_multicolor_no_mcts_check<'slf, 'a, 'mcts>(
+        &'slf self,
+        mcts: &'mcts mut MultiColorTimeSeries<'a, P, T>,
+    ) -> Result<Vec<T>, MultiColorEvaluatorError>
+    where
+        'slf: 'a,
+        'a: 'mcts,
+    {
+        // Flatten into flat f64 arrays; band order matches `self.model` (built from
+        // `passband_set`'s sorted order in `new`).
+        mcts.with_mapping_mut(|_| {});
+        let mapping = mcts.mapping().expect("mapping was just ensured");
+
+        let mut t = Vec::new();
+        let mut flux = Vec::new();
+        let mut flux_err = Vec::new();
+        let mut band_idx = Vec::new();
+
+        for (band_i, (p, maybe_ts)) in mapping.iter_passband_set(&self.passband_set).enumerate() {
+            let ts = maybe_ts.ok_or_else(|| {
+                MultiColorEvaluatorError::wrong_passbands_error(
+                    mcts.passbands(),
+                    self.passband_set.0.iter(),
+                )
+            })?;
+            let _ = p; // only needed for the error path above
+            for i in 0..ts.lenu() {
+                let ti: f64 = ts.t.sample[i].value_into().unwrap();
+                let mi: f64 = ts.m.sample[i].value_into().unwrap();
+                // `w` is inverse-variance weight (`w = 1/sigma^2`), not sigma directly.
+                let wi: f64 = ts.w.sample[i].value_into().unwrap();
+                t.push(ti);
+                flux.push(mi);
+                flux_err.push(1.0 / wi.sqrt());
+                band_idx.push(band_i);
+            }
+        }
+
+        let result = fit::fit(
+            &self.model,
+            &self.algorithm,
+            &t,
+            &flux,
+            &flux_err,
+            &band_idx,
+        );
+        if !result.success {
+            return Err(EvaluatorError::FitDidNotConverge.into());
+        }
+
+        let to_t = |x: f64| {
+            x.approx_as::<T>().unwrap_or_else(|_| {
+                if x.is_sign_negative() {
+                    T::min_value()
+                } else {
+                    T::max_value()
+                }
+            })
+        };
+        let mut out: Vec<T> = Vec::with_capacity(self.properties.info.size);
+        out.extend(result.params.iter().copied().map(to_t));
+        out.push(to_t(result.reduced_chi2));
+
+        Ok(out)
+    }
+}
+
+/// Serde/JsonSchema surrogate for [`RainbowFit`]: (de)serializes only the user-facing config;
+/// `model`/`properties` are derived state, rebuilt via [`RainbowFit::new`].
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(
+    rename = "RainbowFit",
+    bound(
+        serialize = "P: PassbandTrait + Serialize, T: Float",
+        deserialize = "P: PassbandTrait + Deserialize<'de>, T: Float"
+    )
+)]
+struct RainbowFitParameters<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    bolometric: Bolometric,
+    temperature: Temperature,
+    spectral: Spectral,
+    with_baseline: bool,
+    algorithm: CurveFitAlgorithm,
+    bands: Vec<(P, f64)>,
+    #[serde(skip)]
+    _marker: PhantomData<T>,
+}
+
+impl<P, T> From<RainbowFit<P, T>> for RainbowFitParameters<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    fn from(r: RainbowFit<P, T>) -> Self {
+        let bands = r
+            .passband_set
+            .0
+            .iter()
+            .zip(r.model.bands())
+            .map(|(p, band)| (p.clone(), band.wavelength_cm))
+            .collect();
+        Self {
+            bolometric: r.bolometric,
+            temperature: r.temperature,
+            spectral: r.spectral,
+            with_baseline: r.with_baseline,
+            algorithm: r.algorithm,
+            bands,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<P, T> TryFrom<RainbowFitParameters<P, T>> for RainbowFit<P, T>
+where
+    P: PassbandTrait,
+    T: Float,
+{
+    type Error = RainbowFitError;
+
+    fn try_from(p: RainbowFitParameters<P, T>) -> Result<Self, Self::Error> {
+        Self::new(
+            p.bands,
+            p.bolometric,
+            p.temperature,
+            p.spectral,
+            p.with_baseline,
+            p.algorithm,
+        )
+    }
+}
+
+impl<P, T> JsonSchema for RainbowFit<P, T>
+where
+    P: PassbandTrait + JsonSchema,
+    T: Float,
+{
+    json_schema!(RainbowFitParameters<P, T>, false);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::TimeSeries;
+    use crate::multicolor::MonochromePassband;
+    use crate::nl_fit::McmcCurveFit;
+
+    use std::collections::BTreeMap;
+
+    fn bands() -> Vec<(MonochromePassband<'static, f64>, f64)> {
+        vec![
+            (MonochromePassband::new(4770.0e-8, "g"), 4770.0e-8),
+            (MonochromePassband::new(6231.0e-8, "r"), 6231.0e-8),
+        ]
+    }
+
+    fn make_rainbow() -> RainbowFit<MonochromePassband<'static, f64>, f64> {
+        RainbowFit::new(
+            bands(),
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            false,
+            RainbowFit::<MonochromePassband<'static, f64>, f64>::default_algorithm(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn construction_requires_at_least_one_band() {
+        let err = RainbowFit::<MonochromePassband<'static, f64>, f64>::new(
+            [],
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            false,
+            RainbowFit::<MonochromePassband<'static, f64>, f64>::default_algorithm(),
+        )
+        .unwrap_err();
+        assert_eq!(err, RainbowFitError::NoPassbands);
+    }
+
+    #[test]
+    fn construction_rejects_non_positive_wavelength() {
+        use crate::multicolor::StringPassband;
+        let err = RainbowFit::<StringPassband, f64>::new(
+            [(StringPassband::from("g"), 0.0)],
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            false,
+            RainbowFit::<StringPassband, f64>::default_algorithm(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, RainbowFitError::InvalidWavelength(_, _)));
+    }
+
+    #[cfg(feature = "gsl")]
+    #[test]
+    fn construction_rejects_lmsder() {
+        use crate::nl_fit::LmsderCurveFit;
+        let err = RainbowFit::<MonochromePassband<'static, f64>, f64>::new(
+            bands(),
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            false,
+            LmsderCurveFit::new(9).into(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, RainbowFitError::UnsupportedAlgorithm(_)));
+    }
+
+    #[test]
+    fn names_and_size_match_n_plus_1() {
+        let rainbow = make_rainbow();
+        // reference_time, amplitude, rise_time, fall_time, T, T_amplitude, t_color = 7 params
+        assert_eq!(rainbow.size_hint(), 7 + 1);
+        assert_eq!(rainbow.get_names().len(), rainbow.size_hint());
+        assert!(rainbow.get_names().contains(&"rainbow_reference_time"));
+        assert!(rainbow.get_names().contains(&"rainbow_reduced_chi2"));
+    }
+
+    #[test]
+    fn recovers_known_parameters_from_noisy_multiband_light_curve() {
+        let rainbow = RainbowFit::new(
+            bands(),
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            false,
+            McmcCurveFit::new(4096, None).into(),
+        )
+        .unwrap();
+
+        let truth = [58900.0_f64, 120.0, 5.0, 25.0, 11000.0, 0.2, 8.0];
+        let mut rng_state: u64 = 42;
+        let mut rand01 = move || {
+            // xorshift, deterministic, no extra dev-dependency needed here.
+            rng_state ^= rng_state << 13;
+            rng_state ^= rng_state >> 7;
+            rng_state ^= rng_state << 17;
+            (rng_state >> 11) as f64 / (1u64 << 53) as f64
+        };
+
+        let mut map = BTreeMap::new();
+        for (band, _) in bands() {
+            let n = 60;
+            let mut t: Vec<f64> = (0..n).map(|_| truth[0] - 15.0 + rand01() * 90.0).collect();
+            t.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            let m: Vec<f64> = t
+                .iter()
+                .map(|&ti| {
+                    let flux =
+                        rainbow
+                            .model
+                            .model(ti, if band.name == "g" { 0 } else { 1 }, &truth);
+                    let err = (flux.abs() * 0.02).max(0.05);
+                    // Box-Muller for approximately Gaussian noise from two uniforms.
+                    let u1 = rand01().max(1e-12);
+                    let u2 = rand01();
+                    let noise =
+                        err * (-2.0 * u1.ln()).sqrt() * (2.0 * std::f64::consts::PI * u2).cos();
+                    flux + noise
+                })
+                .collect();
+            let w: Vec<f64> = t
+                .iter()
+                .map(|&ti| {
+                    1.0 / (rainbow.model.model(ti, 0, &truth).abs() * 0.02)
+                        .max(0.05)
+                        .powi(2)
+                })
+                .collect();
+            map.insert(band, TimeSeries::new(t, m, w));
+        }
+
+        let mut mcts = MultiColorTimeSeries::from_map(map);
+        let result = rainbow.eval_multicolor(&mut mcts).unwrap();
+
+        assert_eq!(result.len(), rainbow.size_hint());
+        let reduced_chi2 = result[7];
+        assert!(reduced_chi2 < 3.0, "reduced chi2 too high: {reduced_chi2}");
+
+        let rel_err =
+            |actual: f64, expected: f64| (actual - expected).abs() / expected.abs().max(1.0);
+        assert!(rel_err(result[0], truth[0]) < 0.02); // reference_time
+        assert!(rel_err(result[1], truth[1]) < 0.15); // amplitude
+        assert!(rel_err(result[4], truth[4]) < 0.2); // T
+    }
+}

--- a/src/multicolor/rainbow/model.rs
+++ b/src/multicolor/rainbow/model.rs
@@ -1,0 +1,525 @@
+//! Composition of a chosen bolometric + temperature + spectral term (plus an optional per-band
+//! baseline) into the Rainbow flux model:
+//! $$
+//! \mathrm{flux}(t, \lambda) = \mathrm{bol}(t) \cdot \frac{B(\lambda, T(t))}{\mathrm{norm}(T(t))} \ [+ \ \mathrm{baseline}_\mathrm{band}],
+//! \quad \mathrm{norm}(T) = \frac{\sigma_{SB} T^4}{\pi\,\bar\nu},
+//! $$
+//! where $\bar\nu$ is the mean frequency across the fitted bands. `norm(T)` always uses the
+//! Stefan-Boltzmann/Planck form regardless of which SED term is chosen -- only the SED's
+//! *shape* varies per term. Mirrors Python's `BaseRainbowFit._lsq_model_{no_,with_}baseline`.
+//!
+//! Works entirely in physical `f64` units on a fixed [`Band`] list; has no awareness of the
+//! crate's generic `T: Float`/`P: PassbandTrait` -- [RainbowFit](super::RainbowFit) converts
+//! once at construction and is the only place those generics matter.
+//!
+//! Different term combinations have different (possibly shared, e.g. `reference_time`)
+//! parameter counts, so the parameter vector is a runtime-sized `&[f64]`; [`ParamLayout`] maps
+//! each term's local parameter indices into that shared global vector.
+
+use std::collections::HashMap;
+use std::f64::consts::PI;
+
+use super::constants::{SIGMA_SB, SPEED_OF_LIGHT};
+use super::terms::common::{max_min, median, ptp};
+use super::terms::{Bolometric, MAX_LOCAL_PARAMS, Spectral, Temperature};
+
+/// A photometric band: a name and its effective wavelength in cm.
+#[derive(Debug, Clone)]
+pub(crate) struct Band {
+    pub(crate) name: String,
+    pub(crate) wavelength_cm: f64,
+}
+
+fn baseline_param_name(band_name: &str) -> String {
+    format!("baseline_{band_name}")
+}
+
+/// Maps each term's local parameter indices (and, if `with_baseline`, each band's baseline
+/// parameter) to indices in the model's global (deduplicated-by-name) parameter vector.
+#[derive(Clone)]
+struct ParamLayout {
+    names: Vec<String>,
+    bol_map: Vec<usize>,
+    temp_map: Vec<usize>,
+    spec_map: Vec<usize>,
+    /// `baseline_map[band_idx]` = global parameter index, only populated when `with_baseline`.
+    baseline_map: Vec<usize>,
+}
+
+impl ParamLayout {
+    fn build(
+        bolometric: &Bolometric,
+        temperature: &Temperature,
+        spectral: &Spectral,
+        bands: &[Band],
+        with_baseline: bool,
+    ) -> Self {
+        let mut names: Vec<String> = Vec::new();
+        let mut name_to_idx: HashMap<String, usize> = HashMap::new();
+
+        let intern = |name: String,
+                      names: &mut Vec<String>,
+                      name_to_idx: &mut HashMap<String, usize>|
+         -> usize {
+            if let Some(&idx) = name_to_idx.get(&name) {
+                idx
+            } else {
+                names.push(name.clone());
+                let idx = names.len() - 1;
+                name_to_idx.insert(name, idx);
+                idx
+            }
+        };
+
+        let bol_map: Vec<usize> = bolometric
+            .params()
+            .iter()
+            .map(|&n| intern(n.to_string(), &mut names, &mut name_to_idx))
+            .collect();
+        let temp_map: Vec<usize> = temperature
+            .params()
+            .iter()
+            .map(|&n| intern(n.to_string(), &mut names, &mut name_to_idx))
+            .collect();
+        let spec_map: Vec<usize> = spectral
+            .params()
+            .iter()
+            .map(|&n| intern(n.to_string(), &mut names, &mut name_to_idx))
+            .collect();
+
+        let baseline_map: Vec<usize> = if with_baseline {
+            bands
+                .iter()
+                .map(|b| intern(baseline_param_name(&b.name), &mut names, &mut name_to_idx))
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        Self {
+            names,
+            bol_map,
+            temp_map,
+            spec_map,
+            baseline_map,
+        }
+    }
+}
+
+/// The Rainbow model: a chosen bolometric/temperature/spectral term combination (plus an
+/// optional per-band additive baseline) bound to a fixed set of bands.
+#[derive(Clone)]
+pub(crate) struct RainbowModel {
+    bolometric: Bolometric,
+    temperature: Temperature,
+    spectral: Spectral,
+    with_baseline: bool,
+    bands: Vec<Band>,
+    /// `speed_of_light / mean(wavelength)`, used to normalize the SED so that its scale is
+    /// carried entirely by `amplitude`.
+    average_nu: f64,
+    layout: ParamLayout,
+}
+
+impl RainbowModel {
+    pub(crate) fn new(
+        bolometric: Bolometric,
+        temperature: Temperature,
+        spectral: Spectral,
+        bands: Vec<Band>,
+        with_baseline: bool,
+    ) -> Self {
+        assert!(!bands.is_empty(), "RainbowModel requires at least one band");
+        let mean_wave_cm: f64 =
+            bands.iter().map(|b| b.wavelength_cm).sum::<f64>() / bands.len() as f64;
+        let average_nu = SPEED_OF_LIGHT / mean_wave_cm;
+        let layout =
+            ParamLayout::build(&bolometric, &temperature, &spectral, &bands, with_baseline);
+        Self {
+            bolometric,
+            temperature,
+            spectral,
+            with_baseline,
+            bands,
+            average_nu,
+            layout,
+        }
+    }
+
+    pub(crate) fn n_params(&self) -> usize {
+        self.layout.names.len()
+    }
+
+    pub(crate) fn param_names(&self) -> &[String] {
+        &self.layout.names
+    }
+
+    /// Bands this model was constructed with, in the same order used for `band_idx` everywhere
+    /// else (i.e. `passband_set`'s sorted order -- see [`RainbowFit::new`](super::RainbowFit::new)).
+    pub(crate) fn bands(&self) -> &[Band] {
+        &self.bands
+    }
+
+    /// Evaluate the model flux at time `t` in the given band.
+    pub(crate) fn model(&self, t: f64, band_idx: usize, params: &[f64]) -> f64 {
+        self.model_and_gradient(t, band_idx, params).0
+    }
+
+    /// Evaluate the model flux and its gradient w.r.t. every global parameter (length
+    /// `n_params()`), mirroring `_lsq_jac_{no_,with_}baseline`'s chain rule through
+    /// `bol(t) * SED(wave, T(t)) / norm(T(t)) [+ baseline_band]`.
+    pub(crate) fn model_and_gradient(
+        &self,
+        t: f64,
+        band_idx: usize,
+        params: &[f64],
+    ) -> (f64, Vec<f64>) {
+        let wave_cm = self.bands[band_idx].wavelength_cm;
+
+        let n_bol = self.bolometric.n_params();
+        let n_temp = self.temperature.n_params();
+        let n_spec = self.spectral.n_params();
+
+        let mut bol_local = [0.0; MAX_LOCAL_PARAMS];
+        for i in 0..n_bol {
+            bol_local[i] = params[self.layout.bol_map[i]];
+        }
+        let mut bol_jac = [0.0; MAX_LOCAL_PARAMS];
+        let bol = self
+            .bolometric
+            .value_jac(t, &bol_local[..n_bol], &mut bol_jac[..n_bol]);
+
+        let mut temp_local = [0.0; MAX_LOCAL_PARAMS];
+        for i in 0..n_temp {
+            temp_local[i] = params[self.layout.temp_map[i]];
+        }
+        let mut temp_jac = [0.0; MAX_LOCAL_PARAMS];
+        let temp = self
+            .temperature
+            .value_jac(t, &temp_local[..n_temp], &mut temp_jac[..n_temp]);
+
+        let mut spec_local = [0.0; MAX_LOCAL_PARAMS];
+        for i in 0..n_spec {
+            spec_local[i] = params[self.layout.spec_map[i]];
+        }
+        let mut spec_jac = [0.0; MAX_LOCAL_PARAMS];
+        let (spectral_val, dspectral_dt) = self.spectral.value_jac(
+            wave_cm,
+            temp,
+            &spec_local[..n_spec],
+            &mut spec_jac[..n_spec],
+        );
+
+        // norm(T) is always the Stefan-Boltzmann/Planck-based normalization, regardless of which
+        // spectral term is in use (matches Python: only the SED *shape* varies per term, the
+        // amplitude normalization does not).
+        let norm = SIGMA_SB * temp.powi(4) / PI / self.average_nu;
+        let shape = spectral_val / norm;
+        // d(shape)/dT = d(spectral)/dT / norm - 4*shape/T, since d(norm)/dT = 4*norm/T.
+        let dshape_dt = dspectral_dt / norm - 4.0 * shape / temp;
+
+        let mut flux = bol * shape;
+
+        let mut grad = vec![0.0; self.n_params()];
+        for i in 0..n_bol {
+            grad[self.layout.bol_map[i]] += bol_jac[i] * shape;
+        }
+        for i in 0..n_temp {
+            grad[self.layout.temp_map[i]] += bol * dshape_dt * temp_jac[i];
+        }
+        for i in 0..n_spec {
+            grad[self.layout.spec_map[i]] += bol * spec_jac[i] / norm;
+        }
+
+        if self.with_baseline {
+            let g = self.layout.baseline_map[band_idx];
+            flux += params[g];
+            grad[g] += 1.0;
+        }
+
+        (flux, grad)
+    }
+
+    /// Assembles a per-term `Vec` (`bol`/`temp`/`spec`, each in that term's own `params()`
+    /// order) into the global parameter vector, first writer wins for shared names (e.g.
+    /// `reference_time`: the bolometric term's value is used, the temperature term's is computed
+    /// but discarded).
+    fn assemble<T: Copy + Default>(&self, bol: Vec<T>, temp: Vec<T>, spec: Vec<T>) -> Vec<T> {
+        let mut out = vec![T::default(); self.n_params()];
+        let mut filled = vec![false; self.n_params()];
+        for (i, v) in bol.into_iter().enumerate() {
+            let g = self.layout.bol_map[i];
+            out[g] = v;
+            filled[g] = true;
+        }
+        for (i, v) in temp.into_iter().enumerate() {
+            let g = self.layout.temp_map[i];
+            if !filled[g] {
+                out[g] = v;
+                filled[g] = true;
+            }
+        }
+        for (i, v) in spec.into_iter().enumerate() {
+            let g = self.layout.spec_map[i];
+            out[g] = v;
+        }
+        out
+    }
+
+    /// Per-band median flux, used as the baseline's own initial guess and to baseline-subtract
+    /// the data before computing every other term's initial guess / bounds (mirrors Python's
+    /// `_baseline_initial_guesses` + `m_corr`).
+    fn per_band_baseline_estimate(&self, flux: &[f64], band_idx: &[usize]) -> Vec<f64> {
+        (0..self.bands.len())
+            .map(|b| {
+                let band_flux: Vec<f64> = flux
+                    .iter()
+                    .zip(band_idx)
+                    .filter(|&(_, &bi)| bi == b)
+                    .map(|(&f, _)| f)
+                    .collect();
+                if band_flux.is_empty() {
+                    0.0
+                } else {
+                    median(&band_flux)
+                }
+            })
+            .collect()
+    }
+
+    /// Heuristic initial guess (physical units), same order as [`Self::param_names`].
+    pub(crate) fn initial_guess(
+        &self,
+        t: &[f64],
+        flux: &[f64],
+        flux_err: &[f64],
+        band_idx: &[usize],
+    ) -> Vec<f64> {
+        let (flux_corrected, baseline_guess) = if self.with_baseline {
+            let baseline_guess = self.per_band_baseline_estimate(flux, band_idx);
+            let corrected: Vec<f64> = flux
+                .iter()
+                .zip(band_idx)
+                .map(|(&f, &b)| f - baseline_guess[b])
+                .collect();
+            (corrected, baseline_guess)
+        } else {
+            (flux.to_vec(), Vec::new())
+        };
+
+        let bol_guess = self.bolometric.initial_guess(t, &flux_corrected, flux_err);
+        let temp_guess = self.temperature.initial_guess(t, &flux_corrected, flux_err);
+        let spec_guess = self.spectral.initial_guess();
+
+        // Each term's guess is matched positionally against its own params() list (see
+        // layout.{bol,temp,spec}_map); a length mismatch here silently desyncs every subsequent
+        // parameter.
+        debug_assert_eq!(bol_guess.len(), self.bolometric.n_params());
+        debug_assert_eq!(temp_guess.len(), self.temperature.n_params());
+        debug_assert_eq!(spec_guess.len(), self.spectral.n_params());
+
+        let mut params = self.assemble(bol_guess, temp_guess, spec_guess);
+        for (b, g) in self.layout.baseline_map.iter().enumerate() {
+            params[*g] = baseline_guess[b];
+        }
+        params
+    }
+
+    /// Box bounds `(lower, upper)` (physical units), same order as [`Self::param_names`].
+    pub(crate) fn bounds(
+        &self,
+        t: &[f64],
+        flux: &[f64],
+        flux_err: &[f64],
+        band_idx: &[usize],
+    ) -> Vec<(f64, f64)> {
+        let (flux_corrected, baseline_bounds) = if self.with_baseline {
+            let baseline_guess = self.per_band_baseline_estimate(flux, band_idx);
+            let corrected: Vec<f64> = flux
+                .iter()
+                .zip(band_idx)
+                .map(|(&f, &b)| f - baseline_guess[b])
+                .collect();
+            let bounds: Vec<(f64, f64)> = (0..self.bands.len())
+                .map(|b| {
+                    let band_flux: Vec<f64> = flux
+                        .iter()
+                        .zip(band_idx)
+                        .filter(|&(_, &bi)| bi == b)
+                        .map(|(&f, _)| f)
+                        .collect();
+                    if band_flux.is_empty() {
+                        (0.0, 0.0)
+                    } else {
+                        let (max, min) = max_min(&band_flux);
+                        (min - 10.0 * ptp(&band_flux), max)
+                    }
+                })
+                .collect();
+            (corrected, bounds)
+        } else {
+            (flux.to_vec(), Vec::new())
+        };
+
+        let bol_bounds = self.bolometric.bounds(t, &flux_corrected, flux_err);
+        let temp_bounds = self.temperature.bounds(t, &flux_corrected, flux_err);
+        let spec_bounds = self.spectral.bounds();
+
+        debug_assert_eq!(bol_bounds.len(), self.bolometric.n_params());
+        debug_assert_eq!(temp_bounds.len(), self.temperature.n_params());
+        debug_assert_eq!(spec_bounds.len(), self.spectral.n_params());
+
+        let mut bounds = self.assemble(bol_bounds, temp_bounds, spec_bounds);
+        for (b, g) in self.layout.baseline_map.iter().enumerate() {
+            bounds[*g] = baseline_bounds[b];
+        }
+        bounds
+    }
+
+    /// Analytic bolometric peak time, if defined for the chosen bolometric term.
+    pub(crate) fn peak_time(&self, params: &[f64]) -> Option<f64> {
+        let n_bol = self.bolometric.n_params();
+        let bol_local: Vec<f64> = (0..n_bol).map(|i| params[self.layout.bol_map[i]]).collect();
+        self.bolometric.peak_time(&bol_local)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_bands() -> Vec<Band> {
+        vec![
+            Band {
+                name: "g".to_string(),
+                wavelength_cm: 4770.0e-8,
+            },
+            Band {
+                name: "r".to_string(),
+                wavelength_cm: 6231.0e-8,
+            },
+        ]
+    }
+
+    fn check_gradient(model: &RainbowModel, params: &[f64], h: &[f64]) {
+        let t = 15.0;
+        let band_idx = 1;
+        let (_, analytic) = model.model_and_gradient(t, band_idx, params);
+        for k in 0..params.len() {
+            let mut plus = params.to_vec();
+            let mut minus = params.to_vec();
+            plus[k] += h[k];
+            minus[k] -= h[k];
+            let f_plus = model.model(t, band_idx, &plus);
+            let f_minus = model.model(t, band_idx, &minus);
+            let numeric = (f_plus - f_minus) / (2.0 * h[k]);
+            assert!(
+                (analytic[k] - numeric).abs() <= 1e-4 * numeric.abs().max(1.0),
+                "param {k}: analytic={}, numeric={}",
+                analytic[k],
+                numeric
+            );
+        }
+    }
+
+    #[test]
+    fn bazin_sigmoid_planck_gradient_matches_finite_difference() {
+        let model = RainbowModel::new(
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            sample_bands(),
+            false,
+        );
+        // reference_time, amplitude, rise_time, fall_time, T, T_amplitude, t_color
+        let params = [10.0, 5.0, 3.0, 20.0, 9000.0, 0.2, 5.0];
+        let h = [1e-4, 1e-5, 1e-5, 1e-5, 1e-2, 1e-6, 1e-5];
+        check_gradient(&model, &params, &h);
+    }
+
+    #[test]
+    fn bazin_sigmoid_planck_with_baseline_gradient_matches_finite_difference() {
+        let model = RainbowModel::new(
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            sample_bands(),
+            true,
+        );
+        // reference_time, amplitude, rise_time, fall_time, T, T_amplitude, t_color, baseline_g, baseline_r
+        let params = [10.0, 5.0, 3.0, 20.0, 9000.0, 0.2, 5.0, 1.5, -0.7];
+        let h = [1e-4, 1e-5, 1e-5, 1e-5, 1e-2, 1e-6, 1e-5, 1e-5, 1e-5];
+        check_gradient(&model, &params, &h);
+    }
+
+    #[test]
+    fn sigmoid_bol_constant_genwien_gradient_matches_finite_difference() {
+        let model = RainbowModel::new(
+            Bolometric::Sigmoid,
+            Temperature::Constant,
+            Spectral::GenWien,
+            sample_bands(),
+            false,
+        );
+        // reference_time, amplitude, rise_time, T, spec_k
+        let params = [10.0, 5.0, 3.0, 9000.0, 1.3];
+        let h = [1e-4, 1e-5, 1e-5, 1e-2, 1e-6];
+        check_gradient(&model, &params, &h);
+    }
+
+    #[test]
+    fn doublexp_delayed_sigmoid_logparabola_gradient_matches_finite_difference() {
+        let model = RainbowModel::new(
+            Bolometric::Doublexp,
+            Temperature::DelayedSigmoid,
+            Spectral::LogParabola,
+            sample_bands(),
+            false,
+        );
+        // reference_time, amplitude, time1, time2, p, T, T_amplitude, t_color, t_delay, sp_a, sp_b
+        let params = [10.0, 5.0, 3.0, 4.0, 1.5, 9000.0, 0.2, 5.0, 1.0, 0.3, -0.2];
+        let h = [
+            1e-4, 1e-5, 1e-5, 1e-5, 1e-5, 1e-2, 1e-6, 1e-5, 1e-5, 1e-6, 1e-6,
+        ];
+        check_gradient(&model, &params, &h);
+    }
+
+    #[test]
+    fn shared_reference_time_deduplicated() {
+        let model = RainbowModel::new(
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            sample_bands(),
+            false,
+        );
+        assert_eq!(model.n_params(), 7); // not 4+4+0=8; reference_time is shared
+        assert_eq!(model.param_names()[0], "reference_time");
+    }
+
+    #[test]
+    fn constant_temperature_has_no_reference_time_collision() {
+        let model = RainbowModel::new(
+            Bolometric::Bazin,
+            Temperature::Constant,
+            Spectral::Planck,
+            sample_bands(),
+            false,
+        );
+        assert_eq!(model.n_params(), 5); // 4 bol + 1 temp (T), no shared name
+    }
+
+    #[test]
+    fn baseline_params_appended_per_band() {
+        let model = RainbowModel::new(
+            Bolometric::Bazin,
+            Temperature::Sigmoid,
+            Spectral::Planck,
+            sample_bands(),
+            true,
+        );
+        assert_eq!(model.n_params(), 9); // 7 + baseline_g + baseline_r
+        assert_eq!(model.param_names()[7], "baseline_g");
+        assert_eq!(model.param_names()[8], "baseline_r");
+    }
+}

--- a/src/multicolor/rainbow/terms/bolometric.rs
+++ b/src/multicolor/rainbow/terms/bolometric.rs
@@ -1,0 +1,389 @@
+//! Bolometric (flux-vs-time envelope) terms for [RainbowFit](super::super::RainbowFit).
+//!
+//! `Linexp`, present in the Python reference implementation
+//! (`light_curve_py.features.rainbow.bolometric.LinexpBolometricTerm`), is deliberately not
+//! ported here: the Python docstring itself flags its guesses/limits as "not very stable", and a
+//! seed sweep during development of this port confirmed it -- roughly half of random seeds land
+//! the fit in a self-consistent-looking but wrong local optimum. Dropped rather than carried as a
+//! known-flaky term; can be revisited if someone wants to stabilize its initial guess.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::common::{max_min, ptp, t0_and_weighted_centroid_sigma};
+
+// ---------------------------------------------------------------------
+// Bazin (symmetric, peak-normalized)
+// ---------------------------------------------------------------------
+
+fn bazin_jacobian(
+    t: f64,
+    t0: f64,
+    amplitude: f64,
+    rise_time: f64,
+    fall_time: f64,
+    jac: &mut [f64],
+) -> f64 {
+    let dt = t - t0;
+    if !(dt > -100.0 * rise_time && dt < 100.0 * fall_time) {
+        jac[..4].fill(0.0);
+        return 0.0;
+    }
+
+    let e_r = (-dt / rise_time).exp();
+    let e_f = (dt / fall_time).exp();
+    let denom = e_r + e_f;
+
+    let alpha = fall_time / rise_time;
+    let tau = rise_time + fall_time;
+    let u = rise_time / tau;
+    let v = fall_time / tau;
+    let log_alpha = alpha.ln();
+    let a1 = alpha.powf(u);
+    let a2 = alpha.powf(-v);
+    let scale = a1 + a2;
+    let dscale_dr =
+        a1 * (v * log_alpha / tau - u / rise_time) + a2 * (v * log_alpha / tau + v / rise_time);
+    let dscale_df =
+        a1 * u * (1.0 / fall_time - log_alpha / tau) + a2 * (-u * log_alpha / tau - v / fall_time);
+
+    let b = amplitude * scale / denom;
+    let value = b;
+
+    // d(value)/d(t0)
+    jac[0] = (b / denom) * (e_f / fall_time - e_r / rise_time);
+    // d(value)/d(amplitude)
+    jac[1] = scale / denom;
+    // d(value)/d(rise_time)
+    jac[2] = b * (dscale_dr / scale - e_r * dt / (rise_time * rise_time * denom));
+    // d(value)/d(fall_time)
+    jac[3] = b * (dscale_df / scale + e_f * dt / (fall_time * fall_time * denom));
+
+    value
+}
+
+// ---------------------------------------------------------------------
+// Sigmoid
+// ---------------------------------------------------------------------
+
+fn sigmoid_bol_jacobian(t: f64, t0: f64, amplitude: f64, rise_time: f64, jac: &mut [f64]) -> f64 {
+    let dt = t - t0;
+    if dt <= -100.0 * rise_time {
+        jac[..3].fill(0.0);
+        return 0.0;
+    }
+    let e = (-dt / rise_time).exp();
+    let s = 1.0 / (e + 1.0);
+    let s_1ms = e * s * s; // s * (1 - s)
+
+    jac[0] = -amplitude * s_1ms / rise_time;
+    jac[1] = s;
+    jac[2] = -amplitude * s_1ms * dt / (rise_time * rise_time);
+
+    amplitude * s
+}
+
+// ---------------------------------------------------------------------
+// Doublexp
+// ---------------------------------------------------------------------
+
+fn doublexp_bol_jacobian(
+    t: f64,
+    t0: f64,
+    amplitude: f64,
+    time1: f64,
+    time2: f64,
+    p: f64,
+    jac: &mut [f64],
+) -> f64 {
+    let dt = t - t0;
+    let v = (-dt / time2).exp();
+    let a_inner = -(dt / time1) * (p - v);
+    let maxp = 20.0;
+    let clamped = a_inner > maxp;
+    let b = amplitude * a_inner.min(maxp).exp();
+
+    jac[1] = b / amplitude;
+
+    if clamped {
+        // Beyond the exponent clamp, the model is constant in every parameter but amplitude.
+        jac[0] = 0.0;
+        jac[2] = 0.0;
+        jac[3] = 0.0;
+        jac[4] = 0.0;
+    } else {
+        let da_dt0 = (p - v) / time1 + dt * v / (time1 * time2);
+        let da_dtime1 = dt * (p - v) / (time1 * time1);
+        let da_dtime2 = (dt * dt) * v / (time1 * time2 * time2);
+        let da_dp = -dt / time1;
+
+        jac[0] = b * da_dt0;
+        jac[2] = b * da_dtime1;
+        jac[3] = b * da_dtime2;
+        jac[4] = b * da_dp;
+    }
+
+    b
+}
+
+/// Principal branch (`W0`) of the Lambert W function for real `x >= -1/e`, via Halley's method.
+/// Only needed for [`Bolometric::peak_time`] of the Doublexp term; not exposed as a general
+/// utility since it isn't validated outside the range this needs (`x >= 0`, given `p > 0`).
+fn lambert_w0(x: f64) -> f64 {
+    if x == 0.0 {
+        return 0.0;
+    }
+    let mut w = if x < 10.0 {
+        (x + 1.0).ln().max(1e-4)
+    } else {
+        x.ln() - x.ln().ln()
+    };
+    for _ in 0..50 {
+        let ew = w.exp();
+        let f = w * ew - x;
+        let denom = ew * (w + 1.0) - (w + 2.0) * f / (2.0 * w + 2.0);
+        if denom == 0.0 {
+            break;
+        }
+        let step = f / denom;
+        w -= step;
+        if step.abs() < 1e-14 * w.abs().max(1.0) {
+            break;
+        }
+    }
+    w
+}
+
+// ---------------------------------------------------------------------
+// Enum wrapper
+// ---------------------------------------------------------------------
+
+/// Which parametric function models the bolometric (band-integrated) flux envelope $\mathrm{bol}(t)$.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[non_exhaustive]
+pub enum Bolometric {
+    /// Symmetric, peak-normalized Bazin function (Bazin et al. 2009,
+    /// [DOI:10.1051/0004-6361/200911847](https://doi.org/10.1051/0004-6361/200911847)):
+    /// $$
+    /// \mathrm{bol}(t) = A \cdot \frac{\alpha}{\mathrm{e}^{-(t-t_0)/\tau_\mathrm{rise}} + \mathrm{e}^{(t-t_0)/\tau_\mathrm{fall}}},
+    /// $$
+    /// where $\alpha$ is chosen so the peak value equals $A$ exactly:
+    /// $$
+    /// \alpha = \left(\frac{\tau_\mathrm{fall}}{\tau_\mathrm{rise}}\right)^{\tau_\mathrm{rise}/(\tau_\mathrm{rise}+\tau_\mathrm{fall})}
+    ///        + \left(\frac{\tau_\mathrm{fall}}{\tau_\mathrm{rise}}\right)^{-\tau_\mathrm{fall}/(\tau_\mathrm{rise}+\tau_\mathrm{fall})}.
+    /// $$
+    /// Parameters: `reference_time` ($t_0$), `amplitude` ($A$), `rise_time` ($\tau_\mathrm{rise}$),
+    /// `fall_time` ($\tau_\mathrm{fall}$). A good default for transients with a clear rise and
+    /// fall (e.g. supernovae).
+    Bazin,
+    /// Plain logistic rise, with no decline:
+    /// $$
+    /// \mathrm{bol}(t) = \frac{A}{1 + \mathrm{e}^{-(t-t_0)/\tau_\mathrm{rise}}}.
+    /// $$
+    /// Parameters: `reference_time` ($t_0$, the inflection point), `amplitude` ($A$, the
+    /// asymptotic plateau level), `rise_time` ($\tau_\mathrm{rise}$). Appropriate for sources
+    /// that rise and then plateau within the observed window, rather than declining (e.g. AGN,
+    /// TDEs observed only near onset).
+    Sigmoid,
+    /// Asymmetric rise/decline with an adjustable decline sharpness, fitted by symbolic
+    /// regression on ZTF SN Ia light curves (Russeil et al. 2024,
+    /// [arXiv:2402.04298](https://arxiv.org/abs/2402.04298)):
+    /// $$
+    /// \mathrm{bol}(t) = A \, \exp\!\left(-\frac{t-t_0}{\tau_1}\left(p - \mathrm{e}^{-(t-t_0)/\tau_2}\right)\right).
+    /// $$
+    /// Parameters: `reference_time` ($t_0$), `amplitude` ($A$), `time1` ($\tau_1$), `time2`
+    /// ($\tau_2$), `p`. Unlike Bazin, decline sharpness is a free parameter ($p$) rather than
+    /// tied to the same functional form as the rise, at the cost of two extra parameters.
+    Doublexp,
+}
+
+const BAZIN_PARAMS: [&str; 4] = ["reference_time", "amplitude", "rise_time", "fall_time"];
+const SIGMOID_BOL_PARAMS: [&str; 3] = ["reference_time", "amplitude", "rise_time"];
+const DOUBLEXP_PARAMS: [&str; 5] = ["reference_time", "amplitude", "time1", "time2", "p"];
+
+impl Bolometric {
+    pub(crate) fn params(&self) -> &'static [&'static str] {
+        match self {
+            Bolometric::Bazin => &BAZIN_PARAMS,
+            Bolometric::Sigmoid => &SIGMOID_BOL_PARAMS,
+            Bolometric::Doublexp => &DOUBLEXP_PARAMS,
+        }
+    }
+
+    pub(crate) fn n_params(&self) -> usize {
+        self.params().len()
+    }
+
+    /// Evaluates the term and writes its Jacobian (length `n_params()`) into `jac`, returning
+    /// the value.
+    pub(crate) fn value_jac(&self, t: f64, p: &[f64], jac: &mut [f64]) -> f64 {
+        match self {
+            Bolometric::Bazin => bazin_jacobian(t, p[0], p[1], p[2], p[3], jac),
+            Bolometric::Sigmoid => sigmoid_bol_jacobian(t, p[0], p[1], p[2], jac),
+            Bolometric::Doublexp => doublexp_bol_jacobian(t, p[0], p[1], p[2], p[3], p[4], jac),
+        }
+    }
+
+    /// Heuristic initial guess (physical units), same order as [`Self::params`].
+    pub(crate) fn initial_guess(&self, t: &[f64], flux: &[f64], flux_err: &[f64]) -> Vec<f64> {
+        let (max_flux, min_flux) = max_min(flux);
+        let ptp_flux = max_flux - min_flux;
+        match self {
+            Bolometric::Bazin => {
+                let (t0, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![t0, 1.5 * max_flux.max(ptp_flux), dt, dt]
+            }
+            Bolometric::Sigmoid => {
+                let peak_t = t[super::common::argmax(flux)];
+                vec![peak_t, ptp_flux, 1.0]
+            }
+            Bolometric::Doublexp => {
+                let (t0, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![t0, max_flux.max(ptp_flux), 2.0 * dt, 2.0 * dt, 1.0]
+            }
+        }
+    }
+
+    /// Box bounds `(lower, upper)` (physical units), same order as [`Self::params`].
+    pub(crate) fn bounds(&self, t: &[f64], flux: &[f64], flux_err: &[f64]) -> Vec<(f64, f64)> {
+        let (t_max, t_min) = max_min(t);
+        let ptp_t = t_max - t_min;
+        let ptp_flux = ptp(flux);
+        let reference_time_bounds = (t_min - 10.0 * ptp_t, t_max + 10.0 * ptp_t);
+
+        match self {
+            Bolometric::Bazin => {
+                let (_, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![
+                    reference_time_bounds,
+                    (0.0, 20.0 * ptp_flux),
+                    (dt / 100.0, 10.0 * ptp_t),
+                    (dt / 100.0, 10.0 * ptp_t),
+                ]
+            }
+            Bolometric::Sigmoid => {
+                let (_, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![
+                    reference_time_bounds,
+                    (0.0, 20.0 * ptp_flux),
+                    (dt / 100.0, 10.0 * ptp_t),
+                ]
+            }
+            Bolometric::Doublexp => {
+                let (_, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![
+                    reference_time_bounds,
+                    (0.0, 10.0 * ptp_flux),
+                    (dt / 10.0, 2.0 * ptp_t),
+                    (dt / 10.0, 2.0 * ptp_t),
+                    (1e-2, 100.0),
+                ]
+            }
+        }
+    }
+
+    /// Analytic bolometric peak time, if defined for this term.
+    pub(crate) fn peak_time(&self, p: &[f64]) -> Option<f64> {
+        match self {
+            Bolometric::Bazin => {
+                let (t0, _a, rise_time, fall_time) = (p[0], p[1], p[2], p[3]);
+                Some(
+                    t0 + (fall_time / rise_time).ln() * rise_time * fall_time
+                        / (rise_time + fall_time),
+                )
+            }
+            // Peak time is not defined for the sigmoid (monotonic), so it returns the
+            // inflection point (mid-time of the rise) instead.
+            Bolometric::Sigmoid => Some(p[0]),
+            Bolometric::Doublexp => {
+                let (t0, _a, _time1, _time2, pp) = (p[0], p[1], p[2], p[3], p[4]);
+                Some(t0 + (-lambert_w0(pp * std::f64::consts::E) + 1.0))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn finite_diff_check(
+        name: &str,
+        n: usize,
+        value_jac: impl Fn(&[f64], &mut [f64]) -> f64,
+        p: &[f64],
+    ) {
+        let mut jac = vec![0.0; n];
+        value_jac(p, &mut jac);
+        let h = 1e-6;
+        for k in 0..n {
+            let mut plus = p.to_vec();
+            let mut minus = p.to_vec();
+            plus[k] += h * plus[k].abs().max(1.0);
+            minus[k] -= h * minus[k].abs().max(1.0);
+            let step = plus[k] - minus[k];
+            let mut dummy = vec![0.0; n];
+            let f_plus = value_jac(&plus, &mut dummy);
+            let f_minus = value_jac(&minus, &mut dummy);
+            let numeric = (f_plus - f_minus) / step;
+            assert!(
+                (jac[k] - numeric).abs() <= 1e-4 * numeric.abs().max(1.0),
+                "{name} param {k}: analytic={}, numeric={}",
+                jac[k],
+                numeric
+            );
+        }
+    }
+
+    #[test]
+    fn bazin_jacobian_matches_finite_difference() {
+        finite_diff_check(
+            "bazin",
+            4,
+            |p, jac| bazin_jacobian(12.0, p[0], p[1], p[2], p[3], jac),
+            &[10.0, 5.0, 3.0, 20.0],
+        );
+    }
+
+    #[test]
+    fn bazin_peak_equals_amplitude() {
+        let (t0, amplitude, rise_time, fall_time): (f64, f64, f64, f64) = (100.0, 5.0, 3.0, 20.0);
+        let peak_t =
+            t0 + (fall_time / rise_time).ln() * rise_time * fall_time / (rise_time + fall_time);
+        let mut jac = [0.0; 4];
+        let value = bazin_jacobian(peak_t, t0, amplitude, rise_time, fall_time, &mut jac);
+        assert!((value - amplitude).abs() <= 1e-9 * amplitude);
+    }
+
+    #[test]
+    fn sigmoid_bol_jacobian_matches_finite_difference() {
+        finite_diff_check(
+            "sigmoid_bol",
+            3,
+            |p, jac| sigmoid_bol_jacobian(12.0, p[0], p[1], p[2], jac),
+            &[10.0, 5.0, 3.0],
+        );
+    }
+
+    #[test]
+    fn doublexp_bol_jacobian_matches_finite_difference() {
+        finite_diff_check(
+            "doublexp_bol",
+            5,
+            |p, jac| doublexp_bol_jacobian(12.0, p[0], p[1], p[2], p[3], p[4], jac),
+            &[10.0, 5.0, 3.0, 4.0, 1.5],
+        );
+    }
+
+    #[test]
+    fn lambert_w0_matches_definition() {
+        for &x in &[0.1, 1.0, 2.0, 10.0, 100.0, 0.001] {
+            let w = lambert_w0(x);
+            let check = w * w.exp();
+            assert!(
+                (check - x).abs() <= 1e-8 * x.max(1.0),
+                "x={x}, w={w}, w*e^w={check}"
+            );
+        }
+    }
+}

--- a/src/multicolor/rainbow/terms/common.rs
+++ b/src/multicolor/rainbow/terms/common.rs
@@ -1,0 +1,73 @@
+//! Shared initial-guess heuristics used by more than one bolometric/temperature term.
+
+/// Weighted centroid time and its spread, used as an initial guess for `reference_time` and
+/// rise/fall/color timescales. Centroid uses only points above the median flux (the "bright
+/// half"), weighted by `flux / flux_err`, to approximate the peak position without assuming a
+/// model shape; spread is the flux-weighted time stddev around that centroid.
+pub fn t0_and_weighted_centroid_sigma(t: &[f64], flux: &[f64], flux_err: &[f64]) -> (f64, f64) {
+    let min_flux = flux.iter().cloned().fold(f64::MAX, f64::min);
+    let mc: Vec<f64> = flux.iter().map(|m| m - min_flux).collect();
+
+    let median = median(flux);
+    let idx: Vec<usize> = (0..t.len()).filter(|&i| flux[i] > median).collect();
+
+    let weight_sum: f64 = idx.iter().map(|&i| flux[i] / flux_err[i]).sum();
+    let t0 = idx
+        .iter()
+        .map(|&i| t[i] * flux[i] / flux_err[i])
+        .sum::<f64>()
+        / weight_sum;
+
+    let mc_weight_sum: f64 = idx.iter().map(|&i| mc[i] / flux_err[i]).sum();
+    let var = idx
+        .iter()
+        .map(|&i| (t[i] - t0).powi(2) * mc[i] / flux_err[i])
+        .sum::<f64>()
+        / mc_weight_sum;
+    let dt = var.sqrt();
+
+    // Guard against a degenerate spread (e.g. all bright points at the same time): fall back to
+    // a quarter of the light curve's time span, which is always positive and finite.
+    let dt = if dt.is_finite() && dt > 0.0 {
+        dt
+    } else {
+        let t_max = t.iter().cloned().fold(f64::MIN, f64::max);
+        let t_min = t.iter().cloned().fold(f64::MAX, f64::min);
+        ((t_max - t_min) / 4.0).max(1.0)
+    };
+
+    (t0, dt)
+}
+
+pub fn max_min(x: &[f64]) -> (f64, f64) {
+    (
+        x.iter().cloned().fold(f64::MIN, f64::max),
+        x.iter().cloned().fold(f64::MAX, f64::min),
+    )
+}
+
+pub fn ptp(x: &[f64]) -> f64 {
+    let (max, min) = max_min(x);
+    max - min
+}
+
+pub fn argmax(x: &[f64]) -> usize {
+    let mut best = 0;
+    for i in 1..x.len() {
+        if x[i] > x[best] {
+            best = i;
+        }
+    }
+    best
+}
+
+pub fn median(x: &[f64]) -> f64 {
+    let mut sorted = x.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let n = sorted.len();
+    if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        0.5 * (sorted[n / 2 - 1] + sorted[n / 2])
+    }
+}

--- a/src/multicolor/rainbow/terms/mod.rs
+++ b/src/multicolor/rainbow/terms/mod.rs
@@ -1,0 +1,20 @@
+//! Pluggable bolometric / temperature / spectral terms composed by [RainbowFit](super::RainbowFit).
+//!
+//! Each term contributes a small, fixed number of named parameters (see each module's
+//! `params()`), a physical-unit initial guess (`initial_guess()`), and physical-unit box bounds
+//! (`bounds()`). See [super::fit] for how a parameter's bounds drive its optimizer
+//! reparametrization.
+
+pub mod bolometric;
+pub mod common;
+pub mod spectral;
+pub mod temperature;
+
+pub use bolometric::Bolometric;
+pub use spectral::Spectral;
+pub use temperature::Temperature;
+
+/// The largest number of parameters any single bolometric or temperature term has
+/// (`Doublexp` / `DelayedSigmoid`, both 5). Used to size fixed-length stack buffers and avoid
+/// heap allocation in the per-point model evaluation hot path.
+pub(crate) const MAX_LOCAL_PARAMS: usize = 5;

--- a/src/multicolor/rainbow/terms/spectral.rs
+++ b/src/multicolor/rainbow/terms/spectral.rs
@@ -1,0 +1,353 @@
+//! Spectral energy distribution (SED) terms for [RainbowFit](super::super::RainbowFit).
+//!
+//! Python's `BlanketedPlanckSpectralTerm` is deliberately not implemented here: its
+//! `lambda_scale` parameter anchors to the temperature term's own (possibly different)
+//! characteristic `T` parameter via cross-term parameter sharing (Python's `common_temp_spec`
+//! machinery), which is more involved than a straight port of the other terms and is deferred.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::super::constants::{BOLTZMANN_K, PLANCK_H, SPEED_OF_LIGHT};
+
+// ---------------------------------------------------------------------
+// Planck (plain blackbody, no free parameters)
+// ---------------------------------------------------------------------
+
+fn planck(wave_cm: f64, temperature: f64) -> f64 {
+    let nu = SPEED_OF_LIGHT / wave_cm;
+    let x = PLANCK_H * nu / (BOLTZMANN_K * temperature);
+    // B = (2h/c^2) nu^3 / (e^x - 1), written as nu^3 e^{-x} / (1 - e^{-x}) to stay overflow-safe
+    // at large x (cold T / blue wavelengths): e^x/expm1(x) overflows there, whereas e^{-x}
+    // underflows to 0 and B -> 0 (the Wien tail), which is the correct limit.
+    let neg_expm1 = -(-x).exp_m1();
+    (2.0 * PLANCK_H / (SPEED_OF_LIGHT * SPEED_OF_LIGHT)) * nu.powi(3) * (-x).exp() / neg_expm1
+}
+
+fn planck_dtemperature(wave_cm: f64, temperature: f64) -> f64 {
+    let nu = SPEED_OF_LIGHT / wave_cm;
+    let x = PLANCK_H * nu / (BOLTZMANN_K * temperature);
+    let neg_expm1 = -(-x).exp_m1();
+    let value =
+        (2.0 * PLANCK_H / (SPEED_OF_LIGHT * SPEED_OF_LIGHT)) * nu.powi(3) * (-x).exp() / neg_expm1;
+    // d(planck)/dT = planck * x*e^x / (T*expm1(x)) = planck * x / (T * (1 - e^{-x})), the same
+    // overflow-safe rewrite as `planck` itself.
+    value * x / (temperature * neg_expm1)
+}
+
+// ---------------------------------------------------------------------
+// Generalized Wien: B(nu) ~ nu^3 * exp(-x^spec_k), x = h*nu/(k*T)
+// ---------------------------------------------------------------------
+
+fn genwien_x_value(wave_cm: f64, temperature: f64, spec_k: f64) -> (f64, f64) {
+    let nu = SPEED_OF_LIGHT / wave_cm;
+    let x = PLANCK_H * nu / (BOLTZMANN_K * temperature);
+    let value =
+        (2.0 * PLANCK_H / (SPEED_OF_LIGHT * SPEED_OF_LIGHT)) * nu.powi(3) * (-x.powf(spec_k)).exp();
+    (x, value)
+}
+
+fn genwien_dtemperature(wave_cm: f64, temperature: f64, spec_k: f64) -> f64 {
+    let (x, value) = genwien_x_value(wave_cm, temperature, spec_k);
+    value * spec_k * x.powf(spec_k) / temperature
+}
+
+fn genwien_jacobian(wave_cm: f64, temperature: f64, spec_k: f64, jac: &mut [f64]) -> f64 {
+    let (x, value) = genwien_x_value(wave_cm, temperature, spec_k);
+    jac[0] = -value * x.powf(spec_k) * x.ln();
+    value
+}
+
+// ---------------------------------------------------------------------
+// Modified blackbody: Planck(wave, T) * (wave/wave_ref)^beta
+// ---------------------------------------------------------------------
+
+const MODIFIED_BB_WAVE_REF_CM: f64 = 6000e-8;
+
+fn modified_bb_dtemperature(wave_cm: f64, temperature: f64, beta: f64) -> f64 {
+    let tilt = (wave_cm / MODIFIED_BB_WAVE_REF_CM).powf(beta);
+    planck_dtemperature(wave_cm, temperature) * tilt
+}
+
+fn modified_bb_jacobian(wave_cm: f64, temperature: f64, beta: f64, jac: &mut [f64]) -> f64 {
+    let rel = wave_cm / MODIFIED_BB_WAVE_REF_CM;
+    let value = planck(wave_cm, temperature) * rel.powf(beta);
+    jac[0] = value * rel.ln();
+    value
+}
+
+// ---------------------------------------------------------------------
+// Log-parabola: Planck(wave, T) * exp(sp_a*L + sp_b*L^2), L = ln(wave/wave_ref)
+// ---------------------------------------------------------------------
+
+const LOGPARABOLA_WAVE_REF_CM: f64 = 6000e-8;
+
+fn logparabola_l_fac(wave_cm: f64, sp_a: f64, sp_b: f64) -> (f64, f64) {
+    let ell = (wave_cm / LOGPARABOLA_WAVE_REF_CM).ln();
+    (ell, (sp_a * ell + sp_b * ell * ell).exp())
+}
+
+fn logparabola_dtemperature(wave_cm: f64, temperature: f64, sp_a: f64, sp_b: f64) -> f64 {
+    let (_ell, fac) = logparabola_l_fac(wave_cm, sp_a, sp_b);
+    planck_dtemperature(wave_cm, temperature) * fac
+}
+
+fn logparabola_jacobian(
+    wave_cm: f64,
+    temperature: f64,
+    sp_a: f64,
+    sp_b: f64,
+    jac: &mut [f64],
+) -> f64 {
+    let (ell, fac) = logparabola_l_fac(wave_cm, sp_a, sp_b);
+    let value = planck(wave_cm, temperature) * fac;
+    jac[0] = value * ell;
+    jac[1] = value * ell * ell;
+    value
+}
+
+// ---------------------------------------------------------------------
+// Enum wrapper
+// ---------------------------------------------------------------------
+
+/// Which parametric spectral energy distribution (SED) describes the flux shape across bands at
+/// fixed temperature $T$.
+///
+/// Every variant's amplitude is normalized away in [the model composition](super::super::model)
+/// (divided by a Stefan-Boltzmann-based `norm(T)` shared across all variants), so only the SED's
+/// *shape* -- not its absolute scale -- matters here; the overall bolometric amplitude is carried
+/// entirely by the bolometric term. This also means the physical "bolometric luminosity"
+/// interpretation of `amplitude` is only exact for [`Spectral::Planck`]; the other variants trade
+/// that physical interpretation for extra shape flexibility.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[non_exhaustive]
+pub enum Spectral {
+    /// Standard blackbody spectrum (Planck's law), no free parameters:
+    /// $$
+    /// B_\nu(\lambda, T) = \frac{2h}{c^2}\,\nu^3\,\frac{1}{\mathrm{e}^{h\nu/k_BT} - 1}, \quad \nu = c/\lambda.
+    /// $$
+    /// The physically-motivated default; use this unless the data show a clear deviation from a
+    /// pure blackbody.
+    Planck,
+    /// Generalized-Wien SED, replacing the Planck denominator's exponent with a free power
+    /// $\mathrm{spec\_k}$:
+    /// $$
+    /// B(\nu) \propto \nu^3\,\mathrm{e}^{-x^{\mathrm{spec\_k}}}, \quad x = h\nu/(k_BT).
+    /// $$
+    /// $\mathrm{spec\_k} \approx 1$ recovers the Wien tail (equal to Planck for cool sources,
+    /// where $x$ is large); $\mathrm{spec\_k} > 1$ sharpens the blue cutoff, mimicking the UV
+    /// deficit of hot sources. One parameter, `spec_k`. Note the fitted `T` under this term is
+    /// *not* a physical temperature once `spec_k` deviates from 1 -- `spec_k` and `T` trade off,
+    /// so treat `(T, spec_k)` jointly as an SED-shape descriptor rather than separately
+    /// physically meaningful values.
+    GenWien,
+    /// Planck spectrum tilted by a wavelength power law:
+    /// $$
+    /// F(\lambda) = B_\nu(\lambda, T) \cdot (\lambda/\lambda_\mathrm{ref})^\beta, \quad \lambda_\mathrm{ref} = 6000\,\text{\AA}.
+    /// $$
+    /// $\beta = 0$ is exactly Planck, so `T` stays physical; $\beta > 0$ suppresses the blue
+    /// (gentle UV blanketing), $\beta < 0$ enhances it. One parameter, `beta`. Because the
+    /// deviation is a single tilt of an otherwise-intact Planck core, `beta` and `T` stay close
+    /// to orthogonal, making this the best-conditioned of the non-Planck SEDs when a small,
+    /// physically-motivated deviation is expected.
+    ModifiedBlackBody,
+    /// Planck spectrum modulated by a log-parabola in wavelength:
+    /// $$
+    /// F(\lambda) = B_\nu(\lambda, T) \cdot \mathrm{e}^{\mathrm{sp\_a} L + \mathrm{sp\_b} L^2}, \quad L = \ln(\lambda/\lambda_\mathrm{ref}), \quad \lambda_\mathrm{ref} = 6000\,\text{\AA}.
+    /// $$
+    /// Two parameters, `sp_a` (tilt) and `sp_b` (curvature), both anchored at the pure-Planck
+    /// value 0. The most flexible of the deviation terms -- its curvature captures sharper blue
+    /// cutoffs than [`Spectral::ModifiedBlackBody`]'s single tilt can -- at the cost of `(T,
+    /// sp_a, sp_b)` being genuinely degenerate for smooth, close-to-blackbody spectra, where `T`
+    /// can be biased without a prior pulling `sp_a`/`sp_b` back toward 0 (not yet implemented
+    /// here; see the module-level documentation).
+    LogParabola,
+}
+
+const PLANCK_PARAMS: [&str; 0] = [];
+const GENWIEN_PARAMS: [&str; 1] = ["spec_k"];
+const MODIFIED_BB_PARAMS: [&str; 1] = ["beta"];
+const LOGPARABOLA_PARAMS: [&str; 2] = ["sp_a", "sp_b"];
+
+impl Spectral {
+    pub(crate) fn params(&self) -> &'static [&'static str] {
+        match self {
+            Spectral::Planck => &PLANCK_PARAMS,
+            Spectral::GenWien => &GENWIEN_PARAMS,
+            Spectral::ModifiedBlackBody => &MODIFIED_BB_PARAMS,
+            Spectral::LogParabola => &LOGPARABOLA_PARAMS,
+        }
+    }
+
+    pub(crate) fn n_params(&self) -> usize {
+        self.params().len()
+    }
+
+    /// Evaluates the SED and writes its Jacobian w.r.t. this term's own local parameters
+    /// (length `n_params()`, NOT including `T`) into `jac`, returning `(value, d(value)/dT)`.
+    pub(crate) fn value_jac(
+        &self,
+        wave_cm: f64,
+        temperature: f64,
+        p: &[f64],
+        jac: &mut [f64],
+    ) -> (f64, f64) {
+        match self {
+            Spectral::Planck => (
+                planck(wave_cm, temperature),
+                planck_dtemperature(wave_cm, temperature),
+            ),
+            Spectral::GenWien => {
+                let value = genwien_jacobian(wave_cm, temperature, p[0], jac);
+                (value, genwien_dtemperature(wave_cm, temperature, p[0]))
+            }
+            Spectral::ModifiedBlackBody => {
+                let value = modified_bb_jacobian(wave_cm, temperature, p[0], jac);
+                (value, modified_bb_dtemperature(wave_cm, temperature, p[0]))
+            }
+            Spectral::LogParabola => {
+                let value = logparabola_jacobian(wave_cm, temperature, p[0], p[1], jac);
+                (
+                    value,
+                    logparabola_dtemperature(wave_cm, temperature, p[0], p[1]),
+                )
+            }
+        }
+    }
+
+    pub(crate) fn initial_guess(&self) -> Vec<f64> {
+        match self {
+            Spectral::Planck => vec![],
+            Spectral::GenWien => vec![1.0],
+            Spectral::ModifiedBlackBody => vec![0.0],
+            Spectral::LogParabola => vec![0.0, 0.0],
+        }
+    }
+
+    /// Box bounds `(lower, upper)` (physical units), same order as [`Self::params`]. None of
+    /// these are data-dependent.
+    pub(crate) fn bounds(&self) -> Vec<(f64, f64)> {
+        match self {
+            Spectral::Planck => vec![],
+            Spectral::GenWien => vec![(0.3, 3.0)],
+            Spectral::ModifiedBlackBody => vec![(-6.0, 10.0)],
+            Spectral::LogParabola => vec![(-6.0, 6.0), (-4.0, 4.0)],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn finite_diff_check_local(
+        name: &str,
+        n: usize,
+        value_jac: impl Fn(&[f64], &mut [f64]) -> f64,
+        p: &[f64],
+    ) {
+        let mut jac = vec![0.0; n];
+        value_jac(p, &mut jac);
+        let h = 1e-6;
+        for k in 0..n {
+            let mut plus = p.to_vec();
+            let mut minus = p.to_vec();
+            plus[k] += h * plus[k].abs().max(1.0);
+            minus[k] -= h * minus[k].abs().max(1.0);
+            let step = plus[k] - minus[k];
+            let mut dummy = vec![0.0; n];
+            let f_plus = value_jac(&plus, &mut dummy);
+            let f_minus = value_jac(&minus, &mut dummy);
+            let numeric = (f_plus - f_minus) / step;
+            assert!(
+                (jac[k] - numeric).abs() <= 1e-4 * numeric.abs().max(1.0),
+                "{name} param {k}: analytic={}, numeric={}",
+                jac[k],
+                numeric
+            );
+        }
+    }
+
+    fn finite_diff_check_dt(
+        name: &str,
+        value: impl Fn(f64) -> f64,
+        dvalue: impl Fn(f64) -> f64,
+        t: f64,
+    ) {
+        let h = 1e-2;
+        let numeric = (value(t + h) - value(t - h)) / (2.0 * h);
+        let analytic = dvalue(t);
+        assert!(
+            (analytic - numeric).abs() <= 1e-5 * numeric.abs().max(1.0),
+            "{name}: analytic={analytic}, numeric={numeric}"
+        );
+    }
+
+    const WAVE_CM: f64 = 5.0e-5;
+    const TEMP: f64 = 9000.0;
+
+    #[test]
+    fn planck_dtemperature_matches_finite_difference() {
+        finite_diff_check_dt(
+            "planck_dT",
+            |t| planck(WAVE_CM, t),
+            |t| planck_dtemperature(WAVE_CM, t),
+            TEMP,
+        );
+    }
+
+    #[test]
+    fn genwien_jacobian_matches_finite_difference() {
+        finite_diff_check_local(
+            "genwien",
+            1,
+            |p, jac| genwien_jacobian(WAVE_CM, TEMP, p[0], jac),
+            &[1.3],
+        );
+        finite_diff_check_dt(
+            "genwien_dT",
+            |t| genwien_jacobian(WAVE_CM, t, 1.3, &mut [0.0; 1]),
+            |t| genwien_dtemperature(WAVE_CM, t, 1.3),
+            TEMP,
+        );
+    }
+
+    #[test]
+    fn modified_bb_jacobian_matches_finite_difference() {
+        finite_diff_check_local(
+            "modified_bb",
+            1,
+            |p, jac| modified_bb_jacobian(WAVE_CM, TEMP, p[0], jac),
+            &[0.5],
+        );
+        finite_diff_check_dt(
+            "modified_bb_dT",
+            |t| modified_bb_jacobian(WAVE_CM, t, 0.5, &mut [0.0; 1]),
+            |t| modified_bb_dtemperature(WAVE_CM, t, 0.5),
+            TEMP,
+        );
+    }
+
+    #[test]
+    fn logparabola_jacobian_matches_finite_difference() {
+        finite_diff_check_local(
+            "logparabola",
+            2,
+            |p, jac| logparabola_jacobian(WAVE_CM, TEMP, p[0], p[1], jac),
+            &[0.3, -0.2],
+        );
+        finite_diff_check_dt(
+            "logparabola_dT",
+            |t| logparabola_jacobian(WAVE_CM, t, 0.3, -0.2, &mut [0.0; 2]),
+            |t| logparabola_dtemperature(WAVE_CM, t, 0.3, -0.2),
+            TEMP,
+        );
+    }
+
+    #[test]
+    fn modified_bb_beta_zero_equals_planck() {
+        let a = modified_bb_jacobian(WAVE_CM, TEMP, 0.0, &mut [0.0; 1]);
+        let b = planck(WAVE_CM, TEMP);
+        assert!((a - b).abs() <= 1e-9 * b);
+    }
+}

--- a/src/multicolor/rainbow/terms/temperature.rs
+++ b/src/multicolor/rainbow/terms/temperature.rs
@@ -1,0 +1,286 @@
+//! Temperature-vs-time terms for [RainbowFit](super::super::RainbowFit).
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::common::{max_min, t0_and_weighted_centroid_sigma};
+
+// ---------------------------------------------------------------------
+// Constant
+// ---------------------------------------------------------------------
+
+fn constant_temperature_jacobian(temperature: f64, jac: &mut [f64]) -> f64 {
+    jac[0] = 1.0;
+    temperature
+}
+
+// ---------------------------------------------------------------------
+// Sigmoid
+// ---------------------------------------------------------------------
+
+fn sigmoid_temperature_jacobian(
+    t: f64,
+    t0: f64,
+    temperature: f64,
+    temperature_amplitude: f64,
+    t_color: f64,
+    jac: &mut [f64],
+) -> f64 {
+    let dt = t - t0;
+    if dt <= -100.0 * t_color {
+        jac[0] = 0.0;
+        jac[1] = 1.0 + temperature_amplitude;
+        jac[2] = temperature;
+        jac[3] = 0.0;
+        return temperature * (1.0 + temperature_amplitude);
+    }
+    if dt >= 100.0 * t_color {
+        jac[0] = 0.0;
+        jac[1] = 1.0 - temperature_amplitude;
+        jac[2] = -temperature;
+        jac[3] = 0.0;
+        return temperature * (1.0 - temperature_amplitude);
+    }
+
+    let e = (dt / t_color).exp();
+    let inv_1p_e = 1.0 / (1.0 + e);
+    let s = inv_1p_e;
+    let s_1ms = e * inv_1p_e * inv_1p_e; // s * (1 - s)
+    let two_s_m1 = 2.0 * s - 1.0;
+
+    jac[0] = 2.0 * temperature * temperature_amplitude * s_1ms / t_color;
+    jac[1] = 1.0 + temperature_amplitude * two_s_m1;
+    jac[2] = temperature * two_s_m1;
+    jac[3] = 2.0 * temperature * temperature_amplitude * s_1ms * dt / (t_color * t_color);
+
+    temperature * (1.0 + temperature_amplitude * two_s_m1)
+}
+
+// ---------------------------------------------------------------------
+// Delayed sigmoid
+// ---------------------------------------------------------------------
+
+fn delayed_sigmoid_temperature_jacobian(
+    t: f64,
+    t0: f64,
+    temperature: f64,
+    temperature_amplitude: f64,
+    t_color: f64,
+    t_delay: f64,
+    jac: &mut [f64],
+) -> f64 {
+    let mut sigmoid_jac = [0.0; 4];
+    let value = sigmoid_temperature_jacobian(
+        t,
+        t0 + t_delay,
+        temperature,
+        temperature_amplitude,
+        t_color,
+        &mut sigmoid_jac,
+    );
+    jac[0] = sigmoid_jac[0]; // d/d(reference_time)
+    jac[1] = sigmoid_jac[1]; // d/d(T)
+    jac[2] = sigmoid_jac[2]; // d/d(T_amplitude)
+    jac[3] = sigmoid_jac[3]; // d/d(t_color)
+    jac[4] = sigmoid_jac[0]; // d/d(t_delay) = d/d(reference_time), since both enter as their sum
+    value
+}
+
+// ---------------------------------------------------------------------
+// Enum wrapper
+// ---------------------------------------------------------------------
+
+/// Which parametric function models the temperature-vs-time curve $T(t)$.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[non_exhaustive]
+pub enum Temperature {
+    /// Time-independent temperature: $T(t) = T$. One parameter, `T`. Appropriate when the SED
+    /// shape isn't expected to evolve over the observed window (e.g. a short-duration event, or
+    /// one where cooling isn't the dominant behavior).
+    Constant,
+    /// Logistic transition between two temperature plateaus, parametrized by the mid-temperature
+    /// $T$ and a dimensionless relative amplitude $T_\mathrm{amplitude} \in (-1, 1)$ so that
+    /// $T_\mathrm{max} = T(1 + T_\mathrm{amplitude})$ and $T_\mathrm{min} = T(1 - T_\mathrm{amplitude})$:
+    /// $$
+    /// T(t) = T\bigl(1 + T_\mathrm{amplitude}(2s - 1)\bigr), \quad s = \frac{1}{1 + \mathrm{e}^{(t-t_0)/\tau_\mathrm{color}}}.
+    /// $$
+    /// $s$ runs from 1 (early, hot) to 0 (late, cool), so $T(t)$ runs from $T_\mathrm{max}$ down
+    /// to $T_\mathrm{min}$; $T_\mathrm{amplitude} = 0$ recovers the constant-temperature case.
+    /// Parameters: `reference_time` ($t_0$, shared with the bolometric term when both use it),
+    /// `T`, `T_amplitude`, `t_color` ($\tau_\mathrm{color}$). The standard choice for cooling
+    /// transients such as supernovae.
+    Sigmoid,
+    /// Same logistic transition as [`Temperature::Sigmoid`], but with an extra `t_delay`
+    /// parameter offsetting the temperature's own reference time from the bolometric one:
+    /// $$
+    /// T(t) = T\bigl(1 + T_\mathrm{amplitude}(2s - 1)\bigr), \quad s = \frac{1}{1 + \mathrm{e}^{(t-t_0-\tau_\mathrm{delay})/\tau_\mathrm{color}}}.
+    /// $$
+    /// Parameters: `reference_time` ($t_0$), `T`, `T_amplitude`, `t_color`, `t_delay`
+    /// ($\tau_\mathrm{delay}$). Useful when the temperature evolution is expected to lag (or
+    /// lead) the bolometric peak rather than track it exactly.
+    DelayedSigmoid,
+}
+
+const CONSTANT_PARAMS: [&str; 1] = ["T"];
+const SIGMOID_TEMP_PARAMS: [&str; 4] = ["reference_time", "T", "T_amplitude", "t_color"];
+const DELAYED_SIGMOID_PARAMS: [&str; 5] =
+    ["reference_time", "T", "T_amplitude", "t_color", "t_delay"];
+
+impl Temperature {
+    pub(crate) fn params(&self) -> &'static [&'static str] {
+        match self {
+            Temperature::Constant => &CONSTANT_PARAMS,
+            Temperature::Sigmoid => &SIGMOID_TEMP_PARAMS,
+            Temperature::DelayedSigmoid => &DELAYED_SIGMOID_PARAMS,
+        }
+    }
+
+    pub(crate) fn n_params(&self) -> usize {
+        self.params().len()
+    }
+
+    pub(crate) fn value_jac(&self, t: f64, p: &[f64], jac: &mut [f64]) -> f64 {
+        match self {
+            Temperature::Constant => constant_temperature_jacobian(p[0], jac),
+            Temperature::Sigmoid => sigmoid_temperature_jacobian(t, p[0], p[1], p[2], p[3], jac),
+            Temperature::DelayedSigmoid => {
+                delayed_sigmoid_temperature_jacobian(t, p[0], p[1], p[2], p[3], p[4], jac)
+            }
+        }
+    }
+
+    /// Returns exactly `n_params()` values in [`Self::params`] order. Unlike Python (which
+    /// merges initial guesses by *name* and so may omit a term's shared `reference_time`), every
+    /// entry here is positional, so `reference_time` guesses are included even though they end
+    /// up unused when shared with the bolometric term (see `RainbowModel::initial_guess`, whose
+    /// assembly takes the bolometric term's guess for any name both terms declare).
+    pub(crate) fn initial_guess(&self, t: &[f64], flux: &[f64], flux_err: &[f64]) -> Vec<f64> {
+        match self {
+            Temperature::Constant => vec![8000.0],
+            Temperature::Sigmoid => {
+                let (t0, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![t0, 10_000.0, 0.0, 2.0 * dt]
+            }
+            Temperature::DelayedSigmoid => {
+                let (t0, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![t0, 10_000.0, 0.0, 2.0 * dt, 0.0]
+            }
+        }
+    }
+
+    /// Box bounds `(lower, upper)` (physical units), same order as [`Self::params`].
+    pub(crate) fn bounds(&self, t: &[f64], flux: &[f64], flux_err: &[f64]) -> Vec<(f64, f64)> {
+        const T_BOUNDS: (f64, f64) = (1e3, 2e6);
+        const T_AMPLITUDE_BOUNDS: (f64, f64) = (-0.99, 0.99);
+        match self {
+            Temperature::Constant => vec![T_BOUNDS],
+            Temperature::Sigmoid => {
+                let (t_max, t_min) = max_min(t);
+                let ptp_t = t_max - t_min;
+                let (_, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![
+                    (t_min - 10.0 * ptp_t, t_max + 10.0 * ptp_t),
+                    T_BOUNDS,
+                    T_AMPLITUDE_BOUNDS,
+                    (dt / 3.0, 10.0 * ptp_t),
+                ]
+            }
+            Temperature::DelayedSigmoid => {
+                let (t_max, t_min) = max_min(t);
+                let ptp_t = t_max - t_min;
+                let (_, dt) = t0_and_weighted_centroid_sigma(t, flux, flux_err);
+                vec![
+                    (t_min - 10.0 * ptp_t, t_max + 10.0 * ptp_t),
+                    T_BOUNDS,
+                    T_AMPLITUDE_BOUNDS,
+                    (dt / 3.0, 10.0 * ptp_t),
+                    (-ptp_t, ptp_t),
+                ]
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn finite_diff_check(
+        name: &str,
+        n: usize,
+        value_jac: impl Fn(&[f64], &mut [f64]) -> f64,
+        p: &[f64],
+    ) {
+        let mut jac = vec![0.0; n];
+        value_jac(p, &mut jac);
+        let h = 1e-6;
+        for k in 0..n {
+            let mut plus = p.to_vec();
+            let mut minus = p.to_vec();
+            plus[k] += h * plus[k].abs().max(1.0);
+            minus[k] -= h * minus[k].abs().max(1.0);
+            let step = plus[k] - minus[k];
+            let mut dummy = vec![0.0; n];
+            let f_plus = value_jac(&plus, &mut dummy);
+            let f_minus = value_jac(&minus, &mut dummy);
+            let numeric = (f_plus - f_minus) / step;
+            assert!(
+                (jac[k] - numeric).abs() <= 1e-4 * numeric.abs().max(1.0),
+                "{name} param {k}: analytic={}, numeric={}",
+                jac[k],
+                numeric
+            );
+        }
+    }
+
+    #[test]
+    fn sigmoid_temperature_jacobian_matches_finite_difference() {
+        finite_diff_check(
+            "sigmoid_temperature",
+            4,
+            |p, jac| sigmoid_temperature_jacobian(11.5, p[0], p[1], p[2], p[3], jac),
+            &[10.0, 8000.0, 0.3, 2.0],
+        );
+    }
+
+    #[test]
+    fn sigmoid_temperature_plateaus() {
+        let (t0, temperature, temperature_amplitude, t_color) = (10.0, 8000.0, 0.3, 2.0);
+        let mut jac = [0.0; 4];
+        let early = sigmoid_temperature_jacobian(
+            t0 - 1000.0,
+            t0,
+            temperature,
+            temperature_amplitude,
+            t_color,
+            &mut jac,
+        );
+        let late = sigmoid_temperature_jacobian(
+            t0 + 1000.0,
+            t0,
+            temperature,
+            temperature_amplitude,
+            t_color,
+            &mut jac,
+        );
+        assert!((early - temperature * 1.3).abs() <= 1e-9 * temperature);
+        assert!((late - temperature * 0.7).abs() <= 1e-9 * temperature);
+    }
+
+    #[test]
+    fn delayed_sigmoid_jacobian_matches_finite_difference() {
+        finite_diff_check(
+            "delayed_sigmoid",
+            5,
+            |p, jac| delayed_sigmoid_temperature_jacobian(11.5, p[0], p[1], p[2], p[3], p[4], jac),
+            &[10.0, 8000.0, 0.3, 2.0, 1.0],
+        );
+    }
+
+    #[test]
+    fn constant_temperature_is_constant() {
+        let mut jac = [0.0; 1];
+        assert_eq!(constant_temperature_jacobian(9000.0, &mut jac), 9000.0);
+        assert_eq!(jac[0], 1.0);
+    }
+}

--- a/src/nl_fit/bounds.rs
+++ b/src/nl_fit/bounds.rs
@@ -2,10 +2,8 @@ pub(super) fn within_bounds<T>(x: &[T], lower: &[T], upper: &[T]) -> bool
 where
     T: PartialOrd,
 {
-    for i in 0..x.len() {
-        if x[i] < lower[i] || x[i] > upper[i] {
-            return false;
-        }
-    }
-    true
+    x.iter()
+        .zip(lower)
+        .zip(upper)
+        .all(|((xi, li), ui)| xi >= li && xi <= ui)
 }

--- a/src/nl_fit/bounds.rs
+++ b/src/nl_fit/bounds.rs
@@ -1,12 +1,8 @@
-pub(super) fn within_bounds<T, const NPARAMS: usize>(
-    x: &[T; NPARAMS],
-    lower: &[T; NPARAMS],
-    upper: &[T; NPARAMS],
-) -> bool
+pub(super) fn within_bounds<T>(x: &[T], lower: &[T], upper: &[T]) -> bool
 where
     T: PartialOrd,
 {
-    for i in 0..NPARAMS {
+    for i in 0..x.len() {
         if x[i] < lower[i] || x[i] > upper[i] {
             return false;
         }

--- a/src/nl_fit/ceres.rs
+++ b/src/nl_fit/ceres.rs
@@ -1,6 +1,7 @@
 use crate::nl_fit::constants::PARAMETER_TOLERANCE;
 use crate::nl_fit::curve_fit::{CurveFitResult, CurveFitTrait};
 use crate::nl_fit::data::Data;
+use crate::nl_fit::evaluator::MAX_INLINE_PARAMS;
 use crate::nl_fit::prior::ln_prior::LnPriorEvaluator;
 
 use ceres_solver::{CurveFitProblem1D, CurveFunctionType, LossFunction, SolverOptions};
@@ -8,6 +9,7 @@ use ndarray::Zip;
 use ordered_float::NotNan;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use smallvec::{SmallVec, smallvec};
 use std::rc::Rc;
 
 /// Ceres-Solver non-linear least-squares wrapper
@@ -78,7 +80,8 @@ impl CurveFitTrait for CeresCurveFit {
         // Ceres calls this closure once per data point (unlike GSL, which loops over all
         // points inside a single call), so the derivative scratch buffer is allocated once
         // and reused via RefCell rather than fresh on every point.
-        let der_buf = std::cell::RefCell::new(vec![0.0; nparams]);
+        let der_buf: std::cell::RefCell<SmallVec<[f64; MAX_INLINE_PARAMS]>> =
+            std::cell::RefCell::new(smallvec![0.0; nparams]);
         let func: CurveFunctionType = {
             let model = model.clone();
             Box::new(move |t, parameters, y, jacobians| {
@@ -103,8 +106,10 @@ impl CurveFitTrait for CeresCurveFit {
             })
         };
 
-        let lower_bounds: Vec<_> = bounds.0.iter().map(|&v| Some(v)).collect();
-        let upper_bounds: Vec<_> = bounds.1.iter().map(|&v| Some(v)).collect();
+        let lower_bounds: SmallVec<[_; MAX_INLINE_PARAMS]> =
+            bounds.0.iter().map(|&v| Some(v)).collect();
+        let upper_bounds: SmallVec<[_; MAX_INLINE_PARAMS]> =
+            bounds.1.iter().map(|&v| Some(v)).collect();
 
         let options = SolverOptions::builder()
             .parameter_tolerance(PARAMETER_TOLERANCE)

--- a/src/nl_fit/ceres.rs
+++ b/src/nl_fit/ceres.rs
@@ -60,37 +60,37 @@ impl Default for CeresCurveFit {
 }
 
 impl CurveFitTrait for CeresCurveFit {
-    fn curve_fit<F, DF, LP, const NPARAMS: usize>(
+    fn curve_fit<F, DF, LP>(
         &self,
         ts: Rc<Data<f64>>,
-        x0: &[f64; NPARAMS],
-        bounds: (&[f64; NPARAMS], &[f64; NPARAMS]),
+        x0: &[f64],
+        bounds: (&[f64], &[f64]),
         model: F,
         derivatives: DF,
         _ln_prior: LP,
-    ) -> CurveFitResult<f64, NPARAMS>
+    ) -> CurveFitResult<f64>
     where
-        F: 'static + Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-        DF: 'static + Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-        LP: LnPriorEvaluator<NPARAMS>,
+        F: 'static + Clone + Fn(f64, &[f64]) -> f64,
+        DF: 'static + Clone + Fn(f64, &[f64], &mut [f64]),
+        LP: LnPriorEvaluator,
     {
+        let nparams = x0.len();
+        // Ceres calls this closure once per data point (unlike GSL, which loops over all
+        // points inside a single call), so the derivative scratch buffer is allocated once
+        // and reused via RefCell rather than fresh on every point.
+        let der_buf = std::cell::RefCell::new(vec![0.0; nparams]);
         let func: CurveFunctionType = {
             let model = model.clone();
             Box::new(move |t, parameters, y, jacobians| {
-                let parameters = parameters.try_into().unwrap();
                 *y = model(t, parameters);
                 if !y.is_finite() {
                     *y = f64::MAX.sqrt();
                     return false;
                 }
                 if let Some(jacobians) = jacobians {
-                    let jacobians: &mut [_; NPARAMS] = jacobians.try_into().unwrap();
-                    let der = {
-                        let mut der = [0.0; NPARAMS];
-                        derivatives(t, parameters, &mut der);
-                        der
-                    };
-                    for (input, output) in der.into_iter().zip(jacobians.iter_mut()) {
+                    let mut der = der_buf.borrow_mut();
+                    derivatives(t, parameters, &mut der);
+                    for (&input, output) in der.iter().zip(jacobians.iter_mut()) {
                         if let Some(output) = output {
                             if !input.is_finite() {
                                 return false;
@@ -124,7 +124,7 @@ impl CurveFitTrait for CeresCurveFit {
             problem_builder = problem_builder.loss(LossFunction::cauchy(loss_factor.into()));
         };
         let solution = problem_builder.build().unwrap().solve(&options);
-        let x = solution.parameters.try_into().unwrap();
+        let x = solution.parameters;
         let success = solution.summary.is_solution_usable();
 
         let reduced_chi2 = Zip::from(&ts.t)
@@ -133,7 +133,7 @@ impl CurveFitTrait for CeresCurveFit {
             .fold(0.0, |acc, &t, &m, &inv_err| {
                 acc + ((model(t, &x) - m) * inv_err).powi(2)
             })
-            / (ts.t.len() - NPARAMS) as f64;
+            / (ts.t.len() - nparams) as f64;
         CurveFitResult {
             x,
             reduced_chi2,
@@ -153,11 +153,11 @@ mod tests {
     use rand::prelude::*;
     use rand_distr::StandardNormal;
 
-    fn nonlinear_func(t: f64, param: &[f64; 3]) -> f64 {
+    fn nonlinear_func(t: f64, param: &[f64]) -> f64 {
         param[1] * f64::exp(-param[0] * t) * t.powi(2) + param[2]
     }
 
-    fn nonlinear_func_derivatives(t: f64, param: &[f64; 3], derivatives: &mut [f64; 3]) {
+    fn nonlinear_func_derivatives(t: f64, param: &[f64], derivatives: &mut [f64]) {
         derivatives[0] = -param[1] * f64::exp(-param[2] * t) * t.powi(3);
         derivatives[1] = f64::exp(-param[0] * t) * t.powi(2);
         derivatives[2] = 1.0;

--- a/src/nl_fit/curve_fit.rs
+++ b/src/nl_fit/curve_fit.rs
@@ -15,27 +15,27 @@ use std::fmt::Debug;
 use std::rc::Rc;
 
 #[derive(Clone, Debug)]
-pub struct CurveFitResult<T, const NPARAMS: usize> {
-    pub x: [T; NPARAMS],
+pub struct CurveFitResult<T> {
+    pub x: Vec<T>,
     pub reduced_chi2: T,
     pub success: bool,
 }
 
 #[enum_dispatch]
 pub trait CurveFitTrait: Clone + Debug + Serialize + DeserializeOwned {
-    fn curve_fit<F, DF, LP, const NPARAMS: usize>(
+    fn curve_fit<F, DF, LP>(
         &self,
         ts: Rc<Data<f64>>,
-        x0: &[f64; NPARAMS],
-        bounds: (&[f64; NPARAMS], &[f64; NPARAMS]),
+        x0: &[f64],
+        bounds: (&[f64], &[f64]),
         model: F,
         derivatives: DF,
         ln_prior: LP,
-    ) -> CurveFitResult<f64, NPARAMS>
+    ) -> CurveFitResult<f64>
     where
-        F: 'static + Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-        DF: 'static + Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-        LP: LnPriorEvaluator<NPARAMS>;
+        F: 'static + Clone + Fn(f64, &[f64]) -> f64,
+        DF: 'static + Clone + Fn(f64, &[f64], &mut [f64]),
+        LP: LnPriorEvaluator;
 }
 
 /// Optimization algorithm for non-linear least squares

--- a/src/nl_fit/evaluator.rs
+++ b/src/nl_fit/evaluator.rs
@@ -3,224 +3,109 @@ use crate::float_trait::Float;
 use crate::nl_fit::{CurveFitAlgorithm, LikeFloat, LnPrior, data::NormalizedData};
 
 use schemars::JsonSchema;
-use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
+use smallvec::SmallVec;
 
-pub trait FitModelTrait<T, U, const NPARAMS: usize>
+/// Inline capacity for [`FitParametersInternalDimlessTrait`]'s per-point-hot transforms: covers
+/// every current fixed-`NPARAMS` feature (Bazin=5, Linexp=4, Villar=7) without spilling to the
+/// heap. Larger parameter counts still work, just via a heap allocation past this size.
+pub const MAX_INLINE_PARAMS: usize = 8;
+
+pub trait FitModelTrait<T, U>
 where
     T: Float + Into<U>,
     U: LikeFloat,
 {
-    fn model(t: T, param: &[U; NPARAMS]) -> U
+    fn model(t: T, param: &[U]) -> U
     where
         T: Float + Into<U>,
         U: LikeFloat;
 }
 
-pub trait FitFunctionTrait<T: Float, const NPARAMS: usize>:
-    FitModelTrait<T, T, NPARAMS> + FitParametersInternalDimlessTrait<T, NPARAMS>
+pub trait FitFunctionTrait<T: Float>:
+    FitModelTrait<T, T> + FitParametersInternalDimlessTrait<T>
 {
     fn f(t: T, values: &[T]) -> T {
-        let internal = Self::dimensionless_to_internal(
-            values[..NPARAMS]
-                .try_into()
-                .expect("values slice's length is too small"),
-        );
+        let internal = Self::dimensionless_to_internal(values);
         Self::model(t, &internal)
     }
 }
 
-pub trait FitDerivalivesTrait<T: Float, const NPARAMS: usize> {
-    fn derivatives(t: T, param: &[T; NPARAMS], jac: &mut [T; NPARAMS]);
+pub trait FitDerivalivesTrait<T: Float> {
+    fn derivatives(t: T, param: &[T], jac: &mut [T]);
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
-#[serde(
-    into = "FitArraySerde<T>",
-    try_from = "FitArraySerde<T>",
-    bound = "T: Debug + Clone + Serialize + DeserializeOwned + JsonSchema"
-)]
-pub struct FitArray<T, const NPARAMS: usize>(pub [T; NPARAMS]);
-
-impl<T, const NPARAMS: usize> JsonSchema for FitArray<T, NPARAMS>
-where
-    T: schemars::JsonSchema,
-{
-    fn is_referenceable() -> bool {
-        false
-    }
-
-    fn schema_name() -> String {
-        FitArraySerde::<T>::schema_name()
-    }
-
-    fn json_schema(r#gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
-        FitArraySerde::<T>::json_schema(r#gen)
-    }
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct FitInitsBoundsArrays {
+    pub init: Vec<f64>,
+    pub lower: Vec<f64>,
+    pub upper: Vec<f64>,
 }
 
-impl<T, const NPARAMS: usize> From<[T; NPARAMS]> for FitArray<T, NPARAMS> {
-    fn from(item: [T; NPARAMS]) -> Self {
-        Self(item)
-    }
-}
-
-impl<T, const NPARAMS: usize> std::ops::Deref for FitArray<T, NPARAMS> {
-    type Target = [T; NPARAMS];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T, const NPARAMS: usize> From<FitArray<T, NPARAMS>> for FitArray<Option<T>, NPARAMS>
-where
-    T: Copy,
-{
-    fn from(item: FitArray<T, NPARAMS>) -> Self {
-        let mut opt = [None; NPARAMS];
-        for (&x, y) in item.0.iter().zip(opt.iter_mut()) {
-            *y = Some(x);
-        }
-        opt.into()
-    }
-}
-
-impl<T, const NPARAMS: usize> FitArray<Option<T>, NPARAMS>
-where
-    T: Clone,
-{
-    fn unwrap_with(&self, with: &FitArray<T, NPARAMS>) -> FitArray<T, NPARAMS> {
-        let mut a = with.clone();
-        for (opt, x) in self.0.iter().zip(a.0.iter_mut()) {
-            if let Some(value) = opt {
-                *x = value.clone()
-            }
-        }
-        a
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(
-    rename = "FitArray",
-    bound = "T: Debug + Clone + Serialize + DeserializeOwned + JsonSchema"
-)]
-struct FitArraySerde<T>(Vec<T>);
-
-impl<T, const NPARAMS: usize> From<FitArray<T, NPARAMS>> for FitArraySerde<T> {
-    fn from(item: FitArray<T, NPARAMS>) -> Self {
-        Self(item.0.into())
-    }
-}
-
-impl<T, const NPARAMS: usize> TryFrom<FitArraySerde<T>> for FitArray<T, NPARAMS> {
-    type Error = &'static str;
-
-    fn try_from(item: FitArraySerde<T>) -> Result<Self, Self::Error> {
-        Ok(Self(
-            item.0
-                .try_into()
-                .map_err(|_| "wrong size of the FitArray object")?,
-        ))
+impl FitInitsBoundsArrays {
+    pub fn new(init: Vec<f64>, lower: Vec<f64>, upper: Vec<f64>) -> Self {
+        Self { init, lower, upper }
     }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
-pub struct FitInitsBoundsArrays<const NPARAMS: usize> {
-    pub init: FitArray<f64, NPARAMS>,
-    pub lower: FitArray<f64, NPARAMS>,
-    pub upper: FitArray<f64, NPARAMS>,
+pub struct OptionFitInitsBoundsArrays {
+    pub init: Vec<Option<f64>>,
+    pub lower: Vec<Option<f64>>,
+    pub upper: Vec<Option<f64>>,
 }
 
-impl<const NPARAMS: usize> FitInitsBoundsArrays<NPARAMS> {
-    pub fn new(init: [f64; NPARAMS], lower: [f64; NPARAMS], upper: [f64; NPARAMS]) -> Self {
-        Self {
-            init: init.into(),
-            lower: lower.into(),
-            upper: upper.into(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
-pub struct OptionFitInitsBoundsArrays<const NPARAMS: usize> {
-    pub init: FitArray<Option<f64>, NPARAMS>,
-    pub lower: FitArray<Option<f64>, NPARAMS>,
-    pub upper: FitArray<Option<f64>, NPARAMS>,
-}
-
-impl<const NPARAMS: usize> OptionFitInitsBoundsArrays<NPARAMS> {
-    pub fn new(
-        init: [Option<f64>; NPARAMS],
-        lower: [Option<f64>; NPARAMS],
-        upper: [Option<f64>; NPARAMS],
-    ) -> Self {
-        Self {
-            init: init.into(),
-            lower: lower.into(),
-            upper: upper.into(),
-        }
+impl OptionFitInitsBoundsArrays {
+    pub fn new(init: Vec<Option<f64>>, lower: Vec<Option<f64>>, upper: Vec<Option<f64>>) -> Self {
+        Self { init, lower, upper }
     }
 
-    pub fn unwrap_with(&self, x: &FitInitsBoundsArrays<NPARAMS>) -> FitInitsBoundsArrays<NPARAMS> {
+    pub fn unwrap_with(&self, x: &FitInitsBoundsArrays) -> FitInitsBoundsArrays {
+        let unwrap_slice = |opt: &[Option<f64>], with: &[f64]| -> Vec<f64> {
+            opt.iter().zip(with).map(|(o, &w)| o.unwrap_or(w)).collect()
+        };
         FitInitsBoundsArrays {
-            init: self.init.unwrap_with(&x.init),
-            lower: self.lower.unwrap_with(&x.lower),
-            upper: self.upper.unwrap_with(&x.upper),
+            init: unwrap_slice(&self.init, &x.init),
+            lower: unwrap_slice(&self.lower, &x.lower),
+            upper: unwrap_slice(&self.upper, &x.upper),
         }
     }
 }
 
-impl<const NPARAMS: usize> From<FitInitsBoundsArrays<NPARAMS>>
-    for OptionFitInitsBoundsArrays<NPARAMS>
-{
-    fn from(item: FitInitsBoundsArrays<NPARAMS>) -> Self {
+impl From<FitInitsBoundsArrays> for OptionFitInitsBoundsArrays {
+    fn from(item: FitInitsBoundsArrays) -> Self {
         Self {
-            init: item.init.into(),
-            lower: item.lower.into(),
-            upper: item.upper.into(),
+            init: item.init.into_iter().map(Some).collect(),
+            lower: item.lower.into_iter().map(Some).collect(),
+            upper: item.upper.into_iter().map(Some).collect(),
         }
     }
 }
 
-pub trait FitInitsBoundsTrait<T: Float, const NPARAMS: usize> {
-    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS>;
+pub trait FitInitsBoundsTrait<T: Float> {
+    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays;
 }
 
-pub trait FitParametersInternalDimlessTrait<U: LikeFloat, const NPARAMS: usize> {
-    fn dimensionless_to_internal(params: &[U; NPARAMS]) -> [U; NPARAMS];
+pub trait FitParametersInternalDimlessTrait<U: LikeFloat> {
+    fn dimensionless_to_internal(params: &[U]) -> SmallVec<[U; MAX_INLINE_PARAMS]>;
 
-    fn internal_to_dimensionless(params: &[U; NPARAMS]) -> [U; NPARAMS];
+    fn internal_to_dimensionless(params: &[U]) -> SmallVec<[U; MAX_INLINE_PARAMS]>;
 }
 
-pub trait FitParametersOriginalDimLessTrait<const NPARAMS: usize> {
-    fn orig_to_dimensionless(
-        norm_data: &NormalizedData<f64>,
-        orig: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS];
+pub trait FitParametersOriginalDimLessTrait {
+    fn orig_to_dimensionless(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64>;
 
-    fn dimensionless_to_orig(
-        norm_data: &NormalizedData<f64>,
-        norm: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS];
+    fn dimensionless_to_orig(norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64>;
 }
 
-pub trait FitParametersInternalExternalTrait<const NPARAMS: usize>:
-    FitParametersInternalDimlessTrait<f64, NPARAMS> + FitParametersOriginalDimLessTrait<NPARAMS>
+pub trait FitParametersInternalExternalTrait:
+    FitParametersInternalDimlessTrait<f64> + FitParametersOriginalDimLessTrait
 {
-    fn convert_to_internal(
-        norm_data: &NormalizedData<f64>,
-        orig: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
-        Self::dimensionless_to_internal(&Self::orig_to_dimensionless(norm_data, orig))
+    fn convert_to_internal(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
+        Self::dimensionless_to_internal(&Self::orig_to_dimensionless(norm_data, orig)).into_vec()
     }
 
-    fn convert_to_external(
-        norm_data: &NormalizedData<f64>,
-        params: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
+    fn convert_to_external(norm_data: &NormalizedData<f64>, params: &[f64]) -> Vec<f64> {
         Self::dimensionless_to_orig(norm_data, &Self::internal_to_dimensionless(params))
     }
 
@@ -240,14 +125,12 @@ pub trait FitParametersInternalExternalTrait<const NPARAMS: usize>:
     /// 2. `dimensionless_to_orig`: linear scaling by `t_std`, `m_std`, etc.
     ///
     /// Since both transformations are element-wise, the full Jacobian is diagonal.
-    fn jacobian_internal_to_external(
-        norm_data: &NormalizedData<f64>,
-        internal: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS];
+    fn jacobian_internal_to_external(norm_data: &NormalizedData<f64>, internal: &[f64])
+    -> Vec<f64>;
 }
 
-pub trait FitFeatureEvaluatorGettersTrait<const NPARAMS: usize> {
+pub trait FitFeatureEvaluatorGettersTrait {
     fn get_algorithm(&self) -> &CurveFitAlgorithm;
 
-    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS>;
+    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior;
 }

--- a/src/nl_fit/evaluator.rs
+++ b/src/nl_fit/evaluator.rs
@@ -93,19 +93,31 @@ pub trait FitParametersInternalDimlessTrait<U: LikeFloat> {
 }
 
 pub trait FitParametersOriginalDimLessTrait {
-    fn orig_to_dimensionless(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64>;
+    fn orig_to_dimensionless(
+        norm_data: &NormalizedData<f64>,
+        orig: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]>;
 
-    fn dimensionless_to_orig(norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64>;
+    fn dimensionless_to_orig(
+        norm_data: &NormalizedData<f64>,
+        norm: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]>;
 }
 
 pub trait FitParametersInternalExternalTrait:
     FitParametersInternalDimlessTrait<f64> + FitParametersOriginalDimLessTrait
 {
-    fn convert_to_internal(norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
-        Self::dimensionless_to_internal(&Self::orig_to_dimensionless(norm_data, orig)).into_vec()
+    fn convert_to_internal(
+        norm_data: &NormalizedData<f64>,
+        orig: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
+        Self::dimensionless_to_internal(&Self::orig_to_dimensionless(norm_data, orig))
     }
 
-    fn convert_to_external(norm_data: &NormalizedData<f64>, params: &[f64]) -> Vec<f64> {
+    fn convert_to_external(
+        norm_data: &NormalizedData<f64>,
+        params: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]> {
         Self::dimensionless_to_orig(norm_data, &Self::internal_to_dimensionless(params))
     }
 
@@ -125,8 +137,10 @@ pub trait FitParametersInternalExternalTrait:
     /// 2. `dimensionless_to_orig`: linear scaling by `t_std`, `m_std`, etc.
     ///
     /// Since both transformations are element-wise, the full Jacobian is diagonal.
-    fn jacobian_internal_to_external(norm_data: &NormalizedData<f64>, internal: &[f64])
-    -> Vec<f64>;
+    fn jacobian_internal_to_external(
+        norm_data: &NormalizedData<f64>,
+        internal: &[f64],
+    ) -> SmallVec<[f64; MAX_INLINE_PARAMS]>;
 }
 
 pub trait FitFeatureEvaluatorGettersTrait {

--- a/src/nl_fit/lmsder.rs
+++ b/src/nl_fit/lmsder.rs
@@ -50,24 +50,25 @@ impl Default for LmsderCurveFit {
 }
 
 impl CurveFitTrait for LmsderCurveFit {
-    fn curve_fit<F, DF, LP, const NPARAMS: usize>(
+    fn curve_fit<F, DF, LP>(
         &self,
         ts: Rc<Data<f64>>,
-        x0: &[f64; NPARAMS],
-        _bounds: (&[f64; NPARAMS], &[f64; NPARAMS]),
+        x0: &[f64],
+        _bounds: (&[f64], &[f64]),
         model: F,
         derivatives: DF,
         _ln_prior: LP,
-    ) -> CurveFitResult<f64, NPARAMS>
+    ) -> CurveFitResult<f64>
     where
-        F: 'static + Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-        DF: 'static + Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-        LP: LnPriorEvaluator<NPARAMS>,
+        F: 'static + Clone + Fn(f64, &[f64]) -> f64,
+        DF: 'static + Clone + Fn(f64, &[f64], &mut [f64]),
+        LP: LnPriorEvaluator,
     {
+        let nparams = x0.len();
         let f = {
             let ts = ts.clone();
             move |param: VectorF64, mut residual: VectorF64| {
-                let param = param.as_slice().unwrap().try_into().unwrap();
+                let param = param.as_slice().unwrap();
                 Zip::from(&ts.t)
                     .and(&ts.m)
                     .and(&ts.inv_err)
@@ -81,8 +82,8 @@ impl CurveFitTrait for LmsderCurveFit {
         let df = {
             let ts = ts.clone();
             move |param: VectorF64, mut jacobian: MatrixF64| {
-                let param = param.as_slice().unwrap().try_into().unwrap();
-                let mut buffer = [0.0; NPARAMS];
+                let param = param.as_slice().unwrap();
+                let mut buffer = vec![0.0; nparams];
                 Zip::indexed(&ts.t)
                     .and(&ts.inv_err)
                     .for_each(|i, &t, &inv_err| {
@@ -95,18 +96,14 @@ impl CurveFitTrait for LmsderCurveFit {
             }
         };
 
-        let mut problem = NlsProblem::from_f_df(ts.t.len(), NPARAMS, f, df);
+        let mut problem = NlsProblem::from_f_df(ts.t.len(), nparams, f, df);
         problem.max_iter = self.niterations;
         let result = problem.solve(VectorF64::from_slice(x0).unwrap());
-        let x = {
-            let x = result.x();
-            let x: &[_; NPARAMS] = x.as_slice().unwrap().try_into().unwrap();
-            *x
-        };
+        let x = result.x().as_slice().unwrap().to_vec();
 
         CurveFitResult {
             x,
-            reduced_chi2: result.loss() / ((ts.t.len() - NPARAMS) as f64),
+            reduced_chi2: result.loss() / ((ts.t.len() - nparams) as f64),
             success: result.status == Value::Success,
         }
     }

--- a/src/nl_fit/lmsder.rs
+++ b/src/nl_fit/lmsder.rs
@@ -3,6 +3,7 @@ use crate::float_trait::Float;
 use crate::nl_fit::constants::PARAMETER_TOLERANCE;
 use crate::nl_fit::curve_fit::{CurveFitResult, CurveFitTrait};
 use crate::nl_fit::data::Data;
+use crate::nl_fit::evaluator::MAX_INLINE_PARAMS;
 use crate::nl_fit::prior::ln_prior::LnPriorEvaluator;
 
 #[cfg(test)]
@@ -16,6 +17,7 @@ use rgsl::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use smallvec::smallvec;
 #[cfg(test)]
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -83,7 +85,8 @@ impl CurveFitTrait for LmsderCurveFit {
             let ts = ts.clone();
             move |param: VectorF64, mut jacobian: MatrixF64| {
                 let param = param.as_slice().unwrap();
-                let mut buffer = vec![0.0; nparams];
+                let mut buffer: smallvec::SmallVec<[f64; MAX_INLINE_PARAMS]> =
+                    smallvec![0.0; nparams];
                 Zip::indexed(&ts.t)
                     .and(&ts.inv_err)
                     .for_each(|i, &t, &inv_err| {

--- a/src/nl_fit/mcmc.rs
+++ b/src/nl_fit/mcmc.rs
@@ -6,7 +6,6 @@ use crate::nl_fit::prior::ln_prior::LnPriorEvaluator;
 
 use emcee::{EnsembleSampler, Guess, Prob};
 use emcee_rand::{distributions::IndependentSample, *};
-use itertools::Itertools;
 use ndarray::Zip;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -59,22 +58,23 @@ impl Default for McmcCurveFit {
 }
 
 impl CurveFitTrait for McmcCurveFit {
-    fn curve_fit<F, DF, LP, const NPARAMS: usize>(
+    fn curve_fit<F, DF, LP>(
         &self,
         ts: Rc<Data<f64>>,
-        x0: &[f64; NPARAMS],
-        bounds: (&[f64; NPARAMS], &[f64; NPARAMS]),
+        x0: &[f64],
+        bounds: (&[f64], &[f64]),
         model: F,
         derivatives: DF,
         ln_prior: LP,
-    ) -> CurveFitResult<f64, NPARAMS>
+    ) -> CurveFitResult<f64>
     where
-        F: 'static + Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-        DF: 'static + Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-        LP: LnPriorEvaluator<NPARAMS>,
+        F: 'static + Clone + Fn(f64, &[f64]) -> f64,
+        DF: 'static + Clone + Fn(f64, &[f64], &mut [f64]),
+        LP: LnPriorEvaluator,
     {
         const NWALKERS_PER_DIMENSION: usize = 4;
-        let nwalkers = NWALKERS_PER_DIMENSION * NPARAMS;
+        let nparams = x0.len();
+        let nwalkers = NWALKERS_PER_DIMENSION * nparams;
         let nsamples = ts.t.len();
 
         let lnlike = {
@@ -82,7 +82,7 @@ impl CurveFitTrait for McmcCurveFit {
             let model = model.clone();
             move |guess: &Guess| {
                 let mut residual = 0.0;
-                let params = slice_to_array(&guess.values);
+                let params = slice_to_vec(&guess.values);
                 Zip::from(&ts.t)
                     .and(&ts.m)
                     .and(&ts.inv_err)
@@ -95,13 +95,13 @@ impl CurveFitTrait for McmcCurveFit {
         let lnprior = {
             let ln_prior = ln_prior.clone();
             move |guess: &Guess| {
-                let params = slice_to_array(&guess.values);
+                let params = slice_to_vec(&guess.values);
                 ln_prior.ln_prior(&params, None) as f32
             }
         };
 
-        let x0_f32: [_; NPARAMS] = slice_to_array(x0);
-        let bounds_f32 = (slice_to_array(bounds.0), slice_to_array(bounds.1));
+        let x0_f32: Vec<f32> = slice_to_vec(x0);
+        let bounds_f32 = (slice_to_vec(bounds.0), slice_to_vec(bounds.1));
 
         let initial_guesses = generate_initial_guesses(
             nwalkers,
@@ -116,7 +116,7 @@ impl CurveFitTrait for McmcCurveFit {
             lower: &bounds_f32.0,
             upper: &bounds_f32.1,
         };
-        let mut sampler = EnsembleSampler::new(nwalkers, NPARAMS, &emcee_model).unwrap();
+        let mut sampler = EnsembleSampler::new(nwalkers, nparams, &emcee_model).unwrap();
         sampler.seed(&[]);
 
         let (best_x, best_lnprob) = {
@@ -139,17 +139,10 @@ impl CurveFitTrait for McmcCurveFit {
         };
 
         match self.fine_tuning_algorithm.as_ref() {
-            Some(algo) => algo.curve_fit(
-                ts,
-                &best_x.try_into().unwrap(),
-                bounds,
-                model,
-                derivatives,
-                ln_prior,
-            ),
+            Some(algo) => algo.curve_fit(ts, &best_x, bounds, model, derivatives, ln_prior),
             None => CurveFitResult {
-                x: best_x.try_into().unwrap(),
-                reduced_chi2: -best_lnprob / ((nsamples - NPARAMS) as f64),
+                x: best_x,
+                reduced_chi2: -best_lnprob / ((nsamples - nparams) as f64),
                 success: true,
             },
         }
@@ -157,23 +150,21 @@ impl CurveFitTrait for McmcCurveFit {
 }
 
 #[inline]
-fn slice_to_array<T, U, const NPARAMS: usize>(sl: &[T]) -> [U; NPARAMS]
+fn slice_to_vec<T, U>(sl: &[T]) -> Vec<U>
 where
     T: Float,
     U: Float,
 {
-    let mut array = [U::zero(); NPARAMS];
-    for (input, output) in sl.iter().zip_eq(array.iter_mut()) {
-        *output = num_traits::cast::cast(*input).unwrap();
-    }
-    array
+    sl.iter()
+        .map(|&x| num_traits::cast::cast(x).unwrap())
+        .collect()
 }
 
 #[inline]
-fn generate_initial_guesses<R, const NPARAMS: usize>(
+fn generate_initial_guesses<R>(
     nwalkers: usize,
-    x0: &[f32; NPARAMS],
-    bounds: (&[f32; NPARAMS], &[f32; NPARAMS]),
+    x0: &[f32],
+    bounds: (&[f32], &[f32]),
     rng: &mut R,
 ) -> Vec<Guess>
 where
@@ -221,14 +212,14 @@ where
         .collect()
 }
 
-struct EmceeModel<'b, F, LP, const NPARAMS: usize> {
+struct EmceeModel<'b, F, LP> {
     ln_like: F,
     ln_prior: LP,
-    lower: &'b [f32; NPARAMS],
-    upper: &'b [f32; NPARAMS],
+    lower: &'b [f32],
+    upper: &'b [f32],
 }
 
-impl<F, LP, const NPARAMS: usize> Prob for EmceeModel<'_, F, LP, NPARAMS>
+impl<F, LP> Prob for EmceeModel<'_, F, LP>
 where
     F: Fn(&Guess) -> f32,
     LP: Fn(&Guess) -> f32,
@@ -238,11 +229,7 @@ where
     }
 
     fn lnprior(&self, params: &Guess) -> f32 {
-        if !within_bounds(
-            (&params.values[..]).try_into().unwrap(),
-            self.lower,
-            self.upper,
-        ) {
+        if !within_bounds(&params.values, self.lower, self.upper) {
             return f32::NEG_INFINITY;
         }
         (self.ln_prior)(params)

--- a/src/nl_fit/mcmc.rs
+++ b/src/nl_fit/mcmc.rs
@@ -2,6 +2,7 @@ use crate::float_trait::Float;
 use crate::nl_fit::bounds::within_bounds;
 use crate::nl_fit::curve_fit::{CurveFitAlgorithm, CurveFitResult, CurveFitTrait};
 use crate::nl_fit::data::Data;
+use crate::nl_fit::evaluator::MAX_INLINE_PARAMS;
 use crate::nl_fit::prior::ln_prior::LnPriorEvaluator;
 
 use emcee::{EnsembleSampler, Guess, Prob};
@@ -9,6 +10,7 @@ use emcee_rand::{distributions::IndependentSample, *};
 use ndarray::Zip;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 use std::fmt::Debug;
 use std::rc::Rc;
 
@@ -100,7 +102,7 @@ impl CurveFitTrait for McmcCurveFit {
             }
         };
 
-        let x0_f32: Vec<f32> = slice_to_vec(x0);
+        let x0_f32: SmallVec<[f32; MAX_INLINE_PARAMS]> = slice_to_vec(x0);
         let bounds_f32 = (slice_to_vec(bounds.0), slice_to_vec(bounds.1));
 
         let initial_guesses = generate_initial_guesses(
@@ -150,7 +152,7 @@ impl CurveFitTrait for McmcCurveFit {
 }
 
 #[inline]
-fn slice_to_vec<T, U>(sl: &[T]) -> Vec<U>
+fn slice_to_vec<T, U>(sl: &[T]) -> SmallVec<[U; MAX_INLINE_PARAMS]>
 where
     T: Float,
     U: Float,

--- a/src/nl_fit/mod.rs
+++ b/src/nl_fit/mod.rs
@@ -95,7 +95,7 @@
 //! Models implement [`FitModelTrait`](evaluator::FitModelTrait):
 //!
 //! ```text
-//! fn model(t: T, internal_params: &[U; NPARAMS]) -> U
+//! fn model(t: T, internal_params: &[U]) -> U
 //! ```
 //!
 //! The model receives **internal** parameters and typically transforms them to dimensionless

--- a/src/nl_fit/nuts.rs
+++ b/src/nl_fit/nuts.rs
@@ -68,16 +68,15 @@ impl Default for NutsCurveFit {
     }
 }
 
+/// `logp` no longer has a fallible conversion step (it now takes `params: &[f64]` directly,
+/// rather than converting to a fixed-size array first), so this error can never actually be
+/// constructed -- kept as an uninhabited type only because `CpuLogpFunc::LogpError` requires one.
 #[derive(Debug)]
-enum NutsLogpError {
-    NonRecoverable,
-}
+enum NutsLogpError {}
 
 impl std::fmt::Display for NutsLogpError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            NutsLogpError::NonRecoverable => write!(f, "Non-recoverable error in logp calculation"),
-        }
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {}
     }
 }
 
@@ -85,69 +84,68 @@ impl std::error::Error for NutsLogpError {}
 
 impl LogpError for NutsLogpError {
     fn is_recoverable(&self) -> bool {
-        false
+        match *self {}
     }
 }
 
-struct LogpFunc<F, DF, LP, const NPARAMS: usize> {
+struct LogpFunc<F, DF, LP> {
     ts: Rc<Data<f64>>,
     model: F,
     derivatives: DF,
     ln_prior: LP,
-    lower: [f64; NPARAMS],
-    upper: [f64; NPARAMS],
+    lower: Vec<f64>,
+    upper: Vec<f64>,
 }
 
-impl<F, DF, LP, const NPARAMS: usize> HasDims for LogpFunc<F, DF, LP, NPARAMS> {
+impl<F, DF, LP> HasDims for LogpFunc<F, DF, LP> {
     fn dim_sizes(&self) -> HashMap<String, u64> {
+        let nparams = self.lower.len() as u64;
         HashMap::from([
-            ("unconstrained_parameter".to_string(), NPARAMS as u64),
-            ("dim".to_string(), NPARAMS as u64),
+            ("unconstrained_parameter".to_string(), nparams),
+            ("dim".to_string(), nparams),
         ])
     }
 }
 
-impl<F, DF, LP, const NPARAMS: usize> CpuLogpFunc for LogpFunc<F, DF, LP, NPARAMS>
+impl<F, DF, LP> CpuLogpFunc for LogpFunc<F, DF, LP>
 where
-    F: Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-    DF: Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-    LP: LnPriorEvaluator<NPARAMS>,
+    F: Clone + Fn(f64, &[f64]) -> f64,
+    DF: Clone + Fn(f64, &[f64], &mut [f64]),
+    LP: LnPriorEvaluator,
 {
     type LogpError = NutsLogpError;
     type FlowParameters = ();
     type ExpandedVector = Vec<f64>;
 
     fn dim(&self) -> usize {
-        NPARAMS
+        self.lower.len()
     }
 
     fn logp(&mut self, params: &[f64], grad: &mut [f64]) -> Result<f64, Self::LogpError> {
-        // Check boundaries
-        let params_array: [f64; NPARAMS] = params
-            .try_into()
-            .map_err(|_| NutsLogpError::NonRecoverable)?;
+        let nparams = self.lower.len();
 
-        if !within_bounds(&params_array, &self.lower, &self.upper) {
+        // Check boundaries
+        if !within_bounds(params, &self.lower, &self.upper) {
             return Ok(f64::NEG_INFINITY);
         }
 
         // Calculate log-likelihood (negative chi-squared)
         let mut residual = 0.0;
-        let mut grad_array = [0.0; NPARAMS];
+        let mut grad_array = vec![0.0; nparams];
 
         // Compute -chi^2/2 and its gradient
+        let mut model_grad = vec![0.0; nparams];
         Zip::from(&self.ts.t)
             .and(&self.ts.m)
             .and(&self.ts.inv_err)
             .for_each(|&t, &m, &inv_err| {
-                let model_val = (self.model)(t, &params_array);
+                let model_val = (self.model)(t, params);
                 let diff = model_val - m;
                 residual += (inv_err * diff).powi(2);
 
                 // Gradient of chi^2 with respect to parameters
-                let mut model_grad = [0.0; NPARAMS];
-                (self.derivatives)(t, &params_array, &mut model_grad);
-                for i in 0..NPARAMS {
+                (self.derivatives)(t, params, &mut model_grad);
+                for i in 0..nparams {
                     grad_array[i] += 2.0 * inv_err.powi(2) * diff * model_grad[i];
                 }
             });
@@ -155,13 +153,13 @@ where
         let lnlike = -0.5 * residual;
 
         // Add prior and compute its gradient
-        let mut prior_grad = [0.0; NPARAMS];
-        let lnprior = self.ln_prior.ln_prior(&params_array, Some(&mut prior_grad));
+        let mut prior_grad = vec![0.0; nparams];
+        let lnprior = self.ln_prior.ln_prior(params, Some(&mut prior_grad));
 
         // Gradient is d(lnlike + lnprior)/d(params)
         // = d(lnlike)/d(params) + d(lnprior)/d(params)
         // = -0.5 * d(chi^2)/d(params) + d(lnprior)/d(params)
-        for i in 0..NPARAMS {
+        for i in 0..nparams {
             grad[i] = -0.5 * grad_array[i] + prior_grad[i];
         }
 
@@ -178,20 +176,21 @@ where
 }
 
 impl CurveFitTrait for NutsCurveFit {
-    fn curve_fit<F, DF, LP, const NPARAMS: usize>(
+    fn curve_fit<F, DF, LP>(
         &self,
         ts: Rc<Data<f64>>,
-        x0: &[f64; NPARAMS],
-        bounds: (&[f64; NPARAMS], &[f64; NPARAMS]),
+        x0: &[f64],
+        bounds: (&[f64], &[f64]),
         model: F,
         derivatives: DF,
         ln_prior: LP,
-    ) -> CurveFitResult<f64, NPARAMS>
+    ) -> CurveFitResult<f64>
     where
-        F: 'static + Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-        DF: 'static + Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-        LP: LnPriorEvaluator<NPARAMS>,
+        F: 'static + Clone + Fn(f64, &[f64]) -> f64,
+        DF: 'static + Clone + Fn(f64, &[f64], &mut [f64]),
+        LP: LnPriorEvaluator,
     {
+        let nparams = x0.len();
         let nsamples = ts.t.len();
 
         let logp_func = LogpFunc {
@@ -199,8 +198,8 @@ impl CurveFitTrait for NutsCurveFit {
             model: model.clone(),
             derivatives: derivatives.clone(),
             ln_prior: ln_prior.clone(),
-            lower: *bounds.0,
-            upper: *bounds.1,
+            lower: bounds.0.to_vec(),
+            upper: bounds.1.to_vec(),
         };
 
         let math = CpuMath::new(logp_func);
@@ -215,7 +214,7 @@ impl CurveFitTrait for NutsCurveFit {
         let mut sampler = settings.new_chain(0, math, &mut rng);
 
         // Set initial position
-        sampler.set_position(&x0[..]).unwrap_or_else(|e| {
+        sampler.set_position(x0).unwrap_or_else(|e| {
             panic!(
                 "Failed to set initial position for NUTS sampler. \
                      This may be due to invalid parameters or boundary violations. \
@@ -225,16 +224,13 @@ impl CurveFitTrait for NutsCurveFit {
         });
 
         // Collect samples
-        let mut best_x = *x0;
+        let mut best_x = x0.to_vec();
         let mut best_lnprob = f64::NEG_INFINITY;
 
         for _ in 0..(self.num_tune + self.num_draws) {
             match sampler.expanded_draw() {
                 Ok((draw, _expanded, stats, _progress)) => {
-                    // Convert draw to array
-                    let params: [f64; NPARAMS] = Vec::from(draw)
-                        .try_into()
-                        .expect("Failed to convert draw to array");
+                    let params = Vec::from(draw);
 
                     // Use the log probability from the sampler stats
                     let lnprob = stats.point.logp;
@@ -262,7 +258,7 @@ impl CurveFitTrait for NutsCurveFit {
                     .for_each(|&t, &m, &inv_err| {
                         residual += (inv_err * (model(t, &best_x) - m)).powi(2);
                     });
-                let reduced_chi2 = residual / ((nsamples - NPARAMS) as f64);
+                let reduced_chi2 = residual / ((nsamples - nparams) as f64);
 
                 CurveFitResult {
                     x: best_x,
@@ -281,7 +277,7 @@ mod tests {
     use crate::nl_fit::data::NormalizedData;
     use crate::nl_fit::evaluator::{
         FitParametersInternalDimlessTrait, FitParametersInternalExternalTrait,
-        FitParametersOriginalDimLessTrait,
+        FitParametersOriginalDimLessTrait, MAX_INLINE_PARAMS,
     };
     use crate::nl_fit::prior::ln_prior::LnPrior;
     use crate::nl_fit::prior::ln_prior_1d::LnPrior1D;
@@ -298,36 +294,40 @@ mod tests {
     /// with external = dimensionless (no additional scaling).
     struct SimpleConstantModel;
 
-    impl FitParametersInternalDimlessTrait<f64, 1> for SimpleConstantModel {
-        fn dimensionless_to_internal(params: &[f64; 1]) -> [f64; 1] {
-            *params
+    impl FitParametersInternalDimlessTrait<f64> for SimpleConstantModel {
+        fn dimensionless_to_internal(
+            params: &[f64],
+        ) -> smallvec::SmallVec<[f64; MAX_INLINE_PARAMS]> {
+            smallvec::SmallVec::from_slice(params)
         }
 
-        fn internal_to_dimensionless(params: &[f64; 1]) -> [f64; 1] {
-            [params[0].abs()] // Apply abs() transformation
-        }
-    }
-
-    impl FitParametersOriginalDimLessTrait<1> for SimpleConstantModel {
-        fn orig_to_dimensionless(_norm_data: &NormalizedData<f64>, orig: &[f64; 1]) -> [f64; 1] {
-            // No scaling - external = dimensionless for this simple model
-            *orig
-        }
-
-        fn dimensionless_to_orig(_norm_data: &NormalizedData<f64>, norm: &[f64; 1]) -> [f64; 1] {
-            // No scaling - external = dimensionless for this simple model
-            *norm
+        fn internal_to_dimensionless(
+            params: &[f64],
+        ) -> smallvec::SmallVec<[f64; MAX_INLINE_PARAMS]> {
+            smallvec::smallvec![params[0].abs()] // Apply abs() transformation
         }
     }
 
-    impl FitParametersInternalExternalTrait<1> for SimpleConstantModel {
+    impl FitParametersOriginalDimLessTrait for SimpleConstantModel {
+        fn orig_to_dimensionless(_norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
+            // No scaling - external = dimensionless for this simple model
+            orig.to_vec()
+        }
+
+        fn dimensionless_to_orig(_norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
+            // No scaling - external = dimensionless for this simple model
+            norm.to_vec()
+        }
+    }
+
+    impl FitParametersInternalExternalTrait for SimpleConstantModel {
         fn jacobian_internal_to_external(
             _norm_data: &NormalizedData<f64>,
-            internal: &[f64; 1],
-        ) -> [f64; 1] {
+            internal: &[f64],
+        ) -> Vec<f64> {
             // external = |internal|
             // d(external)/d(internal) = sign(internal)
-            [internal[0].signum()]
+            vec![internal[0].signum()]
         }
     }
 
@@ -380,17 +380,18 @@ mod tests {
             posterior_var * ((N as f64) * y_target / obs_var + prior_mean / prior_var);
 
         // Create prior in external space
-        let prior: LnPrior<1> = LnPrior::ind_components([LnPrior1D::normal(prior_mean, prior_std)]);
+        let prior: LnPrior =
+            LnPrior::ind_components(vec![LnPrior1D::normal(prior_mean, prior_std)]);
 
         // Transform prior to work with internal parameters
         let transformed_prior =
             prior.with_fit_parameters_transformation::<SimpleConstantModel>(&norm_data);
 
         // Model: f(t) = |internal[0]|
-        let model = |_t: f64, params: &[f64; 1]| -> f64 { params[0].abs() };
+        let model = |_t: f64, params: &[f64]| -> f64 { params[0].abs() };
 
         // Derivatives: d(|x|)/dx = sign(x)
-        let derivatives = |_t: f64, params: &[f64; 1], jac: &mut [f64; 1]| {
+        let derivatives = |_t: f64, params: &[f64], jac: &mut [f64]| {
             jac[0] = params[0].signum();
         };
 
@@ -457,7 +458,7 @@ mod tests {
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
         // Prior in external space: N(1.0, 0.5²)
-        let prior: LnPrior<1> = LnPrior::ind_components([LnPrior1D::normal(1.0, 0.5)]);
+        let prior: LnPrior = LnPrior::ind_components(vec![LnPrior1D::normal(1.0, 0.5)]);
         let transformed_prior =
             prior.with_fit_parameters_transformation::<SimpleConstantModel>(&norm_data);
 
@@ -530,7 +531,7 @@ mod tests {
         let mut ts = TimeSeries::new(&t_vec, &m_vec, &w_vec);
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
-        let prior: LnPrior<1> = LnPrior::ind_components([LnPrior1D::normal(1.0, 0.5)]);
+        let prior: LnPrior = LnPrior::ind_components(vec![LnPrior1D::normal(1.0, 0.5)]);
         let transformed_prior =
             prior.with_fit_parameters_transformation::<SimpleConstantModel>(&norm_data);
 

--- a/src/nl_fit/nuts.rs
+++ b/src/nl_fit/nuts.rs
@@ -1,6 +1,7 @@
 use crate::nl_fit::bounds::within_bounds;
 use crate::nl_fit::curve_fit::{CurveFitAlgorithm, CurveFitResult, CurveFitTrait};
 use crate::nl_fit::data::Data;
+use crate::nl_fit::evaluator::MAX_INLINE_PARAMS;
 use crate::nl_fit::prior::ln_prior::LnPriorEvaluator;
 
 use ndarray::Zip;
@@ -9,6 +10,7 @@ use rand::SeedableRng;
 use rand::rngs::StdRng;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use smallvec::{SmallVec, smallvec};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::rc::Rc;
@@ -93,8 +95,8 @@ struct LogpFunc<F, DF, LP> {
     model: F,
     derivatives: DF,
     ln_prior: LP,
-    lower: Vec<f64>,
-    upper: Vec<f64>,
+    lower: SmallVec<[f64; MAX_INLINE_PARAMS]>,
+    upper: SmallVec<[f64; MAX_INLINE_PARAMS]>,
 }
 
 impl<F, DF, LP> HasDims for LogpFunc<F, DF, LP> {
@@ -131,10 +133,10 @@ where
 
         // Calculate log-likelihood (negative chi-squared)
         let mut residual = 0.0;
-        let mut grad_array = vec![0.0; nparams];
+        let mut grad_array: SmallVec<[f64; MAX_INLINE_PARAMS]> = smallvec![0.0; nparams];
 
         // Compute -chi^2/2 and its gradient
-        let mut model_grad = vec![0.0; nparams];
+        let mut model_grad: SmallVec<[f64; MAX_INLINE_PARAMS]> = smallvec![0.0; nparams];
         Zip::from(&self.ts.t)
             .and(&self.ts.m)
             .and(&self.ts.inv_err)
@@ -153,7 +155,7 @@ where
         let lnlike = -0.5 * residual;
 
         // Add prior and compute its gradient
-        let mut prior_grad = vec![0.0; nparams];
+        let mut prior_grad: SmallVec<[f64; MAX_INLINE_PARAMS]> = smallvec![0.0; nparams];
         let lnprior = self.ln_prior.ln_prior(params, Some(&mut prior_grad));
 
         // Gradient is d(lnlike + lnprior)/d(params)
@@ -198,8 +200,8 @@ impl CurveFitTrait for NutsCurveFit {
             model: model.clone(),
             derivatives: derivatives.clone(),
             ln_prior: ln_prior.clone(),
-            lower: bounds.0.to_vec(),
-            upper: bounds.1.to_vec(),
+            lower: SmallVec::from_slice(bounds.0),
+            upper: SmallVec::from_slice(bounds.1),
         };
 
         let math = CpuMath::new(logp_func);
@@ -309,14 +311,20 @@ mod tests {
     }
 
     impl FitParametersOriginalDimLessTrait for SimpleConstantModel {
-        fn orig_to_dimensionless(_norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
+        fn orig_to_dimensionless(
+            _norm_data: &NormalizedData<f64>,
+            orig: &[f64],
+        ) -> smallvec::SmallVec<[f64; MAX_INLINE_PARAMS]> {
             // No scaling - external = dimensionless for this simple model
-            orig.to_vec()
+            smallvec::SmallVec::from_slice(orig)
         }
 
-        fn dimensionless_to_orig(_norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
+        fn dimensionless_to_orig(
+            _norm_data: &NormalizedData<f64>,
+            norm: &[f64],
+        ) -> smallvec::SmallVec<[f64; MAX_INLINE_PARAMS]> {
             // No scaling - external = dimensionless for this simple model
-            norm.to_vec()
+            smallvec::SmallVec::from_slice(norm)
         }
     }
 
@@ -324,10 +332,10 @@ mod tests {
         fn jacobian_internal_to_external(
             _norm_data: &NormalizedData<f64>,
             internal: &[f64],
-        ) -> Vec<f64> {
+        ) -> smallvec::SmallVec<[f64; MAX_INLINE_PARAMS]> {
             // external = |internal|
             // d(external)/d(internal) = sign(internal)
-            vec![internal[0].signum()]
+            smallvec::smallvec![internal[0].signum()]
         }
     }
 

--- a/src/nl_fit/prior/ln_prior.rs
+++ b/src/nl_fit/prior/ln_prior.rs
@@ -329,11 +329,17 @@ mod tests {
     }
 
     impl crate::nl_fit::evaluator::FitParametersOriginalDimLessTrait for MockFitParameters {
-        fn orig_to_dimensionless(_norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
-            orig.to_vec()
+        fn orig_to_dimensionless(
+            _norm_data: &NormalizedData<f64>,
+            orig: &[f64],
+        ) -> smallvec::SmallVec<[f64; crate::nl_fit::evaluator::MAX_INLINE_PARAMS]> {
+            smallvec::SmallVec::from_slice(orig)
         }
 
-        fn dimensionless_to_orig(_norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
+        fn dimensionless_to_orig(
+            _norm_data: &NormalizedData<f64>,
+            norm: &[f64],
+        ) -> smallvec::SmallVec<[f64; crate::nl_fit::evaluator::MAX_INLINE_PARAMS]> {
             // Simple transformation: multiply by 2
             norm.iter().map(|&x| x * 2.0).collect()
         }
@@ -343,12 +349,12 @@ mod tests {
         fn jacobian_internal_to_external(
             _norm_data: &NormalizedData<f64>,
             internal: &[f64],
-        ) -> Vec<f64> {
+        ) -> smallvec::SmallVec<[f64; crate::nl_fit::evaluator::MAX_INLINE_PARAMS]> {
             // For MockFitParameters:
             // - internal_to_dimensionless is identity, so derivative is 1
             // - dimensionless_to_orig multiplies by 2, so derivative is 2
             // Combined: 1 * 2 = 2 for each component
-            vec![2.0; internal.len()]
+            smallvec::smallvec![2.0; internal.len()]
         }
     }
 

--- a/src/nl_fit/prior/ln_prior.rs
+++ b/src/nl_fit/prior/ln_prior.rs
@@ -12,11 +12,12 @@ use std::fmt::Debug;
 /// This trait is implemented by types that can evaluate ln(prior) for a given set of parameters.
 /// Unlike [LnPriorTrait], this trait does not require serialization, making it suitable for
 /// use with closures and other non-serializable types.
-pub trait LnPriorEvaluator<const NPARAMS: usize>: Clone {
+pub trait LnPriorEvaluator: Clone {
     /// Evaluate the natural logarithm of the prior at params
     ///
     /// If `jac` is `Some`, the jacobian (gradient) d(ln_prior)/d(params) is also computed and stored in it.
-    fn ln_prior(&self, params: &[f64; NPARAMS], jac: Option<&mut [f64; NPARAMS]>) -> f64;
+    /// `jac`, when given, must be the same length as `params`.
+    fn ln_prior(&self, params: &[f64], jac: Option<&mut [f64]>) -> f64;
 }
 
 /// Trait for serializable prior evaluators
@@ -28,22 +29,19 @@ pub trait LnPriorEvaluator<const NPARAMS: usize>: Clone {
 /// or temporary prior objects). Use this trait when you need to serialize the prior
 /// configuration.
 #[enum_dispatch]
-pub trait LnPriorTrait<const NPARAMS: usize>:
-    LnPriorEvaluator<NPARAMS> + Debug + Serialize + DeserializeOwned
-{
-}
+pub trait LnPriorTrait: LnPriorEvaluator + Debug + Serialize + DeserializeOwned {}
 
 /// Natural logarithm of prior for non-linear curve-fit problem
-#[enum_dispatch(LnPriorTrait<NPARAMS>)]
+#[enum_dispatch(LnPriorTrait)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
 #[non_exhaustive]
-pub enum LnPrior<const NPARAMS: usize> {
+pub enum LnPrior {
     None(NoneLnPrior),
-    IndComponents(IndComponentsLnPrior<NPARAMS>),
+    IndComponents(IndComponentsLnPrior),
 }
 
-impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for LnPrior<NPARAMS> {
-    fn ln_prior(&self, params: &[f64; NPARAMS], jac: Option<&mut [f64; NPARAMS]>) -> f64 {
+impl LnPriorEvaluator for LnPrior {
+    fn ln_prior(&self, params: &[f64], jac: Option<&mut [f64]>) -> f64 {
         match self {
             LnPrior::None(p) => p.ln_prior(params, jac),
             LnPrior::IndComponents(p) => p.ln_prior(params, jac),
@@ -51,39 +49,42 @@ impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for LnPrior<NPARAMS> {
     }
 }
 
-impl<const NPARAMS: usize> LnPrior<NPARAMS> {
+impl LnPrior {
     pub fn none() -> Self {
         NoneLnPrior {}.into()
     }
 
-    pub fn ind_components(components: [LnPrior1D; NPARAMS]) -> Self {
-        IndComponentsLnPrior { components }.into()
+    pub fn ind_components(components: impl Into<Vec<LnPrior1D>>) -> Self {
+        IndComponentsLnPrior {
+            components: components.into(),
+        }
+        .into()
     }
 
-    pub fn into_func(self) -> impl 'static + Clone + Fn(&[f64; NPARAMS]) -> f64 {
+    pub fn into_func(self) -> impl 'static + Clone + Fn(&[f64]) -> f64 {
         move |params| self.ln_prior(params, None)
     }
 
     pub fn into_func_with_transformation<'a, F>(
         self,
         transform: F,
-    ) -> impl 'a + Clone + Fn(&[f64; NPARAMS]) -> f64
+    ) -> impl 'a + Clone + Fn(&[f64]) -> f64
     where
-        F: 'a + Clone + Fn(&[f64; NPARAMS]) -> [f64; NPARAMS],
+        F: 'a + Clone + Fn(&[f64]) -> Vec<f64>,
     {
         move |params| self.ln_prior(&transform(params), None)
     }
 
-    pub fn as_func(&self) -> impl '_ + Fn(&[f64; NPARAMS]) -> f64 {
+    pub fn as_func(&self) -> impl '_ + Fn(&[f64]) -> f64 {
         |params| self.ln_prior(params, None)
     }
 
     pub fn as_func_with_transformation<'a, F>(
         &'a self,
         transform: F,
-    ) -> impl 'a + Clone + Fn(&[f64; NPARAMS]) -> f64
+    ) -> impl 'a + Clone + Fn(&[f64]) -> f64
     where
-        F: 'a + Clone + Fn(&[f64; NPARAMS]) -> [f64; NPARAMS],
+        F: 'a + Clone + Fn(&[f64]) -> Vec<f64>,
     {
         move |params| self.ln_prior(&transform(params), None)
     }
@@ -96,9 +97,9 @@ impl<const NPARAMS: usize> LnPrior<NPARAMS> {
     pub fn with_fit_parameters_transformation<'a, T>(
         &'a self,
         norm_data: &'a NormalizedData<f64>,
-    ) -> TransformedLnPrior<'a, T, NPARAMS>
+    ) -> TransformedLnPrior<'a, T>
     where
-        T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait<NPARAMS>,
+        T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait,
     {
         TransformedLnPrior {
             prior: self.clone(),
@@ -111,8 +112,8 @@ impl<const NPARAMS: usize> LnPrior<NPARAMS> {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
 pub struct NoneLnPrior {}
 
-impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for NoneLnPrior {
-    fn ln_prior(&self, _params: &[f64; NPARAMS], jac: Option<&mut [f64; NPARAMS]>) -> f64 {
+impl LnPriorEvaluator for NoneLnPrior {
+    fn ln_prior(&self, _params: &[f64], jac: Option<&mut [f64]>) -> f64 {
         if let Some(j) = jac {
             j.iter_mut().for_each(|x| *x = 0.0);
         }
@@ -120,19 +121,16 @@ impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for NoneLnPrior {
     }
 }
 
-impl<const NPARAMS: usize> LnPriorTrait<NPARAMS> for NoneLnPrior {}
+impl LnPriorTrait for NoneLnPrior {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(
-    into = "IndComponentsLnPriorSerde",
-    try_from = "IndComponentsLnPriorSerde"
-)]
-pub struct IndComponentsLnPrior<const NPARAMS: usize> {
-    pub components: [LnPrior1D; NPARAMS],
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
+#[serde(rename = "IndComponentsLnPrior")]
+pub struct IndComponentsLnPrior {
+    pub components: Vec<LnPrior1D>,
 }
 
-impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for IndComponentsLnPrior<NPARAMS> {
-    fn ln_prior(&self, params: &[f64; NPARAMS], jac: Option<&mut [f64; NPARAMS]>) -> f64 {
+impl LnPriorEvaluator for IndComponentsLnPrior {
+    fn ln_prior(&self, params: &[f64], jac: Option<&mut [f64]>) -> f64 {
         let mut total_ln_prior = 0.0;
 
         if let Some(jac) = jac {
@@ -156,48 +154,7 @@ impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for IndComponentsLnPrior<NP
     }
 }
 
-impl<const NPARAMS: usize> LnPriorTrait<NPARAMS> for IndComponentsLnPrior<NPARAMS> {}
-
-impl<const NPARAMS: usize> JsonSchema for IndComponentsLnPrior<NPARAMS> {
-    fn is_referenceable() -> bool {
-        false
-    }
-
-    fn schema_name() -> String {
-        IndComponentsLnPriorSerde::schema_name()
-    }
-
-    fn json_schema(r#gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
-        IndComponentsLnPriorSerde::json_schema(r#gen)
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename = "IndComponentsLnPrior")]
-struct IndComponentsLnPriorSerde {
-    components: Vec<LnPrior1D>,
-}
-
-impl<const NPARAMS: usize> From<IndComponentsLnPrior<NPARAMS>> for IndComponentsLnPriorSerde {
-    fn from(value: IndComponentsLnPrior<NPARAMS>) -> Self {
-        Self {
-            components: value.components.into(),
-        }
-    }
-}
-
-impl<const NPARAMS: usize> TryFrom<IndComponentsLnPriorSerde> for IndComponentsLnPrior<NPARAMS> {
-    type Error = &'static str;
-
-    fn try_from(value: IndComponentsLnPriorSerde) -> Result<Self, Self::Error> {
-        Ok(Self {
-            components: value
-                .components
-                .try_into()
-                .map_err(|_| "wrong size of the IndComponentsLnPrior.components")?,
-        })
-    }
-}
+impl LnPriorTrait for IndComponentsLnPrior {}
 
 /// A prior with parameter transformation using FitParametersInternalExternalTrait
 ///
@@ -209,18 +166,18 @@ impl<const NPARAMS: usize> TryFrom<IndComponentsLnPriorSerde> for IndComponentsL
 /// Note: This type stores a reference to `NormalizedData` which is runtime data, so it cannot
 /// be serialized. However, the prior itself can be serialized separately.
 #[derive(Debug)]
-pub struct TransformedLnPrior<'a, T, const NPARAMS: usize>
+pub struct TransformedLnPrior<'a, T>
 where
-    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait<NPARAMS>,
+    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait,
 {
-    prior: LnPrior<NPARAMS>,
+    prior: LnPrior,
     norm_data: &'a NormalizedData<f64>,
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<'a, T, const NPARAMS: usize> Clone for TransformedLnPrior<'a, T, NPARAMS>
+impl<'a, T> Clone for TransformedLnPrior<'a, T>
 where
-    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait<NPARAMS>,
+    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait,
 {
     fn clone(&self) -> Self {
         Self {
@@ -231,11 +188,11 @@ where
     }
 }
 
-impl<'a, T, const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for TransformedLnPrior<'a, T, NPARAMS>
+impl<'a, T> LnPriorEvaluator for TransformedLnPrior<'a, T>
 where
-    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait<NPARAMS>,
+    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait,
 {
-    fn ln_prior(&self, params: &[f64; NPARAMS], jac: Option<&mut [f64; NPARAMS]>) -> f64 {
+    fn ln_prior(&self, params: &[f64], jac: Option<&mut [f64]>) -> f64 {
         let transformed = T::convert_to_external(self.norm_data, params);
 
         match jac {
@@ -264,19 +221,19 @@ mod tests {
 
     #[test]
     fn test_ln_prior_evaluator_trait_none() {
-        let prior: LnPrior<3> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let params = [1.0, 2.0, 3.0];
         assert_eq!(prior.ln_prior(&params, None), 0.0);
     }
 
     #[test]
     fn test_ln_prior_evaluator_trait_ind_components() {
-        let components = [
+        let components = vec![
             LnPrior1D::uniform(0.0, 10.0),
             LnPrior1D::uniform(0.0, 10.0),
             LnPrior1D::uniform(0.0, 10.0),
         ];
-        let prior: LnPrior<3> = LnPrior::ind_components(components);
+        let prior: LnPrior = LnPrior::ind_components(components);
 
         // Test with valid parameters
         let params_valid = [5.0, 5.0, 5.0];
@@ -297,7 +254,7 @@ mod tests {
 
     #[test]
     fn test_ind_components_ln_prior() {
-        let components = [LnPrior1D::uniform(0.0, 1.0), LnPrior1D::uniform(0.0, 2.0)];
+        let components = vec![LnPrior1D::uniform(0.0, 1.0), LnPrior1D::uniform(0.0, 2.0)];
         let prior = IndComponentsLnPrior { components };
 
         // Both within bounds
@@ -311,7 +268,7 @@ mod tests {
 
     #[test]
     fn test_ln_prior_clone() {
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let cloned = prior.clone();
         let params = [1.0, 2.0];
         assert_eq!(
@@ -322,14 +279,14 @@ mod tests {
 
     #[test]
     fn test_ln_prior_debug() {
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let debug_str = format!("{:?}", prior);
         assert!(debug_str.contains("None"));
     }
 
     #[test]
     fn test_ln_prior_into_func() {
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let func = prior.into_func();
         let params = [1.0, 2.0];
         assert_eq!(func(&params), 0.0);
@@ -337,8 +294,8 @@ mod tests {
 
     #[test]
     fn test_ln_prior_into_func_with_transformation() {
-        let prior: LnPrior<2> = LnPrior::none();
-        let transform = |params: &[f64; 2]| [params[0] * 2.0, params[1] * 2.0];
+        let prior: LnPrior = LnPrior::none();
+        let transform = |params: &[f64]| vec![params[0] * 2.0, params[1] * 2.0];
         let func = prior.into_func_with_transformation(transform);
         let params = [1.0, 2.0];
         // Since NoneLnPrior always returns 0, transformation doesn't affect result
@@ -347,7 +304,7 @@ mod tests {
 
     #[test]
     fn test_ln_prior_as_func() {
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let func = prior.as_func();
         let params = [1.0, 2.0];
         assert_eq!(func(&params), 0.0);
@@ -357,37 +314,41 @@ mod tests {
     #[derive(Debug)]
     struct MockFitParameters;
 
-    impl crate::nl_fit::evaluator::FitParametersInternalDimlessTrait<f64, 2> for MockFitParameters {
-        fn dimensionless_to_internal(params: &[f64; 2]) -> [f64; 2] {
-            *params
+    impl crate::nl_fit::evaluator::FitParametersInternalDimlessTrait<f64> for MockFitParameters {
+        fn dimensionless_to_internal(
+            params: &[f64],
+        ) -> smallvec::SmallVec<[f64; crate::nl_fit::evaluator::MAX_INLINE_PARAMS]> {
+            smallvec::SmallVec::from_slice(params)
         }
 
-        fn internal_to_dimensionless(params: &[f64; 2]) -> [f64; 2] {
-            *params
+        fn internal_to_dimensionless(
+            params: &[f64],
+        ) -> smallvec::SmallVec<[f64; crate::nl_fit::evaluator::MAX_INLINE_PARAMS]> {
+            smallvec::SmallVec::from_slice(params)
         }
     }
 
-    impl crate::nl_fit::evaluator::FitParametersOriginalDimLessTrait<2> for MockFitParameters {
-        fn orig_to_dimensionless(_norm_data: &NormalizedData<f64>, orig: &[f64; 2]) -> [f64; 2] {
-            *orig
+    impl crate::nl_fit::evaluator::FitParametersOriginalDimLessTrait for MockFitParameters {
+        fn orig_to_dimensionless(_norm_data: &NormalizedData<f64>, orig: &[f64]) -> Vec<f64> {
+            orig.to_vec()
         }
 
-        fn dimensionless_to_orig(_norm_data: &NormalizedData<f64>, norm: &[f64; 2]) -> [f64; 2] {
+        fn dimensionless_to_orig(_norm_data: &NormalizedData<f64>, norm: &[f64]) -> Vec<f64> {
             // Simple transformation: multiply by 2
-            [norm[0] * 2.0, norm[1] * 2.0]
+            norm.iter().map(|&x| x * 2.0).collect()
         }
     }
 
-    impl crate::nl_fit::evaluator::FitParametersInternalExternalTrait<2> for MockFitParameters {
+    impl crate::nl_fit::evaluator::FitParametersInternalExternalTrait for MockFitParameters {
         fn jacobian_internal_to_external(
             _norm_data: &NormalizedData<f64>,
-            _internal: &[f64; 2],
-        ) -> [f64; 2] {
+            internal: &[f64],
+        ) -> Vec<f64> {
             // For MockFitParameters:
             // - internal_to_dimensionless is identity, so derivative is 1
             // - dimensionless_to_orig multiplies by 2, so derivative is 2
             // Combined: 1 * 2 = 2 for each component
-            [2.0, 2.0]
+            vec![2.0; internal.len()]
         }
     }
 
@@ -398,8 +359,8 @@ mod tests {
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
         // Create a prior with bounds [0, 2] for each parameter
-        let components = [LnPrior1D::uniform(0.0, 2.0), LnPrior1D::uniform(0.0, 2.0)];
-        let prior: LnPrior<2> = LnPrior::ind_components(components);
+        let components = vec![LnPrior1D::uniform(0.0, 2.0), LnPrior1D::uniform(0.0, 2.0)];
+        let prior: LnPrior = LnPrior::ind_components(components);
 
         // Create transformed prior
         let transformed_prior =
@@ -424,7 +385,7 @@ mod tests {
         let mut ts = TimeSeries::new_without_weight(vec![1.0, 2.0, 3.0], vec![1.0, 2.0, 3.0]);
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let transformed_prior =
             prior.with_fit_parameters_transformation::<MockFitParameters>(&norm_data);
         let cloned = transformed_prior.clone();
@@ -441,7 +402,7 @@ mod tests {
         let mut ts = TimeSeries::new_without_weight(vec![1.0, 2.0, 3.0], vec![1.0, 2.0, 3.0]);
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let transformed_prior =
             prior.with_fit_parameters_transformation::<MockFitParameters>(&norm_data);
 
@@ -451,9 +412,9 @@ mod tests {
 
     #[test]
     fn test_ln_prior_serialization() {
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let serialized = serde_json::to_string(&prior).unwrap();
-        let deserialized: LnPrior<2> = serde_json::from_str(&serialized).unwrap();
+        let deserialized: LnPrior = serde_json::from_str(&serialized).unwrap();
 
         let params = [1.0, 2.0];
         assert_eq!(
@@ -464,11 +425,11 @@ mod tests {
 
     #[test]
     fn test_ind_components_serialization() {
-        let components = [LnPrior1D::uniform(0.0, 10.0), LnPrior1D::uniform(-5.0, 5.0)];
-        let prior: LnPrior<2> = LnPrior::ind_components(components);
+        let components = vec![LnPrior1D::uniform(0.0, 10.0), LnPrior1D::uniform(-5.0, 5.0)];
+        let prior: LnPrior = LnPrior::ind_components(components);
 
         let serialized = serde_json::to_string(&prior).unwrap();
-        let deserialized: LnPrior<2> = serde_json::from_str(&serialized).unwrap();
+        let deserialized: LnPrior = serde_json::from_str(&serialized).unwrap();
 
         let params = [5.0, 0.0];
         assert_eq!(
@@ -481,8 +442,8 @@ mod tests {
     fn test_ind_components_gradient() {
         use approx::assert_relative_eq;
 
-        let components = [LnPrior1D::normal(5.0, 2.0), LnPrior1D::normal(10.0, 3.0)];
-        let prior: LnPrior<2> = LnPrior::ind_components(components.clone());
+        let components = vec![LnPrior1D::normal(5.0, 2.0), LnPrior1D::normal(10.0, 3.0)];
+        let prior: LnPrior = LnPrior::ind_components(components.clone());
 
         let params = [6.0, 11.0];
         let mut jac = [0.0; 2];
@@ -506,7 +467,7 @@ mod tests {
 
     #[test]
     fn test_none_ln_prior_gradient() {
-        let prior: LnPrior<3> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let params = [1.0, 2.0, 3.0];
         let mut jac = [0.0; 3];
         let ln_p = prior.ln_prior(&params, Some(&mut jac));
@@ -524,8 +485,8 @@ mod tests {
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
         // Create a prior with normal distribution in external space
-        let components = [LnPrior1D::normal(1.0, 0.5), LnPrior1D::normal(2.0, 0.5)];
-        let prior: LnPrior<2> = LnPrior::ind_components(components);
+        let components = vec![LnPrior1D::normal(1.0, 0.5), LnPrior1D::normal(2.0, 0.5)];
+        let prior: LnPrior = LnPrior::ind_components(components);
 
         // Create transformed prior
         let transformed_prior =


### PR DESCRIPTION
Stacked on #317 (`generalize-nl-fit-nparams`) -- since that branch only exists on my fork,
GitHub won't let me target it directly from here, so this diff includes both commits until #317
merges. The only new one is "Fix Rainbow bounds..." plus the RainbowFit commit itself; #317 is
under separate review.

A Rust port of `light_curve_py.features.rainbow.RainbowFit` as a real `light-curve-feature`
multi-color feature. Jointly fits a per-band flux model

flux(t, band) = bolometric(t) * SED(wavelength_band, temperature(t)) / norm(temperature(t))  [+ baseline_band]

with pluggable sub-models (bolometric envelope: Bazin/Sigmoid/Doublexp; temperature-vs-time:
Constant/Sigmoid/DelayedSigmoid; SED: Planck/GenWien/ModifiedBlackBody/LogParabola), plus an
optional per-band additive baseline. Runs through the existing `CurveFitAlgorithm` (Ceres/MCMC/
NUTS) -- same infrastructure every other `*Fit` feature uses, no bespoke optimizer or new
dependency. This replaces #314, which used a bespoke Levenberg-Marquardt optimizer; closing that
one in favor of this once this is up.

## Priority for this PR: fit the existing structure, not fit quality

This intentionally optimizes for landing on the crate's existing conventions
(`CurveFitAlgorithm`, `PassbandTrait` untouched, no new Cargo feature) over squeezing out the
best possible convergence. It gets close: 82/90 real, multi-band, uneven-cadence light curves
converge within a few x of `light_curve_py`'s reduced chi2, at ~35-40x its speed. The remaining
gap is a real, understood limitation (see below), not a mystery -- happy to chase it in a
follow-up once the structure itself is settled, rather than tangle both in one review.

- No new dependency, no new Cargo feature: `RainbowFit` is unconditionally compiled in, like
  `BazinFit`/`VillarFit`.
- `PassbandTrait` untouched: `RainbowFit::new` takes `(passband, wavelength_cm)` pairs directly
  as constructor data instead of deriving wavelength from the passband type -- matches what the
  companion `light-curve-python` PR already does, and keeps `RainbowFit` in the shared
  `MultiColorFeature<P, T>` registry like every other feature.
- Output is `[params..., reduced_chi2]`, matching `light_curve_py.RainbowFit.__call__`'s own
  convention -- no uncertainty columns.
- Band index is folded into the shared single-scalar-`t` optimizer interface via disjoint
  per-band time offsets, decoded inside Rainbow's own model/derivatives closures -- doesn't
  touch `nl_fit`'s shared types.

## Known limitation: `ceres-solver` 0.5.1 ignores upper bounds

Confirmed directly, independent of anything Rainbow-specific: `CurveFitProblem1DBuilder::build`
wires up `lower_bounds` for real but has a literal `// TODO: upper bounds` where upper bounds
should be applied. Rainbow's bounds are real physical constraints (e.g. `T_amplitude in
[-0.99, 0.99]`, keeping temperature positive), not the generous safety margins `BazinFit` uses,
so this surfaces immediately on real data.

Worked around by reparametrization rather than depending on backend bound support: every
parameter is mapped through a logistic transform from an unconstrained internal value into its
`(lower, upper)` interval before the model sees it; the optimizer itself gets `+-inf` bounds.
Same idea iminuit uses internally, and what this feature's earlier bespoke-optimizer draft did.

This transform has a known failure mode: its derivative vanishes near either bound, so a
gradient-based optimizer can report false convergence pinned at (not just near) a bound. Checked
this isn't a Ceres-specific quirk -- MCMC lands on the same kind of boundary case for the same
light curve. It's a real, occasional local-minimum problem, same failure mode across backends;
not something a Ceres-specific fix would resolve.

Also needed: Ceres's generic default of 10 iterations is tuned for simpler single-band features;
Rainbow's larger parameter space needs more (25/90 vs. 82/90 real light curves converging close
to the Python reference at 10 vs. 200 iterations) -- `RainbowFit`'s Ceres default is 200.

## Not yet ported from the Python reference

- `bolometric = "linexp"`: Python's own docstring flags the guesses/limits as unstable; a seed
  sweep confirmed roughly half of random seeds land the fit in a self-consistent-looking but
  wrong local optimum.
- `spectral = "blanketed"`: its `lambda_scale` parameter anchors to the temperature term's own
  characteristic T via Python's cross-term `common_temp_spec` sharing, more involved than a
  straight port of the other terms.
- Gaussian priors that the Python version uses to break some parameter degeneracies (e.g.
  `T_amplitude`, `beta` anchored toward 0), and non-detection/upper-limit support (Python's
  Tobit-model likelihood term).

Companion `light-curve-python` PR: light-curve/light-curve-python#825 (replaces #816, which used
the old bespoke-LM wrapper).