### PR TITLE
Generalize nl_fit to runtime-sized parameter vectors, keep bounds-che…

### DIFF
--- a/examples/plot_snia_curve_fits.rs
+++ b/examples/plot_snia_curve_fits.rs
@@ -204,9 +204,15 @@ fn fitted_model(
     let values = feature.eval(ts).expect("Feature cannot be extracted");
     let reduced_chi2 = values[values.len() - 1];
     let model: BoxedModel = match feature {
-        Feature::BazinFit(..) => Box::new(BazinFit::f),
-        Feature::LinexpFit(..) => Box::new(LinexpFit::f),
-        Feature::VillarFit(..) => Box::new(VillarFit::f),
+        Feature::BazinFit(..) => {
+            Box::new(|t: f64, values: &[f64]| BazinFit::f(t, values[..5].try_into().unwrap()))
+        }
+        Feature::LinexpFit(..) => {
+            Box::new(|t: f64, values: &[f64]| LinexpFit::f(t, values[..4].try_into().unwrap()))
+        }
+        Feature::VillarFit(..) => {
+            Box::new(|t: f64, values: &[f64]| VillarFit::f(t, values[..7].try_into().unwrap()))
+        }
         _ => panic!("Unknown *Fit variant"),
     };
     let flux = t.mapv(|t| model(t, &values));

--- a/src/features/bazin_fit.rs
+++ b/src/features/bazin_fit.rs
@@ -212,11 +212,11 @@ where
     }
 }
 
-impl<T> FitInitsBoundsTrait<T, NPARAMS> for BazinFit
+impl<T> FitInitsBoundsTrait<T> for BazinFit
 where
     T: Float,
 {
-    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         match &self.inits_bounds {
             BazinInitsBounds::Default => BazinInitsBounds::default_from_ts(ts),
             BazinInitsBounds::Arrays(arrays) => arrays.as_ref().clone(),
@@ -296,12 +296,12 @@ impl FitParametersInternalExternalTrait<NPARAMS> for BazinFit {
     }
 }
 
-impl FitFeatureEvaluatorGettersTrait<NPARAMS> for BazinFit {
+impl FitFeatureEvaluatorGettersTrait for BazinFit {
     fn get_algorithm(&self) -> &CurveFitAlgorithm {
         &self.algorithm
     }
 
-    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior {
         self.ln_prior.ln_prior_from_ts(ts)
     }
 }
@@ -334,7 +334,7 @@ impl<T> FeatureEvaluator<T> for BazinFit
 where
     T: Float,
 {
-    fit_eval!();
+    fit_eval!(NPARAMS);
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Default, PartialEq)]
@@ -342,13 +342,13 @@ where
 pub enum BazinInitsBounds {
     #[default]
     Default,
-    Arrays(Box<FitInitsBoundsArrays<NPARAMS>>),
-    OptionArrays(Box<OptionFitInitsBoundsArrays<NPARAMS>>),
+    Arrays(Box<FitInitsBoundsArrays>),
+    OptionArrays(Box<OptionFitInitsBoundsArrays>),
 }
 
 impl BazinInitsBounds {
     pub fn arrays(init: [f64; NPARAMS], lower: [f64; NPARAMS], upper: [f64; NPARAMS]) -> Self {
-        Self::Arrays(FitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::Arrays(FitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into())
     }
 
     pub fn option_arrays(
@@ -356,10 +356,12 @@ impl BazinInitsBounds {
         lower: [Option<f64>; NPARAMS],
         upper: [Option<f64>; NPARAMS],
     ) -> Self {
-        Self::OptionArrays(OptionFitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::OptionArrays(
+            OptionFitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into(),
+        )
     }
 
-    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         let t_min: f64 = ts.t.get_min().value_into().unwrap();
         let t_max: f64 = ts.t.get_max().value_into().unwrap();
         let t_amplitude = t_max - t_min;
@@ -384,9 +386,9 @@ impl BazinInitsBounds {
         let (fall_lower, fall_upper) = (0.0, 10.0 * t_amplitude);
 
         FitInitsBoundsArrays {
-            init: [a_init, c_init, t0_init, rise_init, fall_init].into(),
-            lower: [a_lower, c_lower, t0_lower, rise_lower, fall_lower].into(),
-            upper: [a_upper, c_upper, t0_upper, rise_upper, fall_upper].into(),
+            init: vec![a_init, c_init, t0_init, rise_init, fall_init],
+            lower: vec![a_lower, c_lower, t0_lower, rise_lower, fall_lower],
+            upper: vec![a_upper, c_upper, t0_upper, rise_upper, fall_upper],
         }
     }
 }
@@ -394,23 +396,23 @@ impl BazinInitsBounds {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum BazinLnPrior {
-    Fixed(Box<LnPrior<NPARAMS>>),
+    Fixed(Box<LnPrior>),
 }
 
 impl BazinLnPrior {
-    pub fn fixed(ln_prior: LnPrior<NPARAMS>) -> Self {
+    pub fn fixed(ln_prior: LnPrior) -> Self {
         Self::Fixed(ln_prior.into())
     }
 
-    pub fn ln_prior_from_ts<T: Float>(&self, _ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    pub fn ln_prior_from_ts<T: Float>(&self, _ts: &mut TimeSeries<T>) -> LnPrior {
         match self {
             Self::Fixed(ln_prior) => ln_prior.as_ref().clone(),
         }
     }
 }
 
-impl From<LnPrior<NPARAMS>> for BazinLnPrior {
-    fn from(item: LnPrior<NPARAMS>) -> Self {
+impl From<LnPrior> for BazinLnPrior {
+    fn from(item: LnPrior) -> Self {
         Self::fixed(item)
     }
 }
@@ -515,7 +517,7 @@ mod tests {
     //     let lmsder = CeresCurveFit::new();
     //     let mcmc = McmcCurveFit::new(512, Some(lmsder.into()));
     //     bazin_fit_noisy(BazinFit::new(
-    //         CeresCurveFit::new().into(),
+    //         mcmc.into(),
     //         LnPrior::none(),
     //         BazinInitsBounds::option_arrays(
     //             [None; 5],
@@ -613,9 +615,9 @@ mod tests {
                 );
                 let result = bazin.eval(&mut ts).unwrap();
 
+                let result_arr: [f64; NPARAMS] = result[..NPARAMS].try_into().unwrap();
                 let t_model = Array1::linspace(t[0] - 1.0, t[t.len() - 1] + 1.0, 100);
-                let flux_model =
-                    t_model.mapv(|x| BazinFit::model(x, &result[..NPARAMS].try_into().unwrap()));
+                let flux_model = t_model.mapv(|x| BazinFit::model(x, &result_arr));
                 flux_model.mapv(|y| -2.5 * f64::log10(y / f0))
             })
             .collect();
@@ -673,4 +675,16 @@ mod tests {
     }
 
     check_fit_jacobian!(BazinFit);
+
+    /// A wrong-length parameter slice must panic loudly (via `try_into`'s `.expect`) rather than
+    /// silently truncating or padding -- this is the boundary between the solver's runtime-length
+    /// `&[f64]` and the feature's fixed-size `[f64; NPARAMS]` math.
+    #[test]
+    #[should_panic(expected = "orig must have exactly MAX_NPARAMS elements")]
+    fn bazin_fit_convert_to_internal_wrong_length_panics() {
+        let mut ts = TimeSeries::new_without_weight(vec![1.0, 2.0, 3.0], vec![1.0, 2.0, 3.0]);
+        let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
+        let wrong_length = vec![1.0; NPARAMS + 1];
+        let _ = BazinFit::convert_to_internal(&norm_data, &wrong_length);
+    }
 }

--- a/src/features/linexp_fit.rs
+++ b/src/features/linexp_fit.rs
@@ -195,11 +195,11 @@ where
     }
 }
 
-impl<T> FitInitsBoundsTrait<T, NPARAMS> for LinexpFit
+impl<T> FitInitsBoundsTrait<T> for LinexpFit
 where
     T: Float,
 {
-    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         match &self.inits_bounds {
             LinexpInitsBounds::Default => LinexpInitsBounds::default_from_ts(ts),
             LinexpInitsBounds::Arrays(arrays) => arrays.as_ref().clone(),
@@ -270,12 +270,12 @@ impl FitParametersInternalExternalTrait<NPARAMS> for LinexpFit {
     }
 }
 
-impl FitFeatureEvaluatorGettersTrait<NPARAMS> for LinexpFit {
+impl FitFeatureEvaluatorGettersTrait for LinexpFit {
     fn get_algorithm(&self) -> &CurveFitAlgorithm {
         &self.algorithm
     }
 
-    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior {
         self.ln_prior.ln_prior_from_ts(ts)
     }
 }
@@ -306,7 +306,7 @@ impl<T> FeatureEvaluator<T> for LinexpFit
 where
     T: Float,
 {
-    fit_eval!();
+    fit_eval!(NPARAMS);
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Default, PartialEq)]
@@ -314,13 +314,13 @@ where
 pub enum LinexpInitsBounds {
     #[default]
     Default,
-    Arrays(Box<FitInitsBoundsArrays<NPARAMS>>),
-    OptionArrays(Box<OptionFitInitsBoundsArrays<NPARAMS>>),
+    Arrays(Box<FitInitsBoundsArrays>),
+    OptionArrays(Box<OptionFitInitsBoundsArrays>),
 }
 
 impl LinexpInitsBounds {
     pub fn arrays(init: [f64; NPARAMS], lower: [f64; NPARAMS], upper: [f64; NPARAMS]) -> Self {
-        Self::Arrays(FitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::Arrays(FitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into())
     }
 
     pub fn option_arrays(
@@ -328,10 +328,12 @@ impl LinexpInitsBounds {
         lower: [Option<f64>; NPARAMS],
         upper: [Option<f64>; NPARAMS],
     ) -> Self {
-        Self::OptionArrays(OptionFitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::OptionArrays(
+            OptionFitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into(),
+        )
     }
 
-    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         let t_min: f64 = ts.t.get_min().value_into().unwrap();
         let t_max: f64 = ts.t.get_max().value_into().unwrap();
         let t_amplitude = t_max - t_min;
@@ -358,9 +360,9 @@ impl LinexpInitsBounds {
         let (b_lower, b_upper) = (m_min - 100.0 * m_amplitude, m_max + 100.0 * m_amplitude);
 
         FitInitsBoundsArrays {
-            init: [a_init, t0_init, tau_init, b_init].into(),
-            lower: [a_lower, t0_lower, tau_lower, b_lower].into(),
-            upper: [a_upper, t0_upper, tau_upper, b_upper].into(),
+            init: vec![a_init, t0_init, tau_init, b_init],
+            lower: vec![a_lower, t0_lower, tau_lower, b_lower],
+            upper: vec![a_upper, t0_upper, tau_upper, b_upper],
         }
     }
 }
@@ -368,23 +370,23 @@ impl LinexpInitsBounds {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[non_exhaustive]
 pub enum LinexpLnPrior {
-    Fixed(Box<LnPrior<NPARAMS>>),
+    Fixed(Box<LnPrior>),
 }
 
 impl LinexpLnPrior {
-    pub fn fixed(ln_prior: LnPrior<NPARAMS>) -> Self {
+    pub fn fixed(ln_prior: LnPrior) -> Self {
         Self::Fixed(ln_prior.into())
     }
 
-    pub fn ln_prior_from_ts<T: Float>(&self, _ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    pub fn ln_prior_from_ts<T: Float>(&self, _ts: &mut TimeSeries<T>) -> LnPrior {
         match self {
             Self::Fixed(ln_prior) => ln_prior.as_ref().clone(),
         }
     }
 }
 
-impl From<LnPrior<NPARAMS>> for LinexpLnPrior {
-    fn from(item: LnPrior<NPARAMS>) -> Self {
+impl From<LnPrior> for LinexpLnPrior {
+    fn from(item: LnPrior) -> Self {
         Self::fixed(item)
     }
 }

--- a/src/features/villar_fit.rs
+++ b/src/features/villar_fit.rs
@@ -206,11 +206,11 @@ where
     }
 }
 
-impl<T> FitInitsBoundsTrait<T, NPARAMS> for VillarFit
+impl<T> FitInitsBoundsTrait<T> for VillarFit
 where
     T: Float,
 {
-    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         match &self.inits_bounds {
             VillarInitsBounds::Default => VillarInitsBounds::default_from_ts(ts),
             VillarInitsBounds::Arrays(arrays) => arrays.as_ref().clone(),
@@ -317,12 +317,12 @@ impl FitParametersInternalExternalTrait<NPARAMS> for VillarFit {
     }
 }
 
-impl FitFeatureEvaluatorGettersTrait<NPARAMS> for VillarFit {
+impl FitFeatureEvaluatorGettersTrait for VillarFit {
     fn get_algorithm(&self) -> &CurveFitAlgorithm {
         &self.algorithm
     }
 
-    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior {
         self.ln_prior.ln_prior_from_ts(ts)
     }
 }
@@ -359,7 +359,7 @@ impl<T> FeatureEvaluator<T> for VillarFit
 where
     T: Float,
 {
-    fit_eval!();
+    fit_eval!(NPARAMS);
 }
 
 struct Params<'a, T> {
@@ -472,13 +472,13 @@ where
 pub enum VillarInitsBounds {
     #[default]
     Default,
-    Arrays(Box<FitInitsBoundsArrays<NPARAMS>>),
-    OptionArrays(Box<OptionFitInitsBoundsArrays<NPARAMS>>),
+    Arrays(Box<FitInitsBoundsArrays>),
+    OptionArrays(Box<OptionFitInitsBoundsArrays>),
 }
 
 impl VillarInitsBounds {
     pub fn arrays(init: [f64; NPARAMS], lower: [f64; NPARAMS], upper: [f64; NPARAMS]) -> Self {
-        Self::Arrays(FitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::Arrays(FitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into())
     }
 
     pub fn option_arrays(
@@ -486,10 +486,12 @@ impl VillarInitsBounds {
         lower: [Option<f64>; NPARAMS],
         upper: [Option<f64>; NPARAMS],
     ) -> Self {
-        Self::OptionArrays(OptionFitInitsBoundsArrays::new(init, lower, upper).into())
+        Self::OptionArrays(
+            OptionFitInitsBoundsArrays::new(init.into(), lower.into(), upper.into()).into(),
+        )
     }
 
-    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS> {
+    fn default_from_ts<T: Float>(ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays {
         let t_min: f64 = ts.t.get_min().value_into().unwrap();
         let t_max: f64 = ts.t.get_max().value_into().unwrap();
         let t_amplitude = t_max - t_min;
@@ -521,7 +523,7 @@ impl VillarInitsBounds {
         let (gamma_lower, gamma_upper) = (0.0, 10.0 * t_amplitude);
 
         FitInitsBoundsArrays {
-            init: [
+            init: vec![
                 a_init,
                 c_init,
                 t0_init,
@@ -529,9 +531,8 @@ impl VillarInitsBounds {
                 tau_fall_init,
                 nu_init,
                 gamma_init,
-            ]
-            .into(),
-            lower: [
+            ],
+            lower: vec![
                 a_lower,
                 c_lower,
                 t0_lower,
@@ -539,9 +540,8 @@ impl VillarInitsBounds {
                 tau_fall_lower,
                 nu_lower,
                 gamma_lower,
-            ]
-            .into(),
-            upper: [
+            ],
+            upper: vec![
                 a_upper,
                 c_upper,
                 t0_upper,
@@ -549,8 +549,7 @@ impl VillarInitsBounds {
                 tau_fall_upper,
                 nu_upper,
                 gamma_upper,
-            ]
-            .into(),
+            ],
         }
     }
 }
@@ -559,7 +558,7 @@ impl VillarInitsBounds {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[non_exhaustive]
 pub enum VillarLnPrior {
-    Fixed(Box<LnPrior<NPARAMS>>),
+    Fixed(Box<LnPrior>),
     /// Adopted from Hosseinzadeh, et al. 2020, table 2
     ///
     /// `time_units_in_day` specifies the units of time you use in yout `TimeSeries` object, it
@@ -572,7 +571,7 @@ pub enum VillarLnPrior {
 }
 
 impl VillarLnPrior {
-    pub fn fixed(ln_prior: LnPrior<NPARAMS>) -> Self {
+    pub fn fixed(ln_prior: LnPrior) -> Self {
         Self::Fixed(ln_prior.into())
     }
 
@@ -584,7 +583,7 @@ impl VillarLnPrior {
         }
     }
 
-    pub fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS> {
+    pub fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior {
         match self {
             Self::Fixed(ln_prior) => ln_prior.as_ref().clone(),
             Self::Hosseinzadeh2020 {
@@ -598,7 +597,7 @@ impl VillarLnPrior {
                 let day = day.into_inner();
                 let min_amplitude = min_amplitude.into_inner();
 
-                LnPrior::ind_components([
+                LnPrior::ind_components(vec![
                     LnPrior1D::log_uniform(min_amplitude, 100.0 * m_amplitude), // amplitude
                     LnPrior1D::none(), // offset, not used in the original paper
                     LnPrior1D::uniform(t_peak - 50.0 * day, t_peak + 300.0 * day), // reference time
@@ -615,8 +614,8 @@ impl VillarLnPrior {
     }
 }
 
-impl From<LnPrior<NPARAMS>> for VillarLnPrior {
-    fn from(item: LnPrior<NPARAMS>) -> Self {
+impl From<LnPrior> for VillarLnPrior {
+    fn from(item: LnPrior) -> Self {
         Self::fixed(item)
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -125,21 +125,39 @@ macro_rules! json_schema {
 /// - implement all traits of [nl_fit::evaluator]
 /// - satisfy all [FeatureEvaluator] trait constraints
 /// - declare `const NPARAMS: usize` in your code
+///
+/// `$n` must be that same `NPARAMS` value: `curve_fit`'s solver-facing API is generic over
+/// `Fn(f64, &[f64]) -> f64`-shaped closures (GSL/Ceres/emcee/nuts-rs don't know about
+/// `MAX_NPARAMS`), while `Self::model`/`Self::derivatives` take fixed-size `&[T; $n]` so their
+/// own indexing is bounds-check-free. This macro is the one place that bridges the two: it
+/// builds thin wrapper closures that convert the solver's runtime slice to a fixed array before
+/// calling into the feature's own math.
 macro_rules! fit_eval {
-    () => {
+    ($n: expr) => {
         fn eval_no_ts_check(&self, ts: &mut TimeSeries<T>) -> Result<Vec<T>, EvaluatorError> {
             let norm_data = NormalizedData::<f64>::from_ts(ts);
 
             let (x0, lower, upper) = {
-                let FitInitsBoundsArrays {
-                    init: FitArray(mut x0),
-                    lower: FitArray(mut lower),
-                    upper: FitArray(mut upper),
-                } = self.init_and_bounds_from_ts(ts);
-                x0 = Self::convert_to_internal(&norm_data, &x0);
-                lower = Self::convert_to_internal(&norm_data, &lower);
-                upper = Self::convert_to_internal(&norm_data, &upper);
+                let FitInitsBoundsArrays { init, lower, upper } = self.init_and_bounds_from_ts(ts);
+                let x0 = Self::convert_to_internal(&norm_data, &init);
+                let lower = Self::convert_to_internal(&norm_data, &lower);
+                let upper = Self::convert_to_internal(&norm_data, &upper);
                 (x0, lower, upper)
+            };
+
+            let model_closure = |t: f64, param: &[f64]| -> f64 {
+                let arr: &[f64; $n] = param
+                    .try_into()
+                    .expect("curve_fit always calls model with exactly NPARAMS values");
+                Self::model(t, arr)
+            };
+            let derivatives_closure = |t: f64, param: &[f64], jac: &mut [f64]| {
+                let arr: &[f64; $n] = param
+                    .try_into()
+                    .expect("curve_fit always calls derivatives with exactly NPARAMS values");
+                let mut jac_arr = [0.0_f64; $n];
+                Self::derivatives(t, arr, &mut jac_arr);
+                jac.copy_from_slice(&jac_arr);
             };
 
             let result = {
@@ -149,13 +167,12 @@ macro_rules! fit_eval {
                     norm_data.data.clone(),
                     &x0,
                     (&lower, &upper),
-                    Self::model,
-                    Self::derivatives,
+                    model_closure,
+                    derivatives_closure,
                     self.ln_prior_from_ts(ts)
-                        .with_fit_parameters_transformation::<Self>(&norm_data),
+                        .with_fit_parameters_transformation::<Self, $n>(&norm_data),
                 );
-                let result =
-                    Self::convert_to_external(&norm_data, (&x as &[_]).try_into().unwrap());
+                let result = Self::convert_to_external(&norm_data, &x);
                 result
                     .into_iter()
                     .chain(std::iter::once(reduced_chi2))

--- a/src/nl_fit/bounds.rs
+++ b/src/nl_fit/bounds.rs
@@ -1,15 +1,9 @@
-pub(super) fn within_bounds<T, const NPARAMS: usize>(
-    x: &[T; NPARAMS],
-    lower: &[T; NPARAMS],
-    upper: &[T; NPARAMS],
-) -> bool
+pub(super) fn within_bounds<T>(x: &[T], lower: &[T], upper: &[T]) -> bool
 where
     T: PartialOrd,
 {
-    for i in 0..NPARAMS {
-        if x[i] < lower[i] || x[i] > upper[i] {
-            return false;
-        }
-    }
-    true
+    x.iter()
+        .zip(lower)
+        .zip(upper)
+        .all(|((xi, li), ui)| xi >= li && xi <= ui)
 }

--- a/src/nl_fit/ceres.rs
+++ b/src/nl_fit/ceres.rs
@@ -60,37 +60,37 @@ impl Default for CeresCurveFit {
 }
 
 impl CurveFitTrait for CeresCurveFit {
-    fn curve_fit<F, DF, LP, const NPARAMS: usize>(
+    fn curve_fit<F, DF, LP>(
         &self,
         ts: Rc<Data<f64>>,
-        x0: &[f64; NPARAMS],
-        bounds: (&[f64; NPARAMS], &[f64; NPARAMS]),
+        x0: &[f64],
+        bounds: (&[f64], &[f64]),
         model: F,
         derivatives: DF,
         _ln_prior: LP,
-    ) -> CurveFitResult<f64, NPARAMS>
+    ) -> CurveFitResult<f64>
     where
-        F: 'static + Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-        DF: 'static + Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-        LP: LnPriorEvaluator<NPARAMS>,
+        F: 'static + Clone + Fn(f64, &[f64]) -> f64,
+        DF: 'static + Clone + Fn(f64, &[f64], &mut [f64]),
+        LP: LnPriorEvaluator,
     {
+        let nparams = x0.len();
+        // Ceres calls this closure once per data point (unlike GSL, which loops over all
+        // points inside a single call), so the derivative scratch buffer is allocated once
+        // and reused via RefCell rather than fresh on every point.
+        let der_buf = std::cell::RefCell::new(vec![0.0; nparams]);
         let func: CurveFunctionType = {
             let model = model.clone();
             Box::new(move |t, parameters, y, jacobians| {
-                let parameters = parameters.try_into().unwrap();
                 *y = model(t, parameters);
                 if !y.is_finite() {
                     *y = f64::MAX.sqrt();
                     return false;
                 }
                 if let Some(jacobians) = jacobians {
-                    let jacobians: &mut [_; NPARAMS] = jacobians.try_into().unwrap();
-                    let der = {
-                        let mut der = [0.0; NPARAMS];
-                        derivatives(t, parameters, &mut der);
-                        der
-                    };
-                    for (input, output) in der.into_iter().zip(jacobians.iter_mut()) {
+                    let mut der = der_buf.borrow_mut();
+                    derivatives(t, parameters, &mut der);
+                    for (&input, output) in der.iter().zip(jacobians.iter_mut()) {
                         if let Some(output) = output {
                             if !input.is_finite() {
                                 return false;
@@ -124,7 +124,7 @@ impl CurveFitTrait for CeresCurveFit {
             problem_builder = problem_builder.loss(LossFunction::cauchy(loss_factor.into()));
         };
         let solution = problem_builder.build().unwrap().solve(&options);
-        let x = solution.parameters.try_into().unwrap();
+        let x = solution.parameters;
         let success = solution.summary.is_solution_usable();
 
         let reduced_chi2 = Zip::from(&ts.t)
@@ -133,7 +133,7 @@ impl CurveFitTrait for CeresCurveFit {
             .fold(0.0, |acc, &t, &m, &inv_err| {
                 acc + ((model(t, &x) - m) * inv_err).powi(2)
             })
-            / (ts.t.len() - NPARAMS) as f64;
+            / (ts.t.len() - nparams) as f64;
         CurveFitResult {
             x,
             reduced_chi2,
@@ -153,11 +153,11 @@ mod tests {
     use rand::prelude::*;
     use rand_distr::StandardNormal;
 
-    fn nonlinear_func(t: f64, param: &[f64; 3]) -> f64 {
+    fn nonlinear_func(t: f64, param: &[f64]) -> f64 {
         param[1] * f64::exp(-param[0] * t) * t.powi(2) + param[2]
     }
 
-    fn nonlinear_func_derivatives(t: f64, param: &[f64; 3], derivatives: &mut [f64; 3]) {
+    fn nonlinear_func_derivatives(t: f64, param: &[f64], derivatives: &mut [f64]) {
         derivatives[0] = -param[1] * f64::exp(-param[2] * t) * t.powi(3);
         derivatives[1] = f64::exp(-param[0] * t) * t.powi(2);
         derivatives[2] = 1.0;

--- a/src/nl_fit/curve_fit.rs
+++ b/src/nl_fit/curve_fit.rs
@@ -15,27 +15,27 @@ use std::fmt::Debug;
 use std::rc::Rc;
 
 #[derive(Clone, Debug)]
-pub struct CurveFitResult<T, const NPARAMS: usize> {
-    pub x: [T; NPARAMS],
+pub struct CurveFitResult<T> {
+    pub x: Vec<T>,
     pub reduced_chi2: T,
     pub success: bool,
 }
 
 #[enum_dispatch]
 pub trait CurveFitTrait: Clone + Debug + Serialize + DeserializeOwned {
-    fn curve_fit<F, DF, LP, const NPARAMS: usize>(
+    fn curve_fit<F, DF, LP>(
         &self,
         ts: Rc<Data<f64>>,
-        x0: &[f64; NPARAMS],
-        bounds: (&[f64; NPARAMS], &[f64; NPARAMS]),
+        x0: &[f64],
+        bounds: (&[f64], &[f64]),
         model: F,
         derivatives: DF,
         ln_prior: LP,
-    ) -> CurveFitResult<f64, NPARAMS>
+    ) -> CurveFitResult<f64>
     where
-        F: 'static + Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-        DF: 'static + Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-        LP: LnPriorEvaluator<NPARAMS>;
+        F: 'static + Clone + Fn(f64, &[f64]) -> f64,
+        DF: 'static + Clone + Fn(f64, &[f64], &mut [f64]),
+        LP: LnPriorEvaluator;
 }
 
 /// Optimization algorithm for non-linear least squares

--- a/src/nl_fit/evaluator.rs
+++ b/src/nl_fit/evaluator.rs
@@ -3,224 +3,119 @@ use crate::float_trait::Float;
 use crate::nl_fit::{CurveFitAlgorithm, LikeFloat, LnPrior, data::NormalizedData};
 
 use schemars::JsonSchema;
-use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 
-pub trait FitModelTrait<T, U, const NPARAMS: usize>
+pub trait FitModelTrait<T, U, const MAX_NPARAMS: usize>
 where
     T: Float + Into<U>,
     U: LikeFloat,
 {
-    fn model(t: T, param: &[U; NPARAMS]) -> U
+    fn model(t: T, param: &[U; MAX_NPARAMS]) -> U
     where
         T: Float + Into<U>,
         U: LikeFloat;
 }
 
-pub trait FitFunctionTrait<T: Float, const NPARAMS: usize>:
-    FitModelTrait<T, T, NPARAMS> + FitParametersInternalDimlessTrait<T, NPARAMS>
+pub trait FitFunctionTrait<T: Float, const MAX_NPARAMS: usize>:
+    FitModelTrait<T, T, MAX_NPARAMS> + FitParametersInternalDimlessTrait<T, MAX_NPARAMS>
 {
-    fn f(t: T, values: &[T]) -> T {
-        let internal = Self::dimensionless_to_internal(
-            values[..NPARAMS]
-                .try_into()
-                .expect("values slice's length is too small"),
-        );
+    fn f(t: T, values: &[T; MAX_NPARAMS]) -> T {
+        let internal = Self::dimensionless_to_internal(values);
         Self::model(t, &internal)
     }
 }
 
-pub trait FitDerivalivesTrait<T: Float, const NPARAMS: usize> {
-    fn derivatives(t: T, param: &[T; NPARAMS], jac: &mut [T; NPARAMS]);
+pub trait FitDerivalivesTrait<T: Float, const MAX_NPARAMS: usize> {
+    fn derivatives(t: T, param: &[T; MAX_NPARAMS], jac: &mut [T; MAX_NPARAMS]);
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
-#[serde(
-    into = "FitArraySerde<T>",
-    try_from = "FitArraySerde<T>",
-    bound = "T: Debug + Clone + Serialize + DeserializeOwned + JsonSchema"
-)]
-pub struct FitArray<T, const NPARAMS: usize>(pub [T; NPARAMS]);
-
-impl<T, const NPARAMS: usize> JsonSchema for FitArray<T, NPARAMS>
-where
-    T: schemars::JsonSchema,
-{
-    fn is_referenceable() -> bool {
-        false
-    }
-
-    fn schema_name() -> String {
-        FitArraySerde::<T>::schema_name()
-    }
-
-    fn json_schema(r#gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
-        FitArraySerde::<T>::json_schema(r#gen)
-    }
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct FitInitsBoundsArrays {
+    pub init: Vec<f64>,
+    pub lower: Vec<f64>,
+    pub upper: Vec<f64>,
 }
 
-impl<T, const NPARAMS: usize> From<[T; NPARAMS]> for FitArray<T, NPARAMS> {
-    fn from(item: [T; NPARAMS]) -> Self {
-        Self(item)
-    }
-}
-
-impl<T, const NPARAMS: usize> std::ops::Deref for FitArray<T, NPARAMS> {
-    type Target = [T; NPARAMS];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T, const NPARAMS: usize> From<FitArray<T, NPARAMS>> for FitArray<Option<T>, NPARAMS>
-where
-    T: Copy,
-{
-    fn from(item: FitArray<T, NPARAMS>) -> Self {
-        let mut opt = [None; NPARAMS];
-        for (&x, y) in item.0.iter().zip(opt.iter_mut()) {
-            *y = Some(x);
-        }
-        opt.into()
-    }
-}
-
-impl<T, const NPARAMS: usize> FitArray<Option<T>, NPARAMS>
-where
-    T: Clone,
-{
-    fn unwrap_with(&self, with: &FitArray<T, NPARAMS>) -> FitArray<T, NPARAMS> {
-        let mut a = with.clone();
-        for (opt, x) in self.0.iter().zip(a.0.iter_mut()) {
-            if let Some(value) = opt {
-                *x = value.clone()
-            }
-        }
-        a
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(
-    rename = "FitArray",
-    bound = "T: Debug + Clone + Serialize + DeserializeOwned + JsonSchema"
-)]
-struct FitArraySerde<T>(Vec<T>);
-
-impl<T, const NPARAMS: usize> From<FitArray<T, NPARAMS>> for FitArraySerde<T> {
-    fn from(item: FitArray<T, NPARAMS>) -> Self {
-        Self(item.0.into())
-    }
-}
-
-impl<T, const NPARAMS: usize> TryFrom<FitArraySerde<T>> for FitArray<T, NPARAMS> {
-    type Error = &'static str;
-
-    fn try_from(item: FitArraySerde<T>) -> Result<Self, Self::Error> {
-        Ok(Self(
-            item.0
-                .try_into()
-                .map_err(|_| "wrong size of the FitArray object")?,
-        ))
+impl FitInitsBoundsArrays {
+    pub fn new(init: Vec<f64>, lower: Vec<f64>, upper: Vec<f64>) -> Self {
+        Self { init, lower, upper }
     }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
-pub struct FitInitsBoundsArrays<const NPARAMS: usize> {
-    pub init: FitArray<f64, NPARAMS>,
-    pub lower: FitArray<f64, NPARAMS>,
-    pub upper: FitArray<f64, NPARAMS>,
+pub struct OptionFitInitsBoundsArrays {
+    pub init: Vec<Option<f64>>,
+    pub lower: Vec<Option<f64>>,
+    pub upper: Vec<Option<f64>>,
 }
 
-impl<const NPARAMS: usize> FitInitsBoundsArrays<NPARAMS> {
-    pub fn new(init: [f64; NPARAMS], lower: [f64; NPARAMS], upper: [f64; NPARAMS]) -> Self {
-        Self {
-            init: init.into(),
-            lower: lower.into(),
-            upper: upper.into(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
-pub struct OptionFitInitsBoundsArrays<const NPARAMS: usize> {
-    pub init: FitArray<Option<f64>, NPARAMS>,
-    pub lower: FitArray<Option<f64>, NPARAMS>,
-    pub upper: FitArray<Option<f64>, NPARAMS>,
-}
-
-impl<const NPARAMS: usize> OptionFitInitsBoundsArrays<NPARAMS> {
-    pub fn new(
-        init: [Option<f64>; NPARAMS],
-        lower: [Option<f64>; NPARAMS],
-        upper: [Option<f64>; NPARAMS],
-    ) -> Self {
-        Self {
-            init: init.into(),
-            lower: lower.into(),
-            upper: upper.into(),
-        }
+impl OptionFitInitsBoundsArrays {
+    pub fn new(init: Vec<Option<f64>>, lower: Vec<Option<f64>>, upper: Vec<Option<f64>>) -> Self {
+        Self { init, lower, upper }
     }
 
-    pub fn unwrap_with(&self, x: &FitInitsBoundsArrays<NPARAMS>) -> FitInitsBoundsArrays<NPARAMS> {
+    pub fn unwrap_with(&self, x: &FitInitsBoundsArrays) -> FitInitsBoundsArrays {
+        let unwrap_slice = |opt: &[Option<f64>], with: &[f64]| -> Vec<f64> {
+            opt.iter().zip(with).map(|(o, &w)| o.unwrap_or(w)).collect()
+        };
         FitInitsBoundsArrays {
-            init: self.init.unwrap_with(&x.init),
-            lower: self.lower.unwrap_with(&x.lower),
-            upper: self.upper.unwrap_with(&x.upper),
+            init: unwrap_slice(&self.init, &x.init),
+            lower: unwrap_slice(&self.lower, &x.lower),
+            upper: unwrap_slice(&self.upper, &x.upper),
         }
     }
 }
 
-impl<const NPARAMS: usize> From<FitInitsBoundsArrays<NPARAMS>>
-    for OptionFitInitsBoundsArrays<NPARAMS>
-{
-    fn from(item: FitInitsBoundsArrays<NPARAMS>) -> Self {
+impl From<FitInitsBoundsArrays> for OptionFitInitsBoundsArrays {
+    fn from(item: FitInitsBoundsArrays) -> Self {
         Self {
-            init: item.init.into(),
-            lower: item.lower.into(),
-            upper: item.upper.into(),
+            init: item.init.into_iter().map(Some).collect(),
+            lower: item.lower.into_iter().map(Some).collect(),
+            upper: item.upper.into_iter().map(Some).collect(),
         }
     }
 }
 
-pub trait FitInitsBoundsTrait<T: Float, const NPARAMS: usize> {
-    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays<NPARAMS>;
+pub trait FitInitsBoundsTrait<T: Float> {
+    fn init_and_bounds_from_ts(&self, ts: &mut TimeSeries<T>) -> FitInitsBoundsArrays;
 }
 
-pub trait FitParametersInternalDimlessTrait<U: LikeFloat, const NPARAMS: usize> {
-    fn dimensionless_to_internal(params: &[U; NPARAMS]) -> [U; NPARAMS];
+pub trait FitParametersInternalDimlessTrait<U: LikeFloat, const MAX_NPARAMS: usize> {
+    fn dimensionless_to_internal(params: &[U; MAX_NPARAMS]) -> [U; MAX_NPARAMS];
 
-    fn internal_to_dimensionless(params: &[U; NPARAMS]) -> [U; NPARAMS];
+    fn internal_to_dimensionless(params: &[U; MAX_NPARAMS]) -> [U; MAX_NPARAMS];
 }
 
-pub trait FitParametersOriginalDimLessTrait<const NPARAMS: usize> {
+pub trait FitParametersOriginalDimLessTrait<const MAX_NPARAMS: usize> {
     fn orig_to_dimensionless(
         norm_data: &NormalizedData<f64>,
-        orig: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS];
+        orig: &[f64; MAX_NPARAMS],
+    ) -> [f64; MAX_NPARAMS];
 
     fn dimensionless_to_orig(
         norm_data: &NormalizedData<f64>,
-        norm: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS];
+        norm: &[f64; MAX_NPARAMS],
+    ) -> [f64; MAX_NPARAMS];
 }
 
-pub trait FitParametersInternalExternalTrait<const NPARAMS: usize>:
-    FitParametersInternalDimlessTrait<f64, NPARAMS> + FitParametersOriginalDimLessTrait<NPARAMS>
+pub trait FitParametersInternalExternalTrait<const MAX_NPARAMS: usize>:
+    FitParametersInternalDimlessTrait<f64, MAX_NPARAMS> + FitParametersOriginalDimLessTrait<MAX_NPARAMS>
 {
-    fn convert_to_internal(
-        norm_data: &NormalizedData<f64>,
-        orig: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
+    /// `orig` must have exactly `MAX_NPARAMS` elements -- true for every caller in this crate,
+    /// since it always originates from this same feature's own `FitInitsBoundsArrays`.
+    fn convert_to_internal(norm_data: &NormalizedData<f64>, orig: &[f64]) -> [f64; MAX_NPARAMS] {
+        let orig: &[f64; MAX_NPARAMS] = orig
+            .try_into()
+            .expect("orig must have exactly MAX_NPARAMS elements");
         Self::dimensionless_to_internal(&Self::orig_to_dimensionless(norm_data, orig))
     }
 
-    fn convert_to_external(
-        norm_data: &NormalizedData<f64>,
-        params: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS] {
+    /// `params` must have exactly `MAX_NPARAMS` elements -- true for every caller in this
+    /// crate, since it always originates from this same feature's own `curve_fit` call.
+    fn convert_to_external(norm_data: &NormalizedData<f64>, params: &[f64]) -> [f64; MAX_NPARAMS] {
+        let params: &[f64; MAX_NPARAMS] = params
+            .try_into()
+            .expect("params must have exactly MAX_NPARAMS elements");
         Self::dimensionless_to_orig(norm_data, &Self::internal_to_dimensionless(params))
     }
 
@@ -242,12 +137,12 @@ pub trait FitParametersInternalExternalTrait<const NPARAMS: usize>:
     /// Since both transformations are element-wise, the full Jacobian is diagonal.
     fn jacobian_internal_to_external(
         norm_data: &NormalizedData<f64>,
-        internal: &[f64; NPARAMS],
-    ) -> [f64; NPARAMS];
+        internal: &[f64; MAX_NPARAMS],
+    ) -> [f64; MAX_NPARAMS];
 }
 
-pub trait FitFeatureEvaluatorGettersTrait<const NPARAMS: usize> {
+pub trait FitFeatureEvaluatorGettersTrait {
     fn get_algorithm(&self) -> &CurveFitAlgorithm;
 
-    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior<NPARAMS>;
+    fn ln_prior_from_ts<T: Float>(&self, ts: &mut TimeSeries<T>) -> LnPrior;
 }

--- a/src/nl_fit/lmsder.rs
+++ b/src/nl_fit/lmsder.rs
@@ -50,24 +50,25 @@ impl Default for LmsderCurveFit {
 }
 
 impl CurveFitTrait for LmsderCurveFit {
-    fn curve_fit<F, DF, LP, const NPARAMS: usize>(
+    fn curve_fit<F, DF, LP>(
         &self,
         ts: Rc<Data<f64>>,
-        x0: &[f64; NPARAMS],
-        _bounds: (&[f64; NPARAMS], &[f64; NPARAMS]),
+        x0: &[f64],
+        _bounds: (&[f64], &[f64]),
         model: F,
         derivatives: DF,
         _ln_prior: LP,
-    ) -> CurveFitResult<f64, NPARAMS>
+    ) -> CurveFitResult<f64>
     where
-        F: 'static + Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-        DF: 'static + Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-        LP: LnPriorEvaluator<NPARAMS>,
+        F: 'static + Clone + Fn(f64, &[f64]) -> f64,
+        DF: 'static + Clone + Fn(f64, &[f64], &mut [f64]),
+        LP: LnPriorEvaluator,
     {
+        let nparams = x0.len();
         let f = {
             let ts = ts.clone();
             move |param: VectorF64, mut residual: VectorF64| {
-                let param = param.as_slice().unwrap().try_into().unwrap();
+                let param = param.as_slice().unwrap();
                 Zip::from(&ts.t)
                     .and(&ts.m)
                     .and(&ts.inv_err)
@@ -81,8 +82,8 @@ impl CurveFitTrait for LmsderCurveFit {
         let df = {
             let ts = ts.clone();
             move |param: VectorF64, mut jacobian: MatrixF64| {
-                let param = param.as_slice().unwrap().try_into().unwrap();
-                let mut buffer = [0.0; NPARAMS];
+                let param = param.as_slice().unwrap();
+                let mut buffer = vec![0.0; nparams];
                 Zip::indexed(&ts.t)
                     .and(&ts.inv_err)
                     .for_each(|i, &t, &inv_err| {
@@ -95,18 +96,14 @@ impl CurveFitTrait for LmsderCurveFit {
             }
         };
 
-        let mut problem = NlsProblem::from_f_df(ts.t.len(), NPARAMS, f, df);
+        let mut problem = NlsProblem::from_f_df(ts.t.len(), nparams, f, df);
         problem.max_iter = self.niterations;
         let result = problem.solve(VectorF64::from_slice(x0).unwrap());
-        let x = {
-            let x = result.x();
-            let x: &[_; NPARAMS] = x.as_slice().unwrap().try_into().unwrap();
-            *x
-        };
+        let x = result.x().as_slice().unwrap().to_vec();
 
         CurveFitResult {
             x,
-            reduced_chi2: result.loss() / ((ts.t.len() - NPARAMS) as f64),
+            reduced_chi2: result.loss() / ((ts.t.len() - nparams) as f64),
             success: result.status == Value::Success,
         }
     }

--- a/src/nl_fit/mcmc.rs
+++ b/src/nl_fit/mcmc.rs
@@ -6,7 +6,6 @@ use crate::nl_fit::prior::ln_prior::LnPriorEvaluator;
 
 use emcee::{EnsembleSampler, Guess, Prob};
 use emcee_rand::{distributions::IndependentSample, *};
-use itertools::Itertools;
 use ndarray::Zip;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -59,22 +58,23 @@ impl Default for McmcCurveFit {
 }
 
 impl CurveFitTrait for McmcCurveFit {
-    fn curve_fit<F, DF, LP, const NPARAMS: usize>(
+    fn curve_fit<F, DF, LP>(
         &self,
         ts: Rc<Data<f64>>,
-        x0: &[f64; NPARAMS],
-        bounds: (&[f64; NPARAMS], &[f64; NPARAMS]),
+        x0: &[f64],
+        bounds: (&[f64], &[f64]),
         model: F,
         derivatives: DF,
         ln_prior: LP,
-    ) -> CurveFitResult<f64, NPARAMS>
+    ) -> CurveFitResult<f64>
     where
-        F: 'static + Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-        DF: 'static + Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-        LP: LnPriorEvaluator<NPARAMS>,
+        F: 'static + Clone + Fn(f64, &[f64]) -> f64,
+        DF: 'static + Clone + Fn(f64, &[f64], &mut [f64]),
+        LP: LnPriorEvaluator,
     {
         const NWALKERS_PER_DIMENSION: usize = 4;
-        let nwalkers = NWALKERS_PER_DIMENSION * NPARAMS;
+        let nparams = x0.len();
+        let nwalkers = NWALKERS_PER_DIMENSION * nparams;
         let nsamples = ts.t.len();
 
         let lnlike = {
@@ -82,7 +82,7 @@ impl CurveFitTrait for McmcCurveFit {
             let model = model.clone();
             move |guess: &Guess| {
                 let mut residual = 0.0;
-                let params = slice_to_array(&guess.values);
+                let params = slice_to_vec(&guess.values);
                 Zip::from(&ts.t)
                     .and(&ts.m)
                     .and(&ts.inv_err)
@@ -95,13 +95,13 @@ impl CurveFitTrait for McmcCurveFit {
         let lnprior = {
             let ln_prior = ln_prior.clone();
             move |guess: &Guess| {
-                let params = slice_to_array(&guess.values);
+                let params = slice_to_vec(&guess.values);
                 ln_prior.ln_prior(&params, None) as f32
             }
         };
 
-        let x0_f32: [_; NPARAMS] = slice_to_array(x0);
-        let bounds_f32 = (slice_to_array(bounds.0), slice_to_array(bounds.1));
+        let x0_f32: Vec<f32> = slice_to_vec(x0);
+        let bounds_f32 = (slice_to_vec(bounds.0), slice_to_vec(bounds.1));
 
         let initial_guesses = generate_initial_guesses(
             nwalkers,
@@ -116,7 +116,7 @@ impl CurveFitTrait for McmcCurveFit {
             lower: &bounds_f32.0,
             upper: &bounds_f32.1,
         };
-        let mut sampler = EnsembleSampler::new(nwalkers, NPARAMS, &emcee_model).unwrap();
+        let mut sampler = EnsembleSampler::new(nwalkers, nparams, &emcee_model).unwrap();
         sampler.seed(&[]);
 
         let (best_x, best_lnprob) = {
@@ -139,17 +139,10 @@ impl CurveFitTrait for McmcCurveFit {
         };
 
         match self.fine_tuning_algorithm.as_ref() {
-            Some(algo) => algo.curve_fit(
-                ts,
-                &best_x.try_into().unwrap(),
-                bounds,
-                model,
-                derivatives,
-                ln_prior,
-            ),
+            Some(algo) => algo.curve_fit(ts, &best_x, bounds, model, derivatives, ln_prior),
             None => CurveFitResult {
-                x: best_x.try_into().unwrap(),
-                reduced_chi2: -best_lnprob / ((nsamples - NPARAMS) as f64),
+                x: best_x,
+                reduced_chi2: -best_lnprob / ((nsamples - nparams) as f64),
                 success: true,
             },
         }
@@ -157,23 +150,21 @@ impl CurveFitTrait for McmcCurveFit {
 }
 
 #[inline]
-fn slice_to_array<T, U, const NPARAMS: usize>(sl: &[T]) -> [U; NPARAMS]
+fn slice_to_vec<T, U>(sl: &[T]) -> Vec<U>
 where
     T: Float,
     U: Float,
 {
-    let mut array = [U::zero(); NPARAMS];
-    for (input, output) in sl.iter().zip_eq(array.iter_mut()) {
-        *output = num_traits::cast::cast(*input).unwrap();
-    }
-    array
+    sl.iter()
+        .map(|&x| num_traits::cast::cast(x).unwrap())
+        .collect()
 }
 
 #[inline]
-fn generate_initial_guesses<R, const NPARAMS: usize>(
+fn generate_initial_guesses<R>(
     nwalkers: usize,
-    x0: &[f32; NPARAMS],
-    bounds: (&[f32; NPARAMS], &[f32; NPARAMS]),
+    x0: &[f32],
+    bounds: (&[f32], &[f32]),
     rng: &mut R,
 ) -> Vec<Guess>
 where
@@ -221,14 +212,14 @@ where
         .collect()
 }
 
-struct EmceeModel<'b, F, LP, const NPARAMS: usize> {
+struct EmceeModel<'b, F, LP> {
     ln_like: F,
     ln_prior: LP,
-    lower: &'b [f32; NPARAMS],
-    upper: &'b [f32; NPARAMS],
+    lower: &'b [f32],
+    upper: &'b [f32],
 }
 
-impl<F, LP, const NPARAMS: usize> Prob for EmceeModel<'_, F, LP, NPARAMS>
+impl<F, LP> Prob for EmceeModel<'_, F, LP>
 where
     F: Fn(&Guess) -> f32,
     LP: Fn(&Guess) -> f32,
@@ -238,11 +229,7 @@ where
     }
 
     fn lnprior(&self, params: &Guess) -> f32 {
-        if !within_bounds(
-            (&params.values[..]).try_into().unwrap(),
-            self.lower,
-            self.upper,
-        ) {
+        if !within_bounds(&params.values, self.lower, self.upper) {
             return f32::NEG_INFINITY;
         }
         (self.ln_prior)(params)

--- a/src/nl_fit/mod.rs
+++ b/src/nl_fit/mod.rs
@@ -95,7 +95,7 @@
 //! Models implement [`FitModelTrait`](evaluator::FitModelTrait):
 //!
 //! ```text
-//! fn model(t: T, internal_params: &[U; NPARAMS]) -> U
+//! fn model(t: T, internal_params: &[U]) -> U
 //! ```
 //!
 //! The model receives **internal** parameters and typically transforms them to dimensionless

--- a/src/nl_fit/nuts.rs
+++ b/src/nl_fit/nuts.rs
@@ -68,16 +68,15 @@ impl Default for NutsCurveFit {
     }
 }
 
+/// `logp` no longer has a fallible conversion step (it now takes `params: &[f64]` directly,
+/// rather than converting to a fixed-size array first), so this error can never actually be
+/// constructed -- kept as an uninhabited type only because `CpuLogpFunc::LogpError` requires one.
 #[derive(Debug)]
-enum NutsLogpError {
-    NonRecoverable,
-}
+enum NutsLogpError {}
 
 impl std::fmt::Display for NutsLogpError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            NutsLogpError::NonRecoverable => write!(f, "Non-recoverable error in logp calculation"),
-        }
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {}
     }
 }
 
@@ -85,69 +84,68 @@ impl std::error::Error for NutsLogpError {}
 
 impl LogpError for NutsLogpError {
     fn is_recoverable(&self) -> bool {
-        false
+        match *self {}
     }
 }
 
-struct LogpFunc<F, DF, LP, const NPARAMS: usize> {
+struct LogpFunc<F, DF, LP> {
     ts: Rc<Data<f64>>,
     model: F,
     derivatives: DF,
     ln_prior: LP,
-    lower: [f64; NPARAMS],
-    upper: [f64; NPARAMS],
+    lower: Vec<f64>,
+    upper: Vec<f64>,
 }
 
-impl<F, DF, LP, const NPARAMS: usize> HasDims for LogpFunc<F, DF, LP, NPARAMS> {
+impl<F, DF, LP> HasDims for LogpFunc<F, DF, LP> {
     fn dim_sizes(&self) -> HashMap<String, u64> {
+        let nparams = self.lower.len() as u64;
         HashMap::from([
-            ("unconstrained_parameter".to_string(), NPARAMS as u64),
-            ("dim".to_string(), NPARAMS as u64),
+            ("unconstrained_parameter".to_string(), nparams),
+            ("dim".to_string(), nparams),
         ])
     }
 }
 
-impl<F, DF, LP, const NPARAMS: usize> CpuLogpFunc for LogpFunc<F, DF, LP, NPARAMS>
+impl<F, DF, LP> CpuLogpFunc for LogpFunc<F, DF, LP>
 where
-    F: Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-    DF: Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-    LP: LnPriorEvaluator<NPARAMS>,
+    F: Clone + Fn(f64, &[f64]) -> f64,
+    DF: Clone + Fn(f64, &[f64], &mut [f64]),
+    LP: LnPriorEvaluator,
 {
     type LogpError = NutsLogpError;
     type FlowParameters = ();
     type ExpandedVector = Vec<f64>;
 
     fn dim(&self) -> usize {
-        NPARAMS
+        self.lower.len()
     }
 
     fn logp(&mut self, params: &[f64], grad: &mut [f64]) -> Result<f64, Self::LogpError> {
-        // Check boundaries
-        let params_array: [f64; NPARAMS] = params
-            .try_into()
-            .map_err(|_| NutsLogpError::NonRecoverable)?;
+        let nparams = self.lower.len();
 
-        if !within_bounds(&params_array, &self.lower, &self.upper) {
+        // Check boundaries
+        if !within_bounds(params, &self.lower, &self.upper) {
             return Ok(f64::NEG_INFINITY);
         }
 
         // Calculate log-likelihood (negative chi-squared)
         let mut residual = 0.0;
-        let mut grad_array = [0.0; NPARAMS];
+        let mut grad_array = vec![0.0; nparams];
 
         // Compute -chi^2/2 and its gradient
+        let mut model_grad = vec![0.0; nparams];
         Zip::from(&self.ts.t)
             .and(&self.ts.m)
             .and(&self.ts.inv_err)
             .for_each(|&t, &m, &inv_err| {
-                let model_val = (self.model)(t, &params_array);
+                let model_val = (self.model)(t, params);
                 let diff = model_val - m;
                 residual += (inv_err * diff).powi(2);
 
                 // Gradient of chi^2 with respect to parameters
-                let mut model_grad = [0.0; NPARAMS];
-                (self.derivatives)(t, &params_array, &mut model_grad);
-                for i in 0..NPARAMS {
+                (self.derivatives)(t, params, &mut model_grad);
+                for i in 0..nparams {
                     grad_array[i] += 2.0 * inv_err.powi(2) * diff * model_grad[i];
                 }
             });
@@ -155,13 +153,13 @@ where
         let lnlike = -0.5 * residual;
 
         // Add prior and compute its gradient
-        let mut prior_grad = [0.0; NPARAMS];
-        let lnprior = self.ln_prior.ln_prior(&params_array, Some(&mut prior_grad));
+        let mut prior_grad = vec![0.0; nparams];
+        let lnprior = self.ln_prior.ln_prior(params, Some(&mut prior_grad));
 
         // Gradient is d(lnlike + lnprior)/d(params)
         // = d(lnlike)/d(params) + d(lnprior)/d(params)
         // = -0.5 * d(chi^2)/d(params) + d(lnprior)/d(params)
-        for i in 0..NPARAMS {
+        for i in 0..nparams {
             grad[i] = -0.5 * grad_array[i] + prior_grad[i];
         }
 
@@ -178,20 +176,21 @@ where
 }
 
 impl CurveFitTrait for NutsCurveFit {
-    fn curve_fit<F, DF, LP, const NPARAMS: usize>(
+    fn curve_fit<F, DF, LP>(
         &self,
         ts: Rc<Data<f64>>,
-        x0: &[f64; NPARAMS],
-        bounds: (&[f64; NPARAMS], &[f64; NPARAMS]),
+        x0: &[f64],
+        bounds: (&[f64], &[f64]),
         model: F,
         derivatives: DF,
         ln_prior: LP,
-    ) -> CurveFitResult<f64, NPARAMS>
+    ) -> CurveFitResult<f64>
     where
-        F: 'static + Clone + Fn(f64, &[f64; NPARAMS]) -> f64,
-        DF: 'static + Clone + Fn(f64, &[f64; NPARAMS], &mut [f64; NPARAMS]),
-        LP: LnPriorEvaluator<NPARAMS>,
+        F: 'static + Clone + Fn(f64, &[f64]) -> f64,
+        DF: 'static + Clone + Fn(f64, &[f64], &mut [f64]),
+        LP: LnPriorEvaluator,
     {
+        let nparams = x0.len();
         let nsamples = ts.t.len();
 
         let logp_func = LogpFunc {
@@ -199,8 +198,8 @@ impl CurveFitTrait for NutsCurveFit {
             model: model.clone(),
             derivatives: derivatives.clone(),
             ln_prior: ln_prior.clone(),
-            lower: *bounds.0,
-            upper: *bounds.1,
+            lower: bounds.0.to_vec(),
+            upper: bounds.1.to_vec(),
         };
 
         let math = CpuMath::new(logp_func);
@@ -215,7 +214,7 @@ impl CurveFitTrait for NutsCurveFit {
         let mut sampler = settings.new_chain(0, math, &mut rng);
 
         // Set initial position
-        sampler.set_position(&x0[..]).unwrap_or_else(|e| {
+        sampler.set_position(x0).unwrap_or_else(|e| {
             panic!(
                 "Failed to set initial position for NUTS sampler. \
                      This may be due to invalid parameters or boundary violations. \
@@ -225,16 +224,13 @@ impl CurveFitTrait for NutsCurveFit {
         });
 
         // Collect samples
-        let mut best_x = *x0;
+        let mut best_x = x0.to_vec();
         let mut best_lnprob = f64::NEG_INFINITY;
 
         for _ in 0..(self.num_tune + self.num_draws) {
             match sampler.expanded_draw() {
                 Ok((draw, _expanded, stats, _progress)) => {
-                    // Convert draw to array
-                    let params: [f64; NPARAMS] = Vec::from(draw)
-                        .try_into()
-                        .expect("Failed to convert draw to array");
+                    let params = Vec::from(draw);
 
                     // Use the log probability from the sampler stats
                     let lnprob = stats.point.logp;
@@ -262,7 +258,7 @@ impl CurveFitTrait for NutsCurveFit {
                     .for_each(|&t, &m, &inv_err| {
                         residual += (inv_err * (model(t, &best_x) - m)).powi(2);
                     });
-                let reduced_chi2 = residual / ((nsamples - NPARAMS) as f64);
+                let reduced_chi2 = residual / ((nsamples - nparams) as f64);
 
                 CurveFitResult {
                     x: best_x,
@@ -380,17 +376,18 @@ mod tests {
             posterior_var * ((N as f64) * y_target / obs_var + prior_mean / prior_var);
 
         // Create prior in external space
-        let prior: LnPrior<1> = LnPrior::ind_components([LnPrior1D::normal(prior_mean, prior_std)]);
+        let prior: LnPrior =
+            LnPrior::ind_components(vec![LnPrior1D::normal(prior_mean, prior_std)]);
 
         // Transform prior to work with internal parameters
         let transformed_prior =
-            prior.with_fit_parameters_transformation::<SimpleConstantModel>(&norm_data);
+            prior.with_fit_parameters_transformation::<SimpleConstantModel, _>(&norm_data);
 
         // Model: f(t) = |internal[0]|
-        let model = |_t: f64, params: &[f64; 1]| -> f64 { params[0].abs() };
+        let model = |_t: f64, params: &[f64]| -> f64 { params[0].abs() };
 
         // Derivatives: d(|x|)/dx = sign(x)
-        let derivatives = |_t: f64, params: &[f64; 1], jac: &mut [f64; 1]| {
+        let derivatives = |_t: f64, params: &[f64], jac: &mut [f64]| {
             jac[0] = params[0].signum();
         };
 
@@ -457,9 +454,9 @@ mod tests {
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
         // Prior in external space: N(1.0, 0.5²)
-        let prior: LnPrior<1> = LnPrior::ind_components([LnPrior1D::normal(1.0, 0.5)]);
+        let prior: LnPrior = LnPrior::ind_components(vec![LnPrior1D::normal(1.0, 0.5)]);
         let transformed_prior =
-            prior.with_fit_parameters_transformation::<SimpleConstantModel>(&norm_data);
+            prior.with_fit_parameters_transformation::<SimpleConstantModel, _>(&norm_data);
 
         // Test with both positive and negative internal parameters
         // The key insight: for external = |internal|, the gradient should flip sign
@@ -530,9 +527,9 @@ mod tests {
         let mut ts = TimeSeries::new(&t_vec, &m_vec, &w_vec);
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
-        let prior: LnPrior<1> = LnPrior::ind_components([LnPrior1D::normal(1.0, 0.5)]);
+        let prior: LnPrior = LnPrior::ind_components(vec![LnPrior1D::normal(1.0, 0.5)]);
         let transformed_prior =
-            prior.with_fit_parameters_transformation::<SimpleConstantModel>(&norm_data);
+            prior.with_fit_parameters_transformation::<SimpleConstantModel, _>(&norm_data);
 
         // Test that ln_prior(+x) == ln_prior(-x) for the same |x|
         for &x in &[0.5, 1.0, 1.5, 2.0] {

--- a/src/nl_fit/prior/ln_prior.rs
+++ b/src/nl_fit/prior/ln_prior.rs
@@ -12,11 +12,12 @@ use std::fmt::Debug;
 /// This trait is implemented by types that can evaluate ln(prior) for a given set of parameters.
 /// Unlike [LnPriorTrait], this trait does not require serialization, making it suitable for
 /// use with closures and other non-serializable types.
-pub trait LnPriorEvaluator<const NPARAMS: usize>: Clone {
+pub trait LnPriorEvaluator: Clone {
     /// Evaluate the natural logarithm of the prior at params
     ///
     /// If `jac` is `Some`, the jacobian (gradient) d(ln_prior)/d(params) is also computed and stored in it.
-    fn ln_prior(&self, params: &[f64; NPARAMS], jac: Option<&mut [f64; NPARAMS]>) -> f64;
+    /// `jac`, when given, must be the same length as `params`.
+    fn ln_prior(&self, params: &[f64], jac: Option<&mut [f64]>) -> f64;
 }
 
 /// Trait for serializable prior evaluators
@@ -28,22 +29,19 @@ pub trait LnPriorEvaluator<const NPARAMS: usize>: Clone {
 /// or temporary prior objects). Use this trait when you need to serialize the prior
 /// configuration.
 #[enum_dispatch]
-pub trait LnPriorTrait<const NPARAMS: usize>:
-    LnPriorEvaluator<NPARAMS> + Debug + Serialize + DeserializeOwned
-{
-}
+pub trait LnPriorTrait: LnPriorEvaluator + Debug + Serialize + DeserializeOwned {}
 
 /// Natural logarithm of prior for non-linear curve-fit problem
-#[enum_dispatch(LnPriorTrait<NPARAMS>)]
+#[enum_dispatch(LnPriorTrait)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
 #[non_exhaustive]
-pub enum LnPrior<const NPARAMS: usize> {
+pub enum LnPrior {
     None(NoneLnPrior),
-    IndComponents(IndComponentsLnPrior<NPARAMS>),
+    IndComponents(IndComponentsLnPrior),
 }
 
-impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for LnPrior<NPARAMS> {
-    fn ln_prior(&self, params: &[f64; NPARAMS], jac: Option<&mut [f64; NPARAMS]>) -> f64 {
+impl LnPriorEvaluator for LnPrior {
+    fn ln_prior(&self, params: &[f64], jac: Option<&mut [f64]>) -> f64 {
         match self {
             LnPrior::None(p) => p.ln_prior(params, jac),
             LnPrior::IndComponents(p) => p.ln_prior(params, jac),
@@ -51,39 +49,42 @@ impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for LnPrior<NPARAMS> {
     }
 }
 
-impl<const NPARAMS: usize> LnPrior<NPARAMS> {
+impl LnPrior {
     pub fn none() -> Self {
         NoneLnPrior {}.into()
     }
 
-    pub fn ind_components(components: [LnPrior1D; NPARAMS]) -> Self {
-        IndComponentsLnPrior { components }.into()
+    pub fn ind_components(components: impl Into<Vec<LnPrior1D>>) -> Self {
+        IndComponentsLnPrior {
+            components: components.into(),
+        }
+        .into()
     }
 
-    pub fn into_func(self) -> impl 'static + Clone + Fn(&[f64; NPARAMS]) -> f64 {
+    pub fn into_func(self) -> impl 'static + Clone + Fn(&[f64]) -> f64 {
         move |params| self.ln_prior(params, None)
     }
 
     pub fn into_func_with_transformation<'a, F>(
         self,
         transform: F,
-    ) -> impl 'a + Clone + Fn(&[f64; NPARAMS]) -> f64
+    ) -> impl 'a + Clone + Fn(&[f64]) -> f64
     where
-        F: 'a + Clone + Fn(&[f64; NPARAMS]) -> [f64; NPARAMS],
+        F: 'a + Clone + Fn(&[f64]) -> Vec<f64>,
     {
         move |params| self.ln_prior(&transform(params), None)
     }
 
-    pub fn as_func(&self) -> impl '_ + Fn(&[f64; NPARAMS]) -> f64 {
+    pub fn as_func(&self) -> impl '_ + Fn(&[f64]) -> f64 {
         |params| self.ln_prior(params, None)
     }
 
     pub fn as_func_with_transformation<'a, F>(
         &'a self,
         transform: F,
-    ) -> impl 'a + Clone + Fn(&[f64; NPARAMS]) -> f64
+    ) -> impl 'a + Clone + Fn(&[f64]) -> f64
     where
-        F: 'a + Clone + Fn(&[f64; NPARAMS]) -> [f64; NPARAMS],
+        F: 'a + Clone + Fn(&[f64]) -> Vec<f64>,
     {
         move |params| self.ln_prior(&transform(params), None)
     }
@@ -93,12 +94,12 @@ impl<const NPARAMS: usize> LnPrior<NPARAMS> {
     /// This method creates a wrapper that stores references to the prior and normalization data,
     /// allowing it to be fully debuggable. The transformation is applied using the trait's
     /// `convert_to_external` method from the `FitParametersInternalExternalTrait` trait.
-    pub fn with_fit_parameters_transformation<'a, T>(
+    pub fn with_fit_parameters_transformation<'a, T, const MAX_NPARAMS: usize>(
         &'a self,
         norm_data: &'a NormalizedData<f64>,
-    ) -> TransformedLnPrior<'a, T, NPARAMS>
+    ) -> TransformedLnPrior<'a, T, MAX_NPARAMS>
     where
-        T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait<NPARAMS>,
+        T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait<MAX_NPARAMS>,
     {
         TransformedLnPrior {
             prior: self.clone(),
@@ -111,8 +112,8 @@ impl<const NPARAMS: usize> LnPrior<NPARAMS> {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
 pub struct NoneLnPrior {}
 
-impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for NoneLnPrior {
-    fn ln_prior(&self, _params: &[f64; NPARAMS], jac: Option<&mut [f64; NPARAMS]>) -> f64 {
+impl LnPriorEvaluator for NoneLnPrior {
+    fn ln_prior(&self, _params: &[f64], jac: Option<&mut [f64]>) -> f64 {
         if let Some(j) = jac {
             j.iter_mut().for_each(|x| *x = 0.0);
         }
@@ -120,19 +121,16 @@ impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for NoneLnPrior {
     }
 }
 
-impl<const NPARAMS: usize> LnPriorTrait<NPARAMS> for NoneLnPrior {}
+impl LnPriorTrait for NoneLnPrior {}
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(
-    into = "IndComponentsLnPriorSerde",
-    try_from = "IndComponentsLnPriorSerde"
-)]
-pub struct IndComponentsLnPrior<const NPARAMS: usize> {
-    pub components: [LnPrior1D; NPARAMS],
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
+#[serde(rename = "IndComponentsLnPrior")]
+pub struct IndComponentsLnPrior {
+    pub components: Vec<LnPrior1D>,
 }
 
-impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for IndComponentsLnPrior<NPARAMS> {
-    fn ln_prior(&self, params: &[f64; NPARAMS], jac: Option<&mut [f64; NPARAMS]>) -> f64 {
+impl LnPriorEvaluator for IndComponentsLnPrior {
+    fn ln_prior(&self, params: &[f64], jac: Option<&mut [f64]>) -> f64 {
         let mut total_ln_prior = 0.0;
 
         if let Some(jac) = jac {
@@ -156,48 +154,7 @@ impl<const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for IndComponentsLnPrior<NP
     }
 }
 
-impl<const NPARAMS: usize> LnPriorTrait<NPARAMS> for IndComponentsLnPrior<NPARAMS> {}
-
-impl<const NPARAMS: usize> JsonSchema for IndComponentsLnPrior<NPARAMS> {
-    fn is_referenceable() -> bool {
-        false
-    }
-
-    fn schema_name() -> String {
-        IndComponentsLnPriorSerde::schema_name()
-    }
-
-    fn json_schema(r#gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
-        IndComponentsLnPriorSerde::json_schema(r#gen)
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename = "IndComponentsLnPrior")]
-struct IndComponentsLnPriorSerde {
-    components: Vec<LnPrior1D>,
-}
-
-impl<const NPARAMS: usize> From<IndComponentsLnPrior<NPARAMS>> for IndComponentsLnPriorSerde {
-    fn from(value: IndComponentsLnPrior<NPARAMS>) -> Self {
-        Self {
-            components: value.components.into(),
-        }
-    }
-}
-
-impl<const NPARAMS: usize> TryFrom<IndComponentsLnPriorSerde> for IndComponentsLnPrior<NPARAMS> {
-    type Error = &'static str;
-
-    fn try_from(value: IndComponentsLnPriorSerde) -> Result<Self, Self::Error> {
-        Ok(Self {
-            components: value
-                .components
-                .try_into()
-                .map_err(|_| "wrong size of the IndComponentsLnPrior.components")?,
-        })
-    }
-}
+impl LnPriorTrait for IndComponentsLnPrior {}
 
 /// A prior with parameter transformation using FitParametersInternalExternalTrait
 ///
@@ -209,18 +166,18 @@ impl<const NPARAMS: usize> TryFrom<IndComponentsLnPriorSerde> for IndComponentsL
 /// Note: This type stores a reference to `NormalizedData` which is runtime data, so it cannot
 /// be serialized. However, the prior itself can be serialized separately.
 #[derive(Debug)]
-pub struct TransformedLnPrior<'a, T, const NPARAMS: usize>
+pub struct TransformedLnPrior<'a, T, const MAX_NPARAMS: usize>
 where
-    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait<NPARAMS>,
+    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait<MAX_NPARAMS>,
 {
-    prior: LnPrior<NPARAMS>,
+    prior: LnPrior,
     norm_data: &'a NormalizedData<f64>,
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<'a, T, const NPARAMS: usize> Clone for TransformedLnPrior<'a, T, NPARAMS>
+impl<'a, T, const MAX_NPARAMS: usize> Clone for TransformedLnPrior<'a, T, MAX_NPARAMS>
 where
-    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait<NPARAMS>,
+    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait<MAX_NPARAMS>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -231,11 +188,11 @@ where
     }
 }
 
-impl<'a, T, const NPARAMS: usize> LnPriorEvaluator<NPARAMS> for TransformedLnPrior<'a, T, NPARAMS>
+impl<'a, T, const MAX_NPARAMS: usize> LnPriorEvaluator for TransformedLnPrior<'a, T, MAX_NPARAMS>
 where
-    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait<NPARAMS>,
+    T: crate::nl_fit::evaluator::FitParametersInternalExternalTrait<MAX_NPARAMS>,
 {
-    fn ln_prior(&self, params: &[f64; NPARAMS], jac: Option<&mut [f64; NPARAMS]>) -> f64 {
+    fn ln_prior(&self, params: &[f64], jac: Option<&mut [f64]>) -> f64 {
         let transformed = T::convert_to_external(self.norm_data, params);
 
         match jac {
@@ -245,7 +202,10 @@ where
 
                 // Apply the chain rule to transform the gradient from external to internal space:
                 // ∂(ln_prior)/∂(internal_i) = ∂(ln_prior)/∂(external_i) × ∂(external_i)/∂(internal_i)
-                let jacobian = T::jacobian_internal_to_external(self.norm_data, params);
+                let params_arr: &[f64; MAX_NPARAMS] = params
+                    .try_into()
+                    .expect("params must have exactly MAX_NPARAMS elements");
+                let jacobian = T::jacobian_internal_to_external(self.norm_data, params_arr);
                 for (grad, jac_elem) in jac.iter_mut().zip(jacobian.iter()) {
                     *grad *= jac_elem;
                 }
@@ -264,19 +224,19 @@ mod tests {
 
     #[test]
     fn test_ln_prior_evaluator_trait_none() {
-        let prior: LnPrior<3> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let params = [1.0, 2.0, 3.0];
         assert_eq!(prior.ln_prior(&params, None), 0.0);
     }
 
     #[test]
     fn test_ln_prior_evaluator_trait_ind_components() {
-        let components = [
+        let components = vec![
             LnPrior1D::uniform(0.0, 10.0),
             LnPrior1D::uniform(0.0, 10.0),
             LnPrior1D::uniform(0.0, 10.0),
         ];
-        let prior: LnPrior<3> = LnPrior::ind_components(components);
+        let prior: LnPrior = LnPrior::ind_components(components);
 
         // Test with valid parameters
         let params_valid = [5.0, 5.0, 5.0];
@@ -297,7 +257,7 @@ mod tests {
 
     #[test]
     fn test_ind_components_ln_prior() {
-        let components = [LnPrior1D::uniform(0.0, 1.0), LnPrior1D::uniform(0.0, 2.0)];
+        let components = vec![LnPrior1D::uniform(0.0, 1.0), LnPrior1D::uniform(0.0, 2.0)];
         let prior = IndComponentsLnPrior { components };
 
         // Both within bounds
@@ -311,7 +271,7 @@ mod tests {
 
     #[test]
     fn test_ln_prior_clone() {
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let cloned = prior.clone();
         let params = [1.0, 2.0];
         assert_eq!(
@@ -322,14 +282,14 @@ mod tests {
 
     #[test]
     fn test_ln_prior_debug() {
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let debug_str = format!("{:?}", prior);
         assert!(debug_str.contains("None"));
     }
 
     #[test]
     fn test_ln_prior_into_func() {
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let func = prior.into_func();
         let params = [1.0, 2.0];
         assert_eq!(func(&params), 0.0);
@@ -337,8 +297,8 @@ mod tests {
 
     #[test]
     fn test_ln_prior_into_func_with_transformation() {
-        let prior: LnPrior<2> = LnPrior::none();
-        let transform = |params: &[f64; 2]| [params[0] * 2.0, params[1] * 2.0];
+        let prior: LnPrior = LnPrior::none();
+        let transform = |params: &[f64]| vec![params[0] * 2.0, params[1] * 2.0];
         let func = prior.into_func_with_transformation(transform);
         let params = [1.0, 2.0];
         // Since NoneLnPrior always returns 0, transformation doesn't affect result
@@ -347,7 +307,7 @@ mod tests {
 
     #[test]
     fn test_ln_prior_as_func() {
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let func = prior.as_func();
         let params = [1.0, 2.0];
         assert_eq!(func(&params), 0.0);
@@ -398,12 +358,12 @@ mod tests {
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
         // Create a prior with bounds [0, 2] for each parameter
-        let components = [LnPrior1D::uniform(0.0, 2.0), LnPrior1D::uniform(0.0, 2.0)];
-        let prior: LnPrior<2> = LnPrior::ind_components(components);
+        let components = vec![LnPrior1D::uniform(0.0, 2.0), LnPrior1D::uniform(0.0, 2.0)];
+        let prior: LnPrior = LnPrior::ind_components(components);
 
         // Create transformed prior
         let transformed_prior =
-            prior.with_fit_parameters_transformation::<MockFitParameters>(&norm_data);
+            prior.with_fit_parameters_transformation::<MockFitParameters, _>(&norm_data);
 
         // Test with internal parameters [0.5, 0.5]
         // After transformation: [1.0, 1.0] which is within bounds
@@ -424,9 +384,9 @@ mod tests {
         let mut ts = TimeSeries::new_without_weight(vec![1.0, 2.0, 3.0], vec![1.0, 2.0, 3.0]);
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let transformed_prior =
-            prior.with_fit_parameters_transformation::<MockFitParameters>(&norm_data);
+            prior.with_fit_parameters_transformation::<MockFitParameters, _>(&norm_data);
         let cloned = transformed_prior.clone();
 
         let params = [1.0, 2.0];
@@ -441,9 +401,9 @@ mod tests {
         let mut ts = TimeSeries::new_without_weight(vec![1.0, 2.0, 3.0], vec![1.0, 2.0, 3.0]);
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let transformed_prior =
-            prior.with_fit_parameters_transformation::<MockFitParameters>(&norm_data);
+            prior.with_fit_parameters_transformation::<MockFitParameters, _>(&norm_data);
 
         let debug_str = format!("{:?}", transformed_prior);
         assert!(debug_str.contains("TransformedLnPrior"));
@@ -451,9 +411,9 @@ mod tests {
 
     #[test]
     fn test_ln_prior_serialization() {
-        let prior: LnPrior<2> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let serialized = serde_json::to_string(&prior).unwrap();
-        let deserialized: LnPrior<2> = serde_json::from_str(&serialized).unwrap();
+        let deserialized: LnPrior = serde_json::from_str(&serialized).unwrap();
 
         let params = [1.0, 2.0];
         assert_eq!(
@@ -464,11 +424,11 @@ mod tests {
 
     #[test]
     fn test_ind_components_serialization() {
-        let components = [LnPrior1D::uniform(0.0, 10.0), LnPrior1D::uniform(-5.0, 5.0)];
-        let prior: LnPrior<2> = LnPrior::ind_components(components);
+        let components = vec![LnPrior1D::uniform(0.0, 10.0), LnPrior1D::uniform(-5.0, 5.0)];
+        let prior: LnPrior = LnPrior::ind_components(components);
 
         let serialized = serde_json::to_string(&prior).unwrap();
-        let deserialized: LnPrior<2> = serde_json::from_str(&serialized).unwrap();
+        let deserialized: LnPrior = serde_json::from_str(&serialized).unwrap();
 
         let params = [5.0, 0.0];
         assert_eq!(
@@ -481,8 +441,8 @@ mod tests {
     fn test_ind_components_gradient() {
         use approx::assert_relative_eq;
 
-        let components = [LnPrior1D::normal(5.0, 2.0), LnPrior1D::normal(10.0, 3.0)];
-        let prior: LnPrior<2> = LnPrior::ind_components(components.clone());
+        let components = vec![LnPrior1D::normal(5.0, 2.0), LnPrior1D::normal(10.0, 3.0)];
+        let prior: LnPrior = LnPrior::ind_components(components.clone());
 
         let params = [6.0, 11.0];
         let mut jac = [0.0; 2];
@@ -506,7 +466,7 @@ mod tests {
 
     #[test]
     fn test_none_ln_prior_gradient() {
-        let prior: LnPrior<3> = LnPrior::none();
+        let prior: LnPrior = LnPrior::none();
         let params = [1.0, 2.0, 3.0];
         let mut jac = [0.0; 3];
         let ln_p = prior.ln_prior(&params, Some(&mut jac));
@@ -524,12 +484,12 @@ mod tests {
         let norm_data = NormalizedData::<f64>::from_ts(&mut ts);
 
         // Create a prior with normal distribution in external space
-        let components = [LnPrior1D::normal(1.0, 0.5), LnPrior1D::normal(2.0, 0.5)];
-        let prior: LnPrior<2> = LnPrior::ind_components(components);
+        let components = vec![LnPrior1D::normal(1.0, 0.5), LnPrior1D::normal(2.0, 0.5)];
+        let prior: LnPrior = LnPrior::ind_components(components);
 
         // Create transformed prior
         let transformed_prior =
-            prior.with_fit_parameters_transformation::<MockFitParameters>(&norm_data);
+            prior.with_fit_parameters_transformation::<MockFitParameters, _>(&norm_data);
 
         // Test at internal params [0.5, 1.0]
         // MockFitParameters transforms: external = internal * 2


### PR DESCRIPTION
…ck-free math

Drops the compile-time NPARAMS const generic from the solver-facing boundary (CurveFitTrait::curve_fit and its GSL/Ceres/emcee/nuts-rs backends) entirely, so a single monomorphization of each solver works for any parameter count at runtime -- required for a future feature whose parameter count depends on runtime data (e.g. number of passbands) rather than being fixed per type.

The per-feature math (FitModelTrait::model, FitDerivalivesTrait:: derivatives, and the parameter-space transformation traits) keeps a compile-time bound instead of going fully dynamic: each trait now carries its own `const MAX_NPARAMS: usize`, and BazinFit/VillarFit/ LinexpFit's trait impls plug in their existing NPARAMS constant (impl ... <5> for BazinFit, etc.) -- their own math stays on plain `[T; MAX_NPARAMS]` arrays, so indexing is bounds-check-free with no unsafe code, exactly as before this generalization. Their public struct signatures don't change at all.

fit_eval!() is the one place that bridges the two: it takes NPARAMS as an explicit macro argument and builds thin wrapper closures that convert the solver's runtime `&[f64]` to a fixed `[f64; NPARAMS]` via `try_into()` before calling into the feature's own model/derivatives, matching the const generic to whatever the concrete Fit type declares.

For all three features today MAX_NPARAMS always equals the actual parameter count -- nothing in this crate yet needs a parameter count that varies at runtime independently of its compile-time bound. That capability exists for a feature to grow into, not because it's exercised anywhere in this commit. A wrong-length parameter slice panics loudly via try_into().expect() rather than silently truncating or padding, since that's the boundary most likely to get a length wrong if a future feature does need actual count to vary.