### PR TITLE
Add MAX_NPARAMS const generic + tinyvec::ArrayVec to Bazin/Villar/Lin…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ special = "0.14"
 take_mut = "0.2.2"
 thiserror = "2"
 thread_local = "1.1"
+tinyvec = "1"
 unzip3 = "1"
 
 [dev-dependencies]

--- a/src/features/bazin_fit.rs
+++ b/src/features/bazin_fit.rs
@@ -5,6 +5,7 @@ use crate::nl_fit::{
 };
 
 use conv::ConvUtil;
+use tinyvec::array_vec;
 
 const NPARAMS: usize = 5;
 
@@ -32,10 +33,10 @@ Bazin et al. 2009 [DOI:10.1051/0004-6361/200911847](https://doi.org/10.1051/0004
 
 #[doc = DOC!()]
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
-pub struct BazinFit {
+pub struct BazinFit<const MAX_NPARAMS: usize = NPARAMS> {
     algorithm: CurveFitAlgorithm,
-    ln_prior: BazinLnPrior,
-    inits_bounds: BazinInitsBounds,
+    ln_prior: BazinLnPrior<MAX_NPARAMS>,
+    inits_bounds: BazinInitsBounds<MAX_NPARAMS>,
 }
 
 impl BazinFit {
@@ -232,26 +233,28 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for BazinFit {
         norm_data: &NormalizedData<f64>,
         orig: &[f64; NPARAMS],
     ) -> [f64; NPARAMS] {
-        [
+        array_vec!([f64; NPARAMS] =>
             norm_data.m_to_norm_scale(orig[0]), // A amplitude
             norm_data.m_to_norm(orig[1]),       // c baseline
             norm_data.t_to_norm(orig[2]),       // t_0 reference_time
             norm_data.t_to_norm_scale(orig[3]), // tau_rise rise time
             norm_data.t_to_norm_scale(orig[4]), // tau_fall fall time
-        ]
+        )
+        .into_inner()
     }
 
     fn dimensionless_to_orig(
         norm_data: &NormalizedData<f64>,
         norm: &[f64; NPARAMS],
     ) -> [f64; NPARAMS] {
-        [
+        array_vec!([f64; NPARAMS] =>
             norm_data.m_to_orig_scale(norm[0]), // A amplitude
             norm_data.m_to_orig(norm[1]),       // c baseline
             norm_data.t_to_orig(norm[2]),       // t_0 reference_time
             norm_data.t_to_orig_scale(norm[3]), // tau_rise rise time
             norm_data.t_to_orig_scale(norm[4]), // tau_fall fall time
-        ]
+        )
+        .into_inner()
     }
 }
 
@@ -286,13 +289,14 @@ impl FitParametersInternalExternalTrait<NPARAMS> for BazinFit {
         // ∂|x|/∂x = sign(x), so the Jacobian is:
         let m_std = norm_data.m_std();
         let t_std = norm_data.t_std();
-        [
+        array_vec!([f64; NPARAMS] =>
             internal[0].signum() * m_std, // A amplitude: |internal[0]| * m_std
             m_std,                        // B baseline: internal[1] * m_std + m_mean
             t_std,                        // t0: internal[2] * t_std + t_mean
             internal[3].signum() * t_std, // tau_rise: |internal[3]| * t_std
             internal[4].signum() * t_std, // tau_fall: |internal[4]| * t_std
-        ]
+        )
+        .into_inner()
     }
 }
 
@@ -339,11 +343,11 @@ where
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Default, PartialEq)]
 #[non_exhaustive]
-pub enum BazinInitsBounds {
+pub enum BazinInitsBounds<const MAX_NPARAMS: usize = NPARAMS> {
     #[default]
     Default,
-    Arrays(Box<FitInitsBoundsArrays<NPARAMS>>),
-    OptionArrays(Box<OptionFitInitsBoundsArrays<NPARAMS>>),
+    Arrays(Box<FitInitsBoundsArrays<MAX_NPARAMS>>),
+    OptionArrays(Box<OptionFitInitsBoundsArrays<MAX_NPARAMS>>),
 }
 
 impl BazinInitsBounds {
@@ -384,17 +388,23 @@ impl BazinInitsBounds {
         let (fall_lower, fall_upper) = (0.0, 10.0 * t_amplitude);
 
         FitInitsBoundsArrays {
-            init: [a_init, c_init, t0_init, rise_init, fall_init].into(),
-            lower: [a_lower, c_lower, t0_lower, rise_lower, fall_lower].into(),
-            upper: [a_upper, c_upper, t0_upper, rise_upper, fall_upper].into(),
+            init: array_vec!([f64; NPARAMS] => a_init, c_init, t0_init, rise_init, fall_init)
+                .into_inner()
+                .into(),
+            lower: array_vec!([f64; NPARAMS] => a_lower, c_lower, t0_lower, rise_lower, fall_lower)
+                .into_inner()
+                .into(),
+            upper: array_vec!([f64; NPARAMS] => a_upper, c_upper, t0_upper, rise_upper, fall_upper)
+                .into_inner()
+                .into(),
         }
     }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
 #[non_exhaustive]
-pub enum BazinLnPrior {
-    Fixed(Box<LnPrior<NPARAMS>>),
+pub enum BazinLnPrior<const MAX_NPARAMS: usize = NPARAMS> {
+    Fixed(Box<LnPrior<MAX_NPARAMS>>),
 }
 
 impl BazinLnPrior {
@@ -433,6 +443,19 @@ mod tests {
     check_feature!(BazinFit);
 
     check_fit_model_derivatives!(BazinFit);
+
+    #[test]
+    fn tinyvec_array_vec_zero_pads_beyond_pushed_length() {
+        // BazinFit always pushes exactly NPARAMS elements into its MAX_NPARAMS-capacity
+        // ArrayVec, so `.len() == MAX_NPARAMS` in practice. This isolates the underlying
+        // tinyvec mechanism for actual_len < MAX_NPARAMS, which a future variable-length
+        // Fit (e.g. Rainbow) would rely on: indices at or beyond the pushed length read
+        // back as zero via `as_inner()` rather than panicking or holding garbage.
+        let partial: tinyvec::ArrayVec<[f64; NPARAMS]> =
+            tinyvec::array_vec!([f64; NPARAMS] => 1.0, 2.0, 3.0);
+        assert_eq!(partial.len(), 3);
+        assert_eq!(*partial.as_inner(), [1.0, 2.0, 3.0, 0.0, 0.0]);
+    }
 
     feature_test!(
         bazin_fit_almost_plateau,

--- a/src/features/linexp_fit.rs
+++ b/src/features/linexp_fit.rs
@@ -5,6 +5,7 @@ use crate::nl_fit::{
 };
 
 use conv::ConvUtil;
+use tinyvec::array_vec;
 
 const NPARAMS: usize = 4;
 
@@ -30,10 +31,10 @@ Note, that the Linexp function is developed to be used with fluxes, not magnitud
 
 #[doc = DOC!()]
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
-pub struct LinexpFit {
+pub struct LinexpFit<const MAX_NPARAMS: usize = NPARAMS> {
     algorithm: CurveFitAlgorithm,
-    ln_prior: LinexpLnPrior,
-    inits_bounds: LinexpInitsBounds,
+    ln_prior: LinexpLnPrior<MAX_NPARAMS>,
+    inits_bounds: LinexpInitsBounds<MAX_NPARAMS>,
 }
 
 impl LinexpFit {
@@ -215,24 +216,26 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for LinexpFit {
         norm_data: &NormalizedData<f64>,
         orig: &[f64; NPARAMS],
     ) -> [f64; NPARAMS] {
-        [
+        array_vec!([f64; NPARAMS] =>
             norm_data.m_to_norm_scale(orig[0]), // A amplitude
             norm_data.t_to_norm(orig[1]),       // t_0 reference_time
             norm_data.t_to_norm_scale(orig[2]), // tau fall time
             norm_data.m_to_norm(orig[3]),       // b baseline
-        ]
+        )
+        .into_inner()
     }
 
     fn dimensionless_to_orig(
         norm_data: &NormalizedData<f64>,
         norm: &[f64; NPARAMS],
     ) -> [f64; NPARAMS] {
-        [
+        array_vec!([f64; NPARAMS] =>
             norm_data.m_to_orig_scale(norm[0]), // A amplitude
             norm_data.t_to_orig(norm[1]),       // t_0 reference_time
             norm_data.t_to_orig_scale(norm[2]), // tau fall time
             norm_data.m_to_orig(norm[3]),       // b baseline
-        ]
+        )
+        .into_inner()
     }
 }
 
@@ -261,12 +264,13 @@ impl FitParametersInternalExternalTrait<NPARAMS> for LinexpFit {
         // ∂|x|/∂x = sign(x), so the Jacobian is:
         let m_std = norm_data.m_std();
         let t_std = norm_data.t_std();
-        [
+        array_vec!([f64; NPARAMS] =>
             internal[0].signum() * m_std, // A amplitude: |internal[0]| * m_std
             t_std,                        // t0: internal[1] * t_std + t_mean
             internal[2].signum() * t_std, // tau: |internal[2]| * t_std
             m_std,                        // B baseline: internal[3] * m_std + m_mean
-        ]
+        )
+        .into_inner()
     }
 }
 
@@ -311,11 +315,11 @@ where
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Default, PartialEq)]
 #[non_exhaustive]
-pub enum LinexpInitsBounds {
+pub enum LinexpInitsBounds<const MAX_NPARAMS: usize = NPARAMS> {
     #[default]
     Default,
-    Arrays(Box<FitInitsBoundsArrays<NPARAMS>>),
-    OptionArrays(Box<OptionFitInitsBoundsArrays<NPARAMS>>),
+    Arrays(Box<FitInitsBoundsArrays<MAX_NPARAMS>>),
+    OptionArrays(Box<OptionFitInitsBoundsArrays<MAX_NPARAMS>>),
 }
 
 impl LinexpInitsBounds {
@@ -358,17 +362,23 @@ impl LinexpInitsBounds {
         let (b_lower, b_upper) = (m_min - 100.0 * m_amplitude, m_max + 100.0 * m_amplitude);
 
         FitInitsBoundsArrays {
-            init: [a_init, t0_init, tau_init, b_init].into(),
-            lower: [a_lower, t0_lower, tau_lower, b_lower].into(),
-            upper: [a_upper, t0_upper, tau_upper, b_upper].into(),
+            init: array_vec!([f64; NPARAMS] => a_init, t0_init, tau_init, b_init)
+                .into_inner()
+                .into(),
+            lower: array_vec!([f64; NPARAMS] => a_lower, t0_lower, tau_lower, b_lower)
+                .into_inner()
+                .into(),
+            upper: array_vec!([f64; NPARAMS] => a_upper, t0_upper, tau_upper, b_upper)
+                .into_inner()
+                .into(),
         }
     }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[non_exhaustive]
-pub enum LinexpLnPrior {
-    Fixed(Box<LnPrior<NPARAMS>>),
+pub enum LinexpLnPrior<const MAX_NPARAMS: usize = NPARAMS> {
+    Fixed(Box<LnPrior<MAX_NPARAMS>>),
 }
 
 impl LinexpLnPrior {

--- a/src/features/villar_fit.rs
+++ b/src/features/villar_fit.rs
@@ -6,6 +6,7 @@ use crate::nl_fit::{
 
 use conv::ConvUtil;
 use ordered_float::NotNan;
+use tinyvec::array_vec;
 
 const NPARAMS: usize = 7;
 
@@ -38,10 +39,10 @@ Villar et al. 2019 [DOI:10.3847/1538-4357/ab418c](https://doi.org/10.3847/1538-4
 
 #[doc = DOC!()]
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
-pub struct VillarFit {
+pub struct VillarFit<const MAX_NPARAMS: usize = NPARAMS> {
     algorithm: CurveFitAlgorithm,
-    ln_prior: VillarLnPrior,
-    inits_bounds: VillarInitsBounds,
+    ln_prior: VillarLnPrior<MAX_NPARAMS>,
+    inits_bounds: VillarInitsBounds<MAX_NPARAMS>,
 }
 
 impl VillarFit {
@@ -226,7 +227,7 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for VillarFit {
         norm_data: &NormalizedData<f64>,
         orig: &[f64; NPARAMS],
     ) -> [f64; NPARAMS] {
-        [
+        array_vec!([f64; NPARAMS] =>
             norm_data.m_to_norm_scale(orig[0]), // A amplitude
             norm_data.m_to_norm(orig[1]),       // c baseline
             norm_data.t_to_norm(orig[2]),       // t_0 reference time
@@ -234,14 +235,15 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for VillarFit {
             norm_data.t_to_norm_scale(orig[4]), // tau_fall fall time
             orig[5],                            // nu = (beta gamma / A), dimensionless
             norm_data.t_to_norm_scale(orig[6]), // gamma plateau duration
-        ]
+        )
+        .into_inner()
     }
 
     fn dimensionless_to_orig(
         norm_data: &NormalizedData<f64>,
         norm: &[f64; NPARAMS],
     ) -> [f64; NPARAMS] {
-        [
+        array_vec!([f64; NPARAMS] =>
             norm_data.m_to_orig_scale(norm[0]), // A amplitude
             norm_data.m_to_orig(norm[1]),       // c baseline
             norm_data.t_to_orig(norm[2]),       // t_0 reference time
@@ -249,7 +251,8 @@ impl FitParametersOriginalDimLessTrait<NPARAMS> for VillarFit {
             norm_data.t_to_orig_scale(norm[4]), // tau_fall fall time
             norm[5], // nu = (beta gamma / A) relative plateau amplitude, dimensionless
             norm_data.t_to_orig_scale(norm[6]), // gamma plateau duration
-        ]
+        )
+        .into_inner()
     }
 }
 
@@ -305,7 +308,7 @@ impl FitParametersInternalExternalTrait<NPARAMS> for VillarFit {
         let nu = Self::b_to_nu(internal[5]);
         let d_nu_d_b = (1.0 - nu.powi(2)) * internal[5].signum();
 
-        [
+        array_vec!([f64; NPARAMS] =>
             internal[0].signum() * m_std, // A amplitude: |internal[0]| * m_std
             m_std,                        // c baseline: internal[1] * m_std + m_mean
             t_std,                        // t0: internal[2] * t_std + t_mean
@@ -313,7 +316,8 @@ impl FitParametersInternalExternalTrait<NPARAMS> for VillarFit {
             internal[4].signum() * t_std, // tau_fall: |internal[4]| * t_std
             d_nu_d_b,                     // nu: b_to_nu(internal[5]), dimensionless
             internal[6].signum() * t_std, // gamma: |internal[6]| * t_std
-        ]
+        )
+        .into_inner()
     }
 }
 
@@ -469,11 +473,11 @@ where
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Default, PartialEq)]
 #[non_exhaustive]
-pub enum VillarInitsBounds {
+pub enum VillarInitsBounds<const MAX_NPARAMS: usize = NPARAMS> {
     #[default]
     Default,
-    Arrays(Box<FitInitsBoundsArrays<NPARAMS>>),
-    OptionArrays(Box<OptionFitInitsBoundsArrays<NPARAMS>>),
+    Arrays(Box<FitInitsBoundsArrays<MAX_NPARAMS>>),
+    OptionArrays(Box<OptionFitInitsBoundsArrays<MAX_NPARAMS>>),
 }
 
 impl VillarInitsBounds {
@@ -521,35 +525,20 @@ impl VillarInitsBounds {
         let (gamma_lower, gamma_upper) = (0.0, 10.0 * t_amplitude);
 
         FitInitsBoundsArrays {
-            init: [
-                a_init,
-                c_init,
-                t0_init,
-                tau_rise_init,
-                tau_fall_init,
-                nu_init,
-                gamma_init,
-            ]
+            init: array_vec!([f64; NPARAMS] =>
+                a_init, c_init, t0_init, tau_rise_init, tau_fall_init, nu_init, gamma_init,
+            )
+            .into_inner()
             .into(),
-            lower: [
-                a_lower,
-                c_lower,
-                t0_lower,
-                tau_rise_lower,
-                tau_fall_lower,
-                nu_lower,
-                gamma_lower,
-            ]
+            lower: array_vec!([f64; NPARAMS] =>
+                a_lower, c_lower, t0_lower, tau_rise_lower, tau_fall_lower, nu_lower, gamma_lower,
+            )
+            .into_inner()
             .into(),
-            upper: [
-                a_upper,
-                c_upper,
-                t0_upper,
-                tau_rise_upper,
-                tau_fall_upper,
-                nu_upper,
-                gamma_upper,
-            ]
+            upper: array_vec!([f64; NPARAMS] =>
+                a_upper, c_upper, t0_upper, tau_rise_upper, tau_fall_upper, nu_upper, gamma_upper,
+            )
+            .into_inner()
             .into(),
         }
     }
@@ -558,8 +547,8 @@ impl VillarInitsBounds {
 /// Logarithm of priors for [VillarFit] parameters
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[non_exhaustive]
-pub enum VillarLnPrior {
-    Fixed(Box<LnPrior<NPARAMS>>),
+pub enum VillarLnPrior<const MAX_NPARAMS: usize = NPARAMS> {
+    Fixed(Box<LnPrior<MAX_NPARAMS>>),
     /// Adopted from Hosseinzadeh, et al. 2020, table 2
     ///
     /// `time_units_in_day` specifies the units of time you use in yout `TimeSeries` object, it


### PR DESCRIPTION
…exp fits

Gives each *Fit struct a MAX_NPARAMS const generic (defaulting to the existing per-feature NPARAMS) and builds parameter vectors via tinyvec::array_vec!/.into_inner() instead of plain array literals, matching the container Kostya proposed for a future variable-length Fit (e.g. Rainbow) without touching curve_fit.rs or any solver backend.

Behavior and performance for existing fits are unchanged: MAX_NPARAMS always equals the concrete NPARAMS value here, so curve_fit and the math/getters keep operating on plain [T; NPARAMS] as before. Added a focused test isolating tinyvec's zero-padding semantics for actual_len < MAX_NPARAMS, which nothing here exercises yet but which a future variable-length Fit will rely on.